### PR TITLE
Implement -Z stdout streaming, add alignment docs page

### DIFF
--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -59,6 +59,8 @@ pub struct PipelineConfig {
     pub fasta: bool,
     /// Allow resuming partial downloads.
     pub resume: bool,
+    /// Write output to stdout instead of files.
+    pub stdout: bool,
     /// Flag for graceful cancellation (e.g. Ctrl-C).
     pub cancelled: Option<Arc<AtomicBool>>,
 }
@@ -153,11 +155,12 @@ pub(crate) fn make_styled_pb(total: u64, template: &str) -> indicatif::ProgressB
 // Output writer
 // ---------------------------------------------------------------------------
 
-/// An output writer that handles gzip, zstd, or plain output.
+/// An output writer that handles gzip, zstd, plain, or stdout output.
 enum OutputWriter {
     Gz(ParGzWriter<std::io::BufWriter<std::fs::File>>),
     Zstd(zstd::stream::write::Encoder<'static, std::io::BufWriter<std::fs::File>>),
     Plain(std::io::BufWriter<std::fs::File>),
+    Stdout(std::io::BufWriter<std::io::Stdout>),
 }
 
 impl OutputWriter {
@@ -166,6 +169,7 @@ impl OutputWriter {
             OutputWriter::Gz(w) => w.write_all(data),
             OutputWriter::Zstd(w) => w.write_all(data),
             OutputWriter::Plain(w) => w.write_all(data),
+            OutputWriter::Stdout(w) => w.write_all(data),
         }
     }
 
@@ -180,6 +184,10 @@ impl OutputWriter {
                 Ok(())
             }
             OutputWriter::Plain(mut w) => {
+                w.flush()?;
+                Ok(())
+            }
+            OutputWriter::Stdout(mut w) => {
                 w.flush()?;
                 Ok(())
             }
@@ -1167,12 +1175,25 @@ fn decode_and_write(
         fasta: config.fasta,
     };
 
-    // Create output directory.
-    std::fs::create_dir_all(&config.output_dir)?;
+    // Create output directory (not needed for stdout mode).
+    if !config.stdout {
+        std::fs::create_dir_all(&config.output_dir)?;
+    }
 
     // Lazily create output writers as we encounter different output slots.
     let mut writers: HashMap<OutputSlot, OutputWriter> = HashMap::new();
     let mut output_files: Vec<PathBuf> = Vec::new();
+
+    // For stdout mode, create a single writer up front. All output slots
+    // write to this shared writer (interleaved, uncompressed).
+    let mut stdout_writer: Option<OutputWriter> = if config.stdout {
+        Some(OutputWriter::Stdout(std::io::BufWriter::with_capacity(
+            256 * 1024,
+            std::io::stdout(),
+        )))
+    } else {
+        None
+    };
 
     let spots_read = std::sync::atomic::AtomicU64::new(0);
     let mut reads_written: u64 = 0;
@@ -1285,40 +1306,45 @@ fn decode_and_write(
                     let (records, num_spots) = result?;
 
                     for (slot, record) in &records {
-                        let writer = writers.entry(*slot).or_insert_with(|| {
-                            let filename = output_filename(
-                                accession,
-                                *slot,
-                                config.fasta,
-                                &config.compression,
-                            );
-                            let path = config.output_dir.join(&filename);
-                            output_files.push(path.clone());
+                        let writer = if let Some(ref mut sw) = stdout_writer {
+                            sw
+                        } else {
+                            writers.entry(*slot).or_insert_with(|| {
+                                let filename = output_filename(
+                                    accession,
+                                    *slot,
+                                    config.fasta,
+                                    &config.compression,
+                                );
+                                let path = config.output_dir.join(&filename);
+                                output_files.push(path.clone());
 
-                            let file =
-                                std::fs::File::create(&path).expect("failed to create output file");
-                            let buf = std::io::BufWriter::with_capacity(256 * 1024, file);
+                                let file = std::fs::File::create(&path)
+                                    .expect("failed to create output file");
+                                let buf = std::io::BufWriter::with_capacity(256 * 1024, file);
 
-                            match config.compression {
-                                CompressionMode::Gzip { level } => {
-                                    OutputWriter::Gz(ParGzWriter::new(
-                                        buf,
-                                        level,
-                                        DEFAULT_BLOCK_SIZE,
-                                        compress_pool.clone().expect("gzip pool must exist"),
-                                    ))
+                                match config.compression {
+                                    CompressionMode::Gzip { level } => {
+                                        OutputWriter::Gz(ParGzWriter::new(
+                                            buf,
+                                            level,
+                                            DEFAULT_BLOCK_SIZE,
+                                            compress_pool.clone().expect("gzip pool must exist"),
+                                        ))
+                                    }
+                                    CompressionMode::Zstd { level, threads } => {
+                                        let mut encoder =
+                                            zstd::stream::write::Encoder::new(buf, level)
+                                                .expect("failed to create zstd encoder");
+                                        encoder
+                                            .multithread(threads)
+                                            .expect("failed to set zstd threads");
+                                        OutputWriter::Zstd(encoder)
+                                    }
+                                    CompressionMode::None => OutputWriter::Plain(buf),
                                 }
-                                CompressionMode::Zstd { level, threads } => {
-                                    let mut encoder = zstd::stream::write::Encoder::new(buf, level)
-                                        .expect("failed to create zstd encoder");
-                                    encoder
-                                        .multithread(threads)
-                                        .expect("failed to set zstd threads");
-                                    OutputWriter::Zstd(encoder)
-                                }
-                                CompressionMode::None => OutputWriter::Plain(buf),
-                            }
-                        });
+                            })
+                        };
 
                         writer.write_all(&record.data).map_err(Error::Io)?;
                         reads_written += 1;
@@ -1543,6 +1569,9 @@ fn decode_and_write(
     );
 
     // Finish all writers.
+    if let Some(sw) = stdout_writer {
+        sw.finish().map_err(Error::Io)?;
+    }
     for (_, writer) in writers {
         writer.finish().map_err(Error::Io)?;
     }

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -80,6 +80,7 @@ fn test_config(
         run_info: None,
         fasta: false,
         resume: true,
+        stdout: false,
         cancelled: None,
     }
 }

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -225,6 +225,10 @@ pub struct GetArgs {
     #[arg(long)]
     pub include_technical: bool,
 
+    /// Write to stdout (stream interleaved FASTQ, auto-delete temp SRA)
+    #[arg(short = 'Z', long)]
+    pub stdout: bool,
+
     /// Overwrite existing files
     #[arg(short, long)]
     pub force: bool,

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -48,6 +48,13 @@ use sracha_core::util::format_size;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Reset SIGPIPE to default so piping to `head` etc. exits cleanly
+    // instead of printing a BrokenPipe error.
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     let cli = Cli::parse();
 
     // Set up tracing
@@ -130,14 +137,20 @@ async fn main() -> Result<()> {
                 args.inputs.len()
             );
 
-            let split_mode = match args.split {
-                cli::SplitMode::Split3 => sracha_core::fastq::SplitMode::Split3,
-                cli::SplitMode::SplitFiles => sracha_core::fastq::SplitMode::SplitFiles,
-                cli::SplitMode::SplitSpot => sracha_core::fastq::SplitMode::SplitSpot,
-                cli::SplitMode::Interleaved => sracha_core::fastq::SplitMode::Interleaved,
+            let split_mode = if args.stdout {
+                sracha_core::fastq::SplitMode::Interleaved
+            } else {
+                match args.split {
+                    cli::SplitMode::Split3 => sracha_core::fastq::SplitMode::Split3,
+                    cli::SplitMode::SplitFiles => sracha_core::fastq::SplitMode::SplitFiles,
+                    cli::SplitMode::SplitSpot => sracha_core::fastq::SplitMode::SplitSpot,
+                    cli::SplitMode::Interleaved => sracha_core::fastq::SplitMode::Interleaved,
+                }
             };
 
-            let compression = if args.zstd {
+            let compression = if args.stdout {
+                CompressionMode::None
+            } else if args.zstd {
                 CompressionMode::Zstd {
                     level: args.zstd_level,
                     threads: args.threads as u32,
@@ -170,10 +183,11 @@ async fn main() -> Result<()> {
                     skip_technical: !args.include_technical,
                     min_read_len: args.min_read_len,
                     force: args.force,
-                    progress: !args.no_progress,
+                    progress: !args.no_progress && !args.stdout,
                     run_info: None,
                     fasta: args.fasta,
                     resume: true,
+                    stdout: args.stdout,
                     cancelled: None,
                 };
 
@@ -185,8 +199,10 @@ async fn main() -> Result<()> {
                     style::count(stats.spots_read),
                     style::count(stats.reads_written),
                 );
-                for path in &stats.output_files {
-                    eprintln!("  -> {}", style::path(path.display()));
+                if !args.stdout {
+                    for path in &stats.output_files {
+                        eprintln!("  -> {}", style::path(path.display()));
+                    }
                 }
             }
 
@@ -230,14 +246,20 @@ async fn main() -> Result<()> {
                 resolved_all.len()
             );
 
-            let split_mode = match args.split {
-                cli::SplitMode::Split3 => sracha_core::fastq::SplitMode::Split3,
-                cli::SplitMode::SplitFiles => sracha_core::fastq::SplitMode::SplitFiles,
-                cli::SplitMode::SplitSpot => sracha_core::fastq::SplitMode::SplitSpot,
-                cli::SplitMode::Interleaved => sracha_core::fastq::SplitMode::Interleaved,
+            let split_mode = if args.stdout {
+                sracha_core::fastq::SplitMode::Interleaved
+            } else {
+                match args.split {
+                    cli::SplitMode::Split3 => sracha_core::fastq::SplitMode::Split3,
+                    cli::SplitMode::SplitFiles => sracha_core::fastq::SplitMode::SplitFiles,
+                    cli::SplitMode::SplitSpot => sracha_core::fastq::SplitMode::SplitSpot,
+                    cli::SplitMode::Interleaved => sracha_core::fastq::SplitMode::Interleaved,
+                }
             };
 
-            let compression = if args.zstd {
+            let compression = if args.stdout {
+                CompressionMode::None
+            } else if args.zstd {
                 CompressionMode::Zstd {
                     level: args.zstd_level,
                     threads: args.threads as u32,
@@ -249,6 +271,8 @@ async fn main() -> Result<()> {
                     level: args.gzip_level,
                 }
             };
+
+            let progress = !args.no_progress && !args.stdout;
 
             // -- Ctrl-C signal handling --
             use std::sync::Arc;
@@ -297,10 +321,11 @@ async fn main() -> Result<()> {
                     skip_technical: !args.include_technical,
                     min_read_len: args.min_read_len,
                     force: args.force,
-                    progress: !args.no_progress,
+                    progress,
                     run_info: resolved.run_info.clone(),
                     fasta: args.fasta,
                     resume: !args.no_resume,
+                    stdout: args.stdout,
                     cancelled: Some(cancelled.clone()),
                 };
 
@@ -344,10 +369,11 @@ async fn main() -> Result<()> {
                         skip_technical: !args.include_technical,
                         min_read_len: args.min_read_len,
                         force: args.force,
-                        progress: !args.no_progress,
+                        progress,
                         run_info: next_resolved.run_info.clone(),
                         fasta: args.fasta,
                         resume: !args.no_resume,
+                        stdout: args.stdout,
                         cancelled: Some(cancelled.clone()),
                     };
                     pending_download = Some(tokio::spawn(async move {
@@ -385,8 +411,10 @@ async fn main() -> Result<()> {
                                 style::value(format_size(stats.total_sra_size)),
                             );
                         }
-                        for path in &stats.output_files {
-                            eprintln!("  -> {}", style::path(path.display()));
+                        if !args.stdout {
+                            for path in &stats.output_files {
+                                eprintln!("  -> {}", style::path(path.display()));
+                            }
                         }
                         completed_accessions.push(resolved.accession.clone());
                     }

--- a/docs/alignment.md
+++ b/docs/alignment.md
@@ -1,0 +1,82 @@
+# Streaming alignment with bwa
+
+sracha can stream FASTQ directly to an aligner via `-Z`, eliminating
+intermediate files and reducing disk I/O.
+
+## Prerequisites
+
+Install bwa and samtools:
+
+```bash
+pixi add bwa samtools
+# or: conda install -c bioconda bwa samtools
+```
+
+## Quick start: align to chr22
+
+Download and index chr22 from hs1 (T2T-CHM13v2.0):
+
+```bash
+wget https://hgdownload.soe.ucsc.edu/goldenPath/hs1/chromosomes/chr22.fa.gz
+bwa index chr22.fa.gz
+```
+
+Stream directly from NCBI to a sorted BAM — no intermediate files:
+
+```bash
+sracha get SRR28588231 -Z \
+  | bwa mem -p -t 8 chr22.fa.gz - \
+  | samtools sort -@ 4 -o SRR28588231.chr22.bam
+samtools index SRR28588231.chr22.bam
+```
+
+sracha downloads the SRA file to a hidden temp file, streams
+interleaved FASTQ to stdout, then auto-deletes the temp file.
+No `.sra` or `.fastq.gz` files are left on disk.
+
+Verify:
+
+```bash
+samtools flagstat SRR28588231.chr22.bam
+```
+
+## Full human genome workflow
+
+Download and index hs1:
+
+```bash
+wget https://hgdownload.soe.ucsc.edu/goldenPath/hs1/bigZips/hs1.fa.gz
+bwa index hs1.fa.gz    # ~1 hour, ~5 GB RAM
+```
+
+Stream alignment:
+
+```bash
+sracha get SRR28588231 -Z \
+  | bwa mem -p -t 8 hs1.fa.gz - \
+  | samtools sort -@ 4 -o SRR28588231.bam
+samtools index SRR28588231.bam
+```
+
+## Two-step workflow
+
+If you already have an SRA file on disk, use `fastq -Z`:
+
+```bash
+sracha fastq SRR28588231.sra -Z \
+  | bwa mem -p -t 8 hs1.fa.gz - \
+  | samtools sort -@ 4 -o SRR28588231.bam
+```
+
+## How it works
+
+- `-Z` forces interleaved, uncompressed output to stdout
+- `bwa mem -p` reads interleaved paired-end FASTQ from stdin
+- `samtools sort` reads SAM from stdin and writes a coordinate-sorted BAM
+- Backpressure flows naturally through the Unix pipe
+
+## Performance tips
+
+- Split threads between sracha and bwa (e.g., `-t 4` for sracha, `-t 8` for bwa on 12 cores)
+- Streaming avoids writing intermediate FASTQ files (saves disk I/O and space)
+- For maximum throughput, use `--format sralite` if quality scores aren't critical

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -132,8 +132,11 @@ Use `-Z` to write interleaved output to stdout, useful for piping
 into other tools:
 
 ```bash
-sracha fastq SRR28588231.sra --split interleaved -Z | bwa mem -p ref.fa -
+sracha get SRR28588231 -Z | bwa mem -p ref.fa -
 ```
+
+See [Streaming Alignment](alignment.md) for a complete walkthrough
+with bwa and samtools.
 
 ## Validating files
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,6 +10,8 @@ rust = ">=1.92"
 python = ">=3.14.4,<3.15"
 sra-tools = ">=3.4.1,<4"
 vhs = ">=0.11.0,<0.12"
+bwa = ">=0.7.18"
+samtools = ">=1.21"
 
 [pypi-dependencies]
 zensical = "*"

--- a/zensical.toml
+++ b/zensical.toml
@@ -66,6 +66,9 @@ Home = "index.md"
 "Getting Started" = "getting-started.md"
 
 [[project.nav]]
+"Streaming Alignment" = "alignment.md"
+
+[[project.nav]]
 "CLI Reference" = "cli.md"
 
 [[project.nav]]


### PR DESCRIPTION
Wire up the -Z/--stdout flag for both `fastq` and `get` subcommands to stream interleaved uncompressed FASTQ to stdout. This enables zero-intermediate-file workflows like:

  sracha get SRR2584863 -Z | bwa mem -p ref.fa - | samtools sort -o out.bam

When -Z is active: forces interleaved split mode, disables compression, suppresses progress bars, and writes to a shared stdout BufWriter instead of per-slot file writers. For `get -Z`, the temp SRA file is auto-deleted after decode, leaving no files on disk.

Also adds SIGPIPE handling for clean exit when piped to head/etc, bwa+samtools to pixi.toml, and a streaming alignment docs page.