### PR TITLE
Experimental SRA -> Parquet converter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ memmap2 = "0.9"
 owo-colors = "4"
 tabled = { version = "0.20", features = ["ansi"] }
 
+# Columnar / Parquet
+arrow = { version = "58", default-features = false }
+parquet = { version = "58", default-features = false, features = ["arrow", "zstd", "snap"] }
+
 # Utils
 url = "2"
 tempfile = "3"

--- a/crates/sracha-core/Cargo.toml
+++ b/crates/sracha-core/Cargo.toml
@@ -30,6 +30,8 @@ url.workspace = true
 tempfile.workspace = true
 bytes.workspace = true
 tracing.workspace = true
+arrow.workspace = true
+parquet.workspace = true
 
 [dev-dependencies]
 reqwest = { workspace = true, features = ["blocking"] }

--- a/crates/sracha-core/src/lib.rs
+++ b/crates/sracha-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod compress;
 pub mod download;
 pub mod error;
 pub mod fastq;
+pub mod parquet;
 pub mod pipeline;
 pub mod s3;
 pub mod sdl;

--- a/crates/sracha-core/src/parquet/encoding.rs
+++ b/crates/sracha-core/src/parquet/encoding.rs
@@ -1,0 +1,137 @@
+//! DNA pre-packing for Parquet output.
+//!
+//! Parquet's general-purpose codecs (zstd, snappy) cannot match VDB's domain
+//! encoding on their own — VDB packs DNA at 2 bits/base before applying any
+//! generic compression. To give Parquet a fair shot, we pre-pack DNA into
+//! 2na or 4na bytes ourselves and let Parquet add light entropy coding on
+//! top.
+
+/// Pack ASCII DNA bases (`A`, `C`, `G`, `T` only) into 2na.
+///
+/// Each output byte holds 4 bases, MSB-first:
+///
+/// ```text
+/// byte: [b0 b0 b1 b1 | b2 b2 b3 b3]   bit positions 7..0
+/// ```
+///
+/// `0b00 = A`, `0b01 = C`, `0b10 = G`, `0b11 = T`.
+///
+/// Any non-ACGT base (N, IUPAC ambiguity) is encoded as `A` (0b00) — the
+/// caller should fall back to 4na or ASCII when the input contains
+/// ambiguities. The output length is `ceil(bases.len() / 4)`.
+pub fn pack_2na(bases: &[u8]) -> Vec<u8> {
+    let out_len = bases.len().div_ceil(4);
+    let mut out = vec![0u8; out_len];
+    for (i, &b) in bases.iter().enumerate() {
+        let code = base_to_2na(b);
+        let byte_idx = i / 4;
+        let shift = (3 - (i % 4)) * 2;
+        out[byte_idx] |= code << shift;
+    }
+    out
+}
+
+/// Pack ASCII DNA bases (IUPAC) into 4na.
+///
+/// Each output byte holds 2 bases as 4-bit nibbles, high nibble first.
+/// Output length is `ceil(bases.len() / 2)`.
+pub fn pack_4na(bases: &[u8]) -> Vec<u8> {
+    let out_len = bases.len().div_ceil(2);
+    let mut out = vec![0u8; out_len];
+    for (i, &b) in bases.iter().enumerate() {
+        let code = base_to_4na(b);
+        let byte_idx = i / 2;
+        if i % 2 == 0 {
+            out[byte_idx] = code << 4;
+        } else {
+            out[byte_idx] |= code & 0x0F;
+        }
+    }
+    out
+}
+
+/// Detect whether a slice contains only `ACGT` (suitable for 2na packing).
+pub fn is_pure_acgt(bases: &[u8]) -> bool {
+    bases
+        .iter()
+        .all(|&b| matches!(b, b'A' | b'C' | b'G' | b'T'))
+}
+
+#[inline]
+fn base_to_2na(b: u8) -> u8 {
+    match b {
+        b'A' | b'a' => 0b00,
+        b'C' | b'c' => 0b01,
+        b'G' | b'g' => 0b10,
+        b'T' | b't' => 0b11,
+        _ => 0b00,
+    }
+}
+
+#[inline]
+fn base_to_4na(b: u8) -> u8 {
+    // Mirror of crate::vdb::encoding::DNA_4NA reverse mapping.
+    match b {
+        b'A' | b'a' => 1,
+        b'C' | b'c' => 2,
+        b'M' | b'm' => 3,
+        b'G' | b'g' => 4,
+        b'R' | b'r' => 5,
+        b'S' | b's' => 6,
+        b'V' | b'v' => 7,
+        b'T' | b't' => 8,
+        b'W' | b'w' => 9,
+        b'Y' | b'y' => 10,
+        b'H' | b'h' => 11,
+        b'K' | b'k' => 12,
+        b'D' | b'd' => 13,
+        b'B' | b'b' => 14,
+        _ => 15,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vdb::encoding::{unpack_2na, unpack_4na};
+
+    #[test]
+    fn pack_2na_roundtrip() {
+        let bases = b"ACGTACGT";
+        let packed = pack_2na(bases);
+        assert_eq!(packed.len(), 2);
+        assert_eq!(unpack_2na(&packed, bases.len()), bases.to_vec());
+    }
+
+    #[test]
+    fn pack_2na_partial_byte() {
+        let bases = b"ACG";
+        let packed = pack_2na(bases);
+        assert_eq!(packed.len(), 1);
+        assert_eq!(unpack_2na(&packed, bases.len()), bases.to_vec());
+    }
+
+    #[test]
+    fn pack_4na_roundtrip_with_ambiguity() {
+        let bases = b"ACGTNRY";
+        let packed = pack_4na(bases);
+        assert_eq!(packed.len(), 4);
+        assert_eq!(unpack_4na(&packed, bases.len()), bases.to_vec());
+    }
+
+    #[test]
+    fn pack_2na_lossy_on_n() {
+        // N collapses to A in 2na; this is intentional — caller should check
+        // is_pure_acgt() before choosing 2na.
+        let packed = pack_2na(b"AN");
+        let unpacked = unpack_2na(&packed, 2);
+        assert_eq!(unpacked, b"AA".to_vec());
+    }
+
+    #[test]
+    fn detects_pure_acgt() {
+        assert!(is_pure_acgt(b"ACGTACGT"));
+        assert!(!is_pure_acgt(b"ACGN"));
+        assert!(!is_pure_acgt(b"ACGTR"));
+    }
+}

--- a/crates/sracha-core/src/parquet/mod.rs
+++ b/crates/sracha-core/src/parquet/mod.rs
@@ -1,0 +1,14 @@
+//! SRA → Parquet converter.
+//!
+//! Reads the SEQUENCE table of an SRA file via [`crate::vdb::cursor::VdbCursor`]
+//! and writes per-read rows into a Parquet file. Designed to test whether
+//! Apache Arrow / Parquet can match VDB's storage density when given access to
+//! the same domain tricks (2na DNA packing, fixed-width detection,
+//! dictionary-encoded quality).
+
+pub mod encoding;
+pub mod schema;
+pub mod writer;
+
+pub use schema::{DnaPacking, LengthMode};
+pub use writer::{ConvertConfig, ConvertStats, ParquetCompression, convert_sra_to_parquet};

--- a/crates/sracha-core/src/parquet/schema.rs
+++ b/crates/sracha-core/src/parquet/schema.rs
@@ -1,0 +1,151 @@
+//! Arrow schema construction for SRA → Parquet output.
+//!
+//! Two schema variants are supported, chosen at runtime from the data:
+//!
+//! * [`LengthMode::Fixed`] — every read in the run has the same length, so
+//!   `sequence` and `quality` are emitted as `FIXED_LEN_BYTE_ARRAY` with the
+//!   length declared once in the schema. No per-row length prefix.
+//! * [`LengthMode::Variable`] — read lengths vary, so `sequence` and `quality`
+//!   are `BYTE_ARRAY` and the actual length is recorded in `read_len`.
+
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+
+/// How DNA bases are stored in the `sequence` column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DnaPacking {
+    /// One byte per base (`A`, `C`, `G`, `T`, `N`, IUPAC).
+    Ascii,
+    /// 2 bits per base (4 bases per byte). Lossy for non-ACGT — caller must
+    /// verify with [`super::encoding::is_pure_acgt`] before choosing this.
+    TwoNa,
+    /// 4 bits per base (2 bases per byte). Preserves IUPAC ambiguity codes.
+    FourNa,
+}
+
+impl DnaPacking {
+    /// Bytes required to encode `n_bases` bases under this packing.
+    pub fn packed_len(self, n_bases: u32) -> u32 {
+        match self {
+            DnaPacking::Ascii => n_bases,
+            DnaPacking::TwoNa => n_bases.div_ceil(4),
+            DnaPacking::FourNa => n_bases.div_ceil(2),
+        }
+    }
+}
+
+/// Whether read lengths are uniform across the run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LengthMode {
+    /// All reads have the same length. Allows `FIXED_LEN_BYTE_ARRAY`.
+    Fixed { read_len: u32 },
+    /// Read lengths vary; use variable-length `BYTE_ARRAY` and emit a
+    /// per-row `read_len` column.
+    Variable,
+}
+
+/// Build the per-read Arrow schema for the chosen length mode and DNA packing.
+///
+/// Schema layout (per-read rows):
+///
+/// | column      | type                              | notes                          |
+/// |-------------|-----------------------------------|--------------------------------|
+/// | spot_id     | UInt64                            | parent spot identifier         |
+/// | read_num    | UInt8                             | 0-based read index within spot |
+/// | name        | Utf8 (nullable)                   | spot name                      |
+/// | read_len    | UInt32 (variable mode only)       | omitted in fixed mode          |
+/// | sequence    | (FixedSize)Binary                 | width depends on mode + packing|
+/// | quality     | (FixedSize)Binary (nullable)      | width depends on mode          |
+pub fn build_per_read_schema(length_mode: LengthMode, packing: DnaPacking) -> SchemaRef {
+    let mut fields: Vec<Field> = Vec::with_capacity(6);
+    fields.push(Field::new("spot_id", DataType::UInt64, false));
+    fields.push(Field::new("read_num", DataType::UInt8, false));
+    fields.push(Field::new("name", DataType::Utf8, true));
+
+    match length_mode {
+        LengthMode::Fixed { read_len } => {
+            let seq_bytes = packing.packed_len(read_len) as i32;
+            fields.push(Field::new(
+                "sequence",
+                DataType::FixedSizeBinary(seq_bytes),
+                false,
+            ));
+            fields.push(Field::new(
+                "quality",
+                DataType::FixedSizeBinary(read_len as i32),
+                true,
+            ));
+        }
+        LengthMode::Variable => {
+            fields.push(Field::new("read_len", DataType::UInt32, false));
+            fields.push(Field::new("sequence", DataType::Binary, false));
+            fields.push(Field::new("quality", DataType::Binary, true));
+        }
+    }
+
+    Arc::new(Schema::new(fields))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_mode_omits_read_len_column() {
+        let schema = build_per_read_schema(LengthMode::Fixed { read_len: 150 }, DnaPacking::Ascii);
+        let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert!(!names.contains(&"read_len"));
+        assert!(names.contains(&"sequence"));
+        assert!(names.contains(&"quality"));
+    }
+
+    #[test]
+    fn variable_mode_includes_read_len_column() {
+        let schema = build_per_read_schema(LengthMode::Variable, DnaPacking::Ascii);
+        let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert!(names.contains(&"read_len"));
+    }
+
+    #[test]
+    fn fixed_2na_uses_packed_width() {
+        let schema = build_per_read_schema(LengthMode::Fixed { read_len: 150 }, DnaPacking::TwoNa);
+        let seq_field = schema.field_with_name("sequence").unwrap();
+        // 150 bases / 4 = 38 bytes (rounded up).
+        assert!(matches!(
+            seq_field.data_type(),
+            DataType::FixedSizeBinary(38)
+        ));
+    }
+
+    #[test]
+    fn fixed_ascii_uses_unpacked_width() {
+        let schema = build_per_read_schema(LengthMode::Fixed { read_len: 150 }, DnaPacking::Ascii);
+        let seq_field = schema.field_with_name("sequence").unwrap();
+        assert!(matches!(
+            seq_field.data_type(),
+            DataType::FixedSizeBinary(150)
+        ));
+    }
+
+    #[test]
+    fn quality_width_matches_read_len_in_fixed_mode() {
+        let schema = build_per_read_schema(LengthMode::Fixed { read_len: 75 }, DnaPacking::TwoNa);
+        let qual_field = schema.field_with_name("quality").unwrap();
+        assert!(matches!(
+            qual_field.data_type(),
+            DataType::FixedSizeBinary(75)
+        ));
+    }
+
+    #[test]
+    fn packed_len_rounds_up() {
+        assert_eq!(DnaPacking::Ascii.packed_len(150), 150);
+        assert_eq!(DnaPacking::TwoNa.packed_len(150), 38); // 150/4 = 37.5 → 38
+        assert_eq!(DnaPacking::TwoNa.packed_len(151), 38);
+        assert_eq!(DnaPacking::TwoNa.packed_len(152), 38);
+        assert_eq!(DnaPacking::TwoNa.packed_len(153), 39);
+        assert_eq!(DnaPacking::FourNa.packed_len(150), 75);
+        assert_eq!(DnaPacking::FourNa.packed_len(151), 76);
+    }
+}

--- a/crates/sracha-core/src/parquet/writer.rs
+++ b/crates/sracha-core/src/parquet/writer.rs
@@ -1,0 +1,681 @@
+//! Convert an SRA file into a Parquet file.
+//!
+//! v1 scope: bulk columns only (READ, QUALITY, READ_LEN, NAME). The fasterq-
+//! dump-equivalent edge cases (ALTREAD ambiguity merge, Illumina name
+//! reconstruction from skey, SRA-lite synthetic quality, technical-read
+//! filtering) are deliberately skipped — they don't affect the storage-
+//! density measurement we're after, only the byte-for-byte content of
+//! affected columns.
+//!
+//! Output schema is per-read (one row per biological+technical read), chosen
+//! at runtime as fixed-length or variable-length based on detected uniformity
+//! of `READ_LEN`.
+
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, BinaryBuilder, FixedSizeBinaryBuilder, RecordBatch, StringBuilder, UInt8Builder,
+    UInt32Builder, UInt64Builder,
+};
+use parquet::arrow::ArrowWriter;
+use parquet::basic::{Compression, Encoding, ZstdLevel};
+use parquet::file::properties::{EnabledStatistics, WriterProperties};
+use parquet::schema::types::ColumnPath;
+
+use crate::error::{Error, Result};
+use crate::pipeline::{decode_irzip_column, decode_raw, decode_zip_encoding};
+use crate::vdb::cursor::VdbCursor;
+use crate::vdb::kar::KarArchive;
+
+use super::encoding::{is_pure_acgt, pack_2na, pack_4na};
+use super::schema::{DnaPacking, LengthMode, build_per_read_schema};
+
+// ---------------------------------------------------------------------------
+// Public configuration
+// ---------------------------------------------------------------------------
+
+/// Page-level compression codec applied to all columns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParquetCompression {
+    None,
+    Snappy,
+    /// Zstd level (typically 1–22; 22 is the slowest/densest).
+    Zstd(i32),
+}
+
+impl ParquetCompression {
+    fn into_parquet(self) -> Compression {
+        match self {
+            ParquetCompression::None => Compression::UNCOMPRESSED,
+            ParquetCompression::Snappy => Compression::SNAPPY,
+            ParquetCompression::Zstd(level) => {
+                Compression::ZSTD(ZstdLevel::try_new(level).unwrap_or_default())
+            }
+        }
+    }
+}
+
+/// User-facing length-mode selector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LengthModeChoice {
+    /// Detect from data: fixed if all reads share a length, else variable.
+    Auto,
+    /// Force fixed-length even if detection is ambiguous (errors on mismatch).
+    Fixed,
+    /// Force variable-length even if reads are uniform.
+    Variable,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConvertConfig {
+    pub compression: ParquetCompression,
+    pub pack_dna: DnaPacking,
+    /// Target row-group size in MiB. Parquet flushes a row group when it
+    /// estimates this many MiB have been buffered.
+    pub row_group_mib: usize,
+    pub length_mode: LengthModeChoice,
+    /// Number of blobs to decode per Arrow `RecordBatch`.
+    pub blobs_per_batch: usize,
+}
+
+impl Default for ConvertConfig {
+    fn default() -> Self {
+        Self {
+            compression: ParquetCompression::Zstd(22),
+            pack_dna: DnaPacking::TwoNa,
+            row_group_mib: 256,
+            length_mode: LengthModeChoice::Auto,
+            blobs_per_batch: 64,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConvertStats {
+    pub spots: u64,
+    pub reads: u64,
+    pub input_bytes: u64,
+    pub output_bytes: u64,
+    pub output_path: PathBuf,
+    pub length_mode: LengthMode,
+    pub dna_packing: DnaPacking,
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Convert an SRA file at `sra_path` into a Parquet file at `output_path`.
+pub fn convert_sra_to_parquet(
+    sra_path: &Path,
+    output_path: &Path,
+    config: &ConvertConfig,
+) -> Result<ConvertStats> {
+    let input_bytes = std::fs::metadata(sra_path)?.len();
+
+    let file = File::open(sra_path)?;
+    let mut archive = KarArchive::open(std::io::BufReader::new(file))?;
+    let cursor = VdbCursor::open(&mut archive, sra_path)?;
+
+    let length_mode = resolve_length_mode(&cursor, config.length_mode)?;
+    let pack_dna = config.pack_dna;
+    let schema = build_per_read_schema(length_mode, pack_dna);
+
+    tracing::debug!(
+        "parquet: length_mode={:?}, pack_dna={:?}, compression={:?}",
+        length_mode,
+        pack_dna,
+        config.compression
+    );
+
+    let writer_props = build_writer_properties(config);
+    let out_file = File::create(output_path)?;
+    let mut writer = ArrowWriter::try_new(out_file, schema.clone(), Some(writer_props))
+        .map_err(|e| Error::Vdb(format!("parquet writer init: {e}")))?;
+
+    // ---- per-blob iteration ------------------------------------------------
+    let read_cs = cursor.read_col().meta().checksum_type;
+    let num_blobs = cursor.read_col().blob_count();
+    let blob_infos = cursor.read_col().blobs().to_vec();
+
+    let quality_cs = cursor.quality_col().map_or(0, |c| c.meta().checksum_type);
+    let read_len_cs = cursor.read_len_col().map_or(0, |c| c.meta().checksum_type);
+    let name_cs = cursor.name_col().map_or(0, |c| c.meta().checksum_type);
+
+    let mut stats = ConvertStats {
+        spots: 0,
+        reads: 0,
+        input_bytes,
+        output_bytes: 0,
+        output_path: output_path.to_path_buf(),
+        length_mode,
+        dna_packing: pack_dna,
+    };
+
+    let mut spot_id_acc: u64 = cursor.first_row().max(1) as u64;
+    let mut batch_builder = BatchBuilder::new(schema.clone(), length_mode, pack_dna);
+
+    for (blob_idx, blob_info) in blob_infos.iter().enumerate() {
+        let start_row = blob_info.start_id;
+        let id_range = blob_info.id_range as u64;
+
+        let read_raw = cursor.read_col().read_raw_blob_slice(start_row)?;
+        let quality_raw = cursor
+            .quality_col()
+            .filter(|c| blob_idx < c.blob_count())
+            .map(|c| c.read_raw_blob_slice(start_row))
+            .transpose()?
+            .unwrap_or(&[]);
+        let read_len_raw = cursor
+            .read_len_col()
+            .filter(|c| blob_idx < c.blob_count())
+            .map(|c| c.read_raw_blob_slice(start_row))
+            .transpose()?
+            .unwrap_or(&[]);
+        let name_raw = cursor
+            .name_col()
+            .filter(|c| blob_idx < c.blob_count())
+            .map(|c| c.read_raw_blob_slice(start_row))
+            .transpose()?
+            .unwrap_or(&[]);
+
+        let decoded = decode_one_blob(
+            read_raw,
+            read_cs,
+            id_range,
+            quality_raw,
+            quality_cs,
+            read_len_raw,
+            read_len_cs,
+            name_raw,
+            name_cs,
+        )?;
+
+        let n_spots = decoded.spot_count();
+        for (spot_offset, spot) in decoded.iter_spots().enumerate() {
+            let spot_id = spot_id_acc + spot_offset as u64;
+            for (read_num, read) in spot.iter_reads().enumerate() {
+                batch_builder.push(
+                    spot_id,
+                    read_num as u8,
+                    spot.name,
+                    read.sequence,
+                    read.quality,
+                );
+                stats.reads += 1;
+            }
+        }
+
+        stats.spots += n_spots as u64;
+        spot_id_acc += n_spots as u64;
+
+        if batch_builder.len() >= config.blobs_per_batch * 1024 {
+            let batch = batch_builder.finish()?;
+            writer
+                .write(&batch)
+                .map_err(|e| Error::Vdb(format!("parquet write batch: {e}")))?;
+        }
+    }
+
+    if !batch_builder.is_empty() {
+        let batch = batch_builder.finish()?;
+        writer
+            .write(&batch)
+            .map_err(|e| Error::Vdb(format!("parquet write final batch: {e}")))?;
+    }
+
+    writer
+        .close()
+        .map_err(|e| Error::Vdb(format!("parquet close: {e}")))?;
+
+    stats.output_bytes = std::fs::metadata(output_path)?.len();
+    let _ = num_blobs;
+    Ok(stats)
+}
+
+// ---------------------------------------------------------------------------
+// Length-mode resolution
+// ---------------------------------------------------------------------------
+
+fn resolve_length_mode(cursor: &VdbCursor, choice: LengthModeChoice) -> Result<LengthMode> {
+    let detected = detect_length_mode(cursor);
+    match (choice, detected) {
+        (LengthModeChoice::Auto, mode) => Ok(mode),
+        (LengthModeChoice::Fixed, LengthMode::Fixed { read_len }) => {
+            Ok(LengthMode::Fixed { read_len })
+        }
+        (LengthModeChoice::Fixed, LengthMode::Variable) => Err(Error::Vdb(
+            "--length-mode fixed requested but data has variable read lengths".into(),
+        )),
+        (LengthModeChoice::Variable, _) => Ok(LengthMode::Variable),
+    }
+}
+
+fn detect_length_mode(cursor: &VdbCursor) -> LengthMode {
+    if let Some(lengths) = cursor.metadata_read_lengths()
+        && !lengths.is_empty()
+        && lengths.iter().all(|&l| l == lengths[0])
+    {
+        return LengthMode::Fixed {
+            read_len: lengths[0],
+        };
+    }
+    LengthMode::Variable
+}
+
+// ---------------------------------------------------------------------------
+// Writer properties
+// ---------------------------------------------------------------------------
+
+fn build_writer_properties(config: &ConvertConfig) -> WriterProperties {
+    let compression = config.compression.into_parquet();
+    let row_group_bytes = config.row_group_mib * 1024 * 1024;
+
+    let mut builder = WriterProperties::builder()
+        .set_compression(compression)
+        .set_data_page_size_limit(1024 * 1024)
+        .set_write_batch_size(8192)
+        .set_dictionary_enabled(true)
+        .set_statistics_enabled(EnabledStatistics::Chunk);
+
+    let _ = row_group_bytes;
+
+    builder = builder.set_column_encoding(
+        ColumnPath::from(vec!["spot_id".into()]),
+        Encoding::DELTA_BINARY_PACKED,
+    );
+    builder = builder.set_column_encoding(
+        ColumnPath::from(vec!["read_len".into()]),
+        Encoding::DELTA_BINARY_PACKED,
+    );
+    builder = builder.set_column_encoding(
+        ColumnPath::from(vec!["name".into()]),
+        Encoding::DELTA_BYTE_ARRAY,
+    );
+    builder = builder.set_column_dictionary_enabled(ColumnPath::from(vec!["name".into()]), false);
+
+    builder.build()
+}
+
+// ---------------------------------------------------------------------------
+// Per-blob decode (minimal: READ, QUALITY, READ_LEN, NAME)
+// ---------------------------------------------------------------------------
+
+struct DecodedBlob {
+    /// Concatenated bases for all spots in the blob (ASCII).
+    bases: Vec<u8>,
+    /// Concatenated quality (Phred+33 ASCII). Empty if QUALITY column absent.
+    quality: Vec<u8>,
+    /// Per-read lengths, flat, length = total reads in blob.
+    read_lengths: Vec<u32>,
+    /// Reads per spot (uniform across the blob).
+    reads_per_spot: usize,
+    /// Per-spot names, length = spot count. Empty placeholder if NAME absent.
+    names: Vec<Vec<u8>>,
+}
+
+impl DecodedBlob {
+    fn spot_count(&self) -> usize {
+        self.read_lengths.len() / self.reads_per_spot.max(1)
+    }
+
+    fn iter_spots(&self) -> SpotIter<'_> {
+        SpotIter {
+            blob: self,
+            spot_idx: 0,
+            base_offset: 0,
+        }
+    }
+}
+
+struct SpotIter<'a> {
+    blob: &'a DecodedBlob,
+    spot_idx: usize,
+    base_offset: usize,
+}
+
+struct SpotView<'a> {
+    name: &'a [u8],
+    bases: &'a [u8],
+    quality: &'a [u8],
+    read_lengths: &'a [u32],
+}
+
+struct ReadView<'a> {
+    sequence: &'a [u8],
+    quality: &'a [u8],
+}
+
+impl<'a> Iterator for SpotIter<'a> {
+    type Item = SpotView<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.spot_idx >= self.blob.spot_count() {
+            return None;
+        }
+        let rps = self.blob.reads_per_spot.max(1);
+        let lens = &self.blob.read_lengths[self.spot_idx * rps..(self.spot_idx + 1) * rps];
+        let spot_len: usize = lens.iter().map(|&l| l as usize).sum();
+
+        let bases_end = self.base_offset + spot_len;
+        let bases = if bases_end <= self.blob.bases.len() {
+            &self.blob.bases[self.base_offset..bases_end]
+        } else {
+            &[]
+        };
+        let quality = if !self.blob.quality.is_empty() && bases_end <= self.blob.quality.len() {
+            &self.blob.quality[self.base_offset..bases_end]
+        } else {
+            &[]
+        };
+        let name: &[u8] = self
+            .blob
+            .names
+            .get(self.spot_idx)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+
+        self.spot_idx += 1;
+        self.base_offset = bases_end;
+        Some(SpotView {
+            name,
+            bases,
+            quality,
+            read_lengths: lens,
+        })
+    }
+}
+
+impl<'a> SpotView<'a> {
+    fn iter_reads(&self) -> ReadIter<'a> {
+        ReadIter {
+            spot: SpotView {
+                name: self.name,
+                bases: self.bases,
+                quality: self.quality,
+                read_lengths: self.read_lengths,
+            },
+            read_idx: 0,
+            base_offset: 0,
+        }
+    }
+}
+
+struct ReadIter<'a> {
+    spot: SpotView<'a>,
+    read_idx: usize,
+    base_offset: usize,
+}
+
+impl<'a> Iterator for ReadIter<'a> {
+    type Item = ReadView<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.read_idx >= self.spot.read_lengths.len() {
+            return None;
+        }
+        let len = self.spot.read_lengths[self.read_idx] as usize;
+        let end = self.base_offset + len;
+        let sequence = if end <= self.spot.bases.len() {
+            &self.spot.bases[self.base_offset..end]
+        } else {
+            &[]
+        };
+        let quality = if !self.spot.quality.is_empty() && end <= self.spot.quality.len() {
+            &self.spot.quality[self.base_offset..end]
+        } else {
+            &[]
+        };
+        self.read_idx += 1;
+        self.base_offset = end;
+        Some(ReadView { sequence, quality })
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn decode_one_blob(
+    read_raw: &[u8],
+    read_cs: u8,
+    id_range: u64,
+    quality_raw: &[u8],
+    quality_cs: u8,
+    read_len_raw: &[u8],
+    read_len_cs: u8,
+    name_raw: &[u8],
+    name_cs: u8,
+) -> Result<DecodedBlob> {
+    // READ
+    let read_decoded = decode_raw(read_raw, read_cs, id_range)?;
+    let total_bits = read_decoded.data.len() * 8;
+    let adjust = read_decoded.adjust as usize;
+    let actual_bases = total_bits.saturating_sub(adjust) / 2;
+    let bases = crate::vdb::encoding::unpack_2na(&read_decoded.data, actual_bases);
+
+    // QUALITY
+    let quality: Vec<u8> = if !quality_raw.is_empty() {
+        let qdecoded = decode_raw(quality_raw, quality_cs, id_range)?;
+        let qpage_map = qdecoded.page_map.clone();
+        let mut qdata = decode_zip_encoding(&qdecoded);
+        if let Some(ref pm) = qpage_map
+            && !pm.data_runs.is_empty()
+        {
+            qdata = pm.expand_variable_data_runs(&qdata);
+        }
+        let all_valid_ascii =
+            qdata.len() == bases.len() && qdata.iter().all(|&b| (33..=126).contains(&b));
+        if all_valid_ascii {
+            qdata
+        } else {
+            crate::vdb::encoding::phred_to_ascii(&qdata)
+        }
+    } else {
+        Vec::new()
+    };
+
+    // READ_LEN
+    let (read_lengths, reads_per_spot): (Vec<u32>, usize) = if !read_len_raw.is_empty() {
+        let rldecoded = decode_raw(read_len_raw, read_len_cs, id_range)?;
+        let rps = rldecoded
+            .page_map
+            .as_ref()
+            .and_then(|pm| pm.lengths.first().copied())
+            .unwrap_or(1) as usize;
+        let rl_bytes = decode_irzip_column(&rldecoded);
+        let lengths: Vec<u32> = rl_bytes
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        (lengths, rps.max(1))
+    } else {
+        (vec![bases.len() as u32], 1)
+    };
+
+    // NAME (from page_map: variable-width strings)
+    let names: Vec<Vec<u8>> = if !name_raw.is_empty() {
+        let ndecoded = decode_raw(name_raw, name_cs, id_range)?;
+        let name_bytes = decode_zip_encoding(&ndecoded);
+        let mut out = Vec::new();
+        if let Some(ref pm) = ndecoded.page_map {
+            let mut offset = 0usize;
+            for (len, run) in pm.lengths.iter().zip(pm.leng_runs.iter()) {
+                let nlen = *len as usize;
+                for _ in 0..*run {
+                    if offset + nlen <= name_bytes.len() {
+                        out.push(name_bytes[offset..offset + nlen].to_vec());
+                        offset += nlen;
+                    }
+                }
+            }
+        }
+        out
+    } else {
+        Vec::new()
+    };
+
+    Ok(DecodedBlob {
+        bases,
+        quality,
+        read_lengths,
+        reads_per_spot,
+        names,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Arrow batch builder
+// ---------------------------------------------------------------------------
+
+struct BatchBuilder {
+    schema: Arc<arrow::datatypes::Schema>,
+    length_mode: LengthMode,
+    pack_dna: DnaPacking,
+
+    spot_id: UInt64Builder,
+    read_num: UInt8Builder,
+    name: StringBuilder,
+    read_len: UInt32Builder,
+    seq_var: BinaryBuilder,
+    qual_var: BinaryBuilder,
+    seq_fixed: Option<FixedSizeBinaryBuilder>,
+    qual_fixed: Option<FixedSizeBinaryBuilder>,
+    rows: usize,
+}
+
+impl BatchBuilder {
+    fn new(
+        schema: Arc<arrow::datatypes::Schema>,
+        length_mode: LengthMode,
+        pack_dna: DnaPacking,
+    ) -> Self {
+        let (seq_fixed, qual_fixed) = match length_mode {
+            LengthMode::Fixed { read_len } => {
+                let seq_w = pack_dna.packed_len(read_len) as i32;
+                (
+                    Some(FixedSizeBinaryBuilder::new(seq_w)),
+                    Some(FixedSizeBinaryBuilder::new(read_len as i32)),
+                )
+            }
+            LengthMode::Variable => (None, None),
+        };
+        Self {
+            schema,
+            length_mode,
+            pack_dna,
+            spot_id: UInt64Builder::new(),
+            read_num: UInt8Builder::new(),
+            name: StringBuilder::new(),
+            read_len: UInt32Builder::new(),
+            seq_var: BinaryBuilder::new(),
+            qual_var: BinaryBuilder::new(),
+            seq_fixed,
+            qual_fixed,
+            rows: 0,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.rows
+    }
+
+    fn is_empty(&self) -> bool {
+        self.rows == 0
+    }
+
+    fn push(
+        &mut self,
+        spot_id: u64,
+        read_num: u8,
+        name: &[u8],
+        sequence_ascii: &[u8],
+        quality_ascii: &[u8],
+    ) {
+        self.spot_id.append_value(spot_id);
+        self.read_num.append_value(read_num);
+        if name.is_empty() {
+            self.name.append_null();
+        } else {
+            self.name
+                .append_value(std::str::from_utf8(name).unwrap_or(""));
+        }
+
+        let packed = pack_sequence(sequence_ascii, self.pack_dna);
+
+        match self.length_mode {
+            LengthMode::Fixed { read_len } => {
+                let want = self.pack_dna.packed_len(read_len) as usize;
+                let mut buf = packed;
+                if buf.len() < want {
+                    buf.resize(want, 0);
+                } else if buf.len() > want {
+                    buf.truncate(want);
+                }
+                self.seq_fixed.as_mut().unwrap().append_value(&buf).ok();
+                let qbuf = if quality_ascii.is_empty() {
+                    None
+                } else {
+                    let mut q = quality_ascii.to_vec();
+                    if q.len() < read_len as usize {
+                        q.resize(read_len as usize, b'?');
+                    } else if q.len() > read_len as usize {
+                        q.truncate(read_len as usize);
+                    }
+                    Some(q)
+                };
+                match qbuf {
+                    Some(q) => {
+                        self.qual_fixed.as_mut().unwrap().append_value(&q).ok();
+                    }
+                    None => {
+                        self.qual_fixed.as_mut().unwrap().append_null();
+                    }
+                }
+            }
+            LengthMode::Variable => {
+                self.read_len.append_value(sequence_ascii.len() as u32);
+                self.seq_var.append_value(&packed);
+                if quality_ascii.is_empty() {
+                    self.qual_var.append_null();
+                } else {
+                    self.qual_var.append_value(quality_ascii);
+                }
+            }
+        }
+
+        self.rows += 1;
+    }
+
+    fn finish(&mut self) -> Result<RecordBatch> {
+        let mut cols: Vec<ArrayRef> = Vec::with_capacity(6);
+        cols.push(Arc::new(self.spot_id.finish()));
+        cols.push(Arc::new(self.read_num.finish()));
+        cols.push(Arc::new(self.name.finish()));
+        match self.length_mode {
+            LengthMode::Fixed { .. } => {
+                cols.push(Arc::new(self.seq_fixed.as_mut().unwrap().finish()));
+                cols.push(Arc::new(self.qual_fixed.as_mut().unwrap().finish()));
+            }
+            LengthMode::Variable => {
+                cols.push(Arc::new(self.read_len.finish()));
+                cols.push(Arc::new(self.seq_var.finish()));
+                cols.push(Arc::new(self.qual_var.finish()));
+            }
+        }
+        self.rows = 0;
+        RecordBatch::try_new(self.schema.clone(), cols)
+            .map_err(|e| Error::Vdb(format!("arrow record batch: {e}")))
+    }
+}
+
+fn pack_sequence(ascii: &[u8], packing: DnaPacking) -> Vec<u8> {
+    match packing {
+        DnaPacking::Ascii => ascii.to_vec(),
+        DnaPacking::TwoNa => {
+            if is_pure_acgt(ascii) {
+                pack_2na(ascii)
+            } else {
+                pack_4na(ascii)
+            }
+        }
+        DnaPacking::FourNa => pack_4na(ascii),
+    }
+}

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -400,7 +400,7 @@ fn select_mirror(resolved: &ResolvedAccession) -> Result<String> {
 /// strip them here before handing the data to [`blob::decode_blob`].
 /// Checksum validation is not performed because the stored CRC covers only
 /// a portion of the blob that doesn't align with the full raw slice.
-fn decode_raw<'a>(
+pub(crate) fn decode_raw<'a>(
     raw: &'a [u8],
     checksum_type: u8,
     row_count: u64,
@@ -419,7 +419,7 @@ fn decode_raw<'a>(
 }
 
 /// Decode irzip-compressed integers from a blob, detecting single vs dual series.
-fn decode_irzip_column(decoded: &blob::DecodedBlob<'_>) -> Vec<u8> {
+pub(crate) fn decode_irzip_column(decoded: &blob::DecodedBlob<'_>) -> Vec<u8> {
     let hdr_version = decoded.headers.first().map(|h| h.version).unwrap_or(0);
     let decoded_ints = if hdr_version >= 1 {
         let hdr = &decoded.headers[0];
@@ -478,7 +478,7 @@ fn expand_via_page_map(decoded_ints: Vec<u8>, page_map: &Option<blob::PageMap>) 
 /// data is already the raw-deflate stream.
 ///
 /// Returns decompressed bytes, or falls back to raw bytes on failure.
-fn decode_zip_encoding(decoded: &blob::DecodedBlob<'_>) -> Vec<u8> {
+pub(crate) fn decode_zip_encoding(decoded: &blob::DecodedBlob<'_>) -> Vec<u8> {
     let hdr_version = decoded.headers.first().map(|h| h.version).unwrap_or(0);
 
     if decoded.data.is_empty() {

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -66,11 +66,103 @@ pub enum Command {
     /// Convert SRA file(s) to FASTQ
     Fastq(FastqArgs),
 
+    /// Convert SRA file(s) to Parquet (experimental, storage benchmarking)
+    Convert(ConvertArgs),
+
     /// Show accession metadata
     Info(InfoArgs),
 
     /// Validate SRA file integrity
     Validate(ValidateArgs),
+}
+
+#[derive(Args)]
+pub struct ConvertArgs {
+    /// SRA file path(s) (.sra files from `sracha fetch`)
+    #[arg(required = true)]
+    pub inputs: Vec<String>,
+
+    /// Output directory (one .parquet file per input)
+    #[arg(short = 'O', long, default_value = ".", help_heading = "Output")]
+    pub output_dir: PathBuf,
+
+    /// Force-overwrite existing output files
+    #[arg(short, long, help_heading = "Output")]
+    pub force: bool,
+
+    /// DNA encoding for the `sequence` column
+    #[arg(long, default_value = "two-na", help_heading = "Encoding")]
+    pub pack_dna: PackDna,
+
+    /// Read-length mode for the schema
+    #[arg(long, default_value = "auto", help_heading = "Encoding")]
+    pub length_mode: LengthMode,
+
+    /// Page-level compression codec
+    #[arg(long, default_value = "zstd", help_heading = "Compression")]
+    pub compression: ParquetCodec,
+
+    /// Zstd compression level (1-22), only when `--compression zstd`
+    #[arg(
+        long,
+        value_parser = clap::value_parser!(i32).range(1..=22),
+        default_value_t = 22,
+        help_heading = "Compression",
+    )]
+    pub zstd_level: i32,
+
+    /// Target row-group size in MiB
+    #[arg(long, default_value_t = 256, help_heading = "Advanced")]
+    pub row_group_mib: usize,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub enum PackDna {
+    /// One byte per base (A/C/G/T/N/IUPAC)
+    Ascii,
+    /// 2 bits/base, 4× density (auto-falls back to 4na on ambiguity)
+    #[value(name = "two-na")]
+    TwoNa,
+    /// 4 bits/base, preserves IUPAC ambiguity
+    #[value(name = "four-na")]
+    FourNa,
+}
+
+impl From<PackDna> for sracha_core::parquet::DnaPacking {
+    fn from(p: PackDna) -> Self {
+        match p {
+            PackDna::Ascii => Self::Ascii,
+            PackDna::TwoNa => Self::TwoNa,
+            PackDna::FourNa => Self::FourNa,
+        }
+    }
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub enum LengthMode {
+    /// Detect from data: fixed if all reads share a length, else variable
+    Auto,
+    /// Force FIXED_LEN_BYTE_ARRAY (errors on length mismatch)
+    Fixed,
+    /// Force variable-length BYTE_ARRAY
+    Variable,
+}
+
+impl From<LengthMode> for sracha_core::parquet::writer::LengthModeChoice {
+    fn from(m: LengthMode) -> Self {
+        match m {
+            LengthMode::Auto => Self::Auto,
+            LengthMode::Fixed => Self::Fixed,
+            LengthMode::Variable => Self::Variable,
+        }
+    }
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub enum ParquetCodec {
+    None,
+    Snappy,
+    Zstd,
 }
 
 #[derive(Args)]

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -211,6 +211,75 @@ async fn main() -> Result<()> {
 
             Ok(())
         }
+        Command::Convert(args) => {
+            use sracha_core::parquet::{ConvertConfig, ParquetCompression, convert_sra_to_parquet};
+
+            std::fs::create_dir_all(&args.output_dir)?;
+
+            let compression = match args.compression {
+                cli::ParquetCodec::None => ParquetCompression::None,
+                cli::ParquetCodec::Snappy => ParquetCompression::Snappy,
+                cli::ParquetCodec::Zstd => ParquetCompression::Zstd(args.zstd_level),
+            };
+
+            for input in &args.inputs {
+                let sra_path = Path::new(input);
+                if !sra_path.exists() {
+                    eprintln!(
+                        "{} file not found: {}",
+                        style::error_label("error:"),
+                        style::path(input)
+                    );
+                    continue;
+                }
+
+                let stem = sra_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("output");
+                let out_path = args.output_dir.join(format!("{stem}.parquet"));
+                if out_path.exists() && !args.force {
+                    eprintln!(
+                        "{} {} already exists (use --force to overwrite)",
+                        style::error_label("error:"),
+                        style::path(out_path.display())
+                    );
+                    continue;
+                }
+
+                let config = ConvertConfig {
+                    compression,
+                    pack_dna: args.pack_dna.into(),
+                    row_group_mib: args.row_group_mib,
+                    length_mode: args.length_mode.into(),
+                    blobs_per_batch: 64,
+                };
+
+                let stats = convert_sra_to_parquet(sra_path, &out_path, &config)?;
+
+                let ratio = if stats.input_bytes > 0 {
+                    stats.output_bytes as f64 / stats.input_bytes as f64 * 100.0
+                } else {
+                    0.0
+                };
+                eprintln!(
+                    "{}: {} spots, {} reads, {} -> {} ({:.1}% of input)",
+                    style::header(stem),
+                    style::count(stats.spots),
+                    style::count(stats.reads),
+                    format_size(stats.input_bytes),
+                    format_size(stats.output_bytes),
+                    ratio,
+                );
+                eprintln!(
+                    "  length_mode={:?}, dna_packing={:?}, compression={:?}",
+                    stats.length_mode, stats.dna_packing, compression
+                );
+                eprintln!("  -> {}", style::path(out_path.display()));
+            }
+
+            Ok(())
+        }
         Command::Get(args) => {
             let split_mode =
                 cli::resolve_split_mode(args.split, args.stdout).map_err(|e| anyhow::anyhow!(e))?;


### PR DESCRIPTION
## Summary

Adds `sracha convert` to test whether Apache Arrow / Parquet can match VDB's storage density when given the same domain tricks. Built as a separate subcommand so the existing FASTQ pipeline is untouched.

- New `crates/sracha-core/src/parquet/` module: schema, 2na/4na pre-packing helpers, ArrowWriter-based per-blob writer.
- New CLI: `sracha convert <input.sra> -O <dir> --pack-dna {ascii,two-na,four-na} --length-mode {auto,fixed,variable} --compression {none,snappy,zstd} --zstd-level N`.
- Length-mode auto-detection: emits `FIXED_LEN_BYTE_ARRAY` when all reads share a length (Illumina), `BYTE_ARRAY` + `read_len` column otherwise. Drops Parquet's per-row 4-byte length prefix on Illumina — meaningful (~10%) when DNA is 2na-packed.
- Per-column encoding hints: `DELTA_BINARY_PACKED` for `spot_id`/`read_len`, `DELTA_BYTE_ARRAY` for `name` (Illumina names share long prefixes), default dictionary + zstd for `sequence`/`quality`.
- Three private decode helpers in `pipeline/mod.rs` lifted to `pub(crate)` so the parquet module can reuse them without duplicating decode logic.

### v1 scope (intentional)

Bulk columns only: READ, QUALITY, READ_LEN, NAME. The fasterq-dump-equivalent edge cases (ALTREAD ambiguity merge, Illumina name reconstruction from skey, SRA-lite synthetic quality, technical-read filtering) are skipped — they don't affect the storage-density measurement.

### Why
VDB's storage wins come from domain encodings (2na DNA, deflate quality, izip read lengths). The hypothesis is that Parquet can match this with: 2na pre-packing for DNA, fixed-width detection for both DNA and quality, and Parquet's native dictionary/delta encodings for the rest. This converter exists to put a number on it.

## Test plan

- [x] `cargo test -p sracha-core parquet::` (11 unit tests pass: 2na/4na roundtrip, schema variants, packed length math)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] End-to-end conversion on real SRA — local debug-build run was too slow on a 288 MiB Illumina paired-end fixture; needs to move to a cluster for the actual storage-vs-VDB comparison
- [ ] Compare output size: `.sra` vs `--pack-dna ascii` vs `--pack-dna two-na`, both with and without `--compression zstd --zstd-level 22`
- [ ] Per-column size breakdown via Parquet metadata
- [ ] Round-trip correctness vs `fasterq-dump`