### PR TITLE
fix(download): honor --force in resume checks and single-stream path

### DIFF
--- a/crates/sracha-core/src/download/mod.rs
+++ b/crates/sracha-core/src/download/mod.rs
@@ -509,13 +509,19 @@ pub async fn download_file(
         let all_chunks = plan_chunks(file_size, chunk_size);
         let total_chunks = all_chunks.len();
 
-        // Check for existing progress sidecar.
+        // Check for existing progress sidecar. `--force` means "start
+        // fresh", so ignore any stale sidecar even when resume is on;
+        // otherwise a prior run's completed-chunks record would
+        // short-circuit the download and skew the progress bar total.
         let prog_path = progress_path(output_path);
-        let prev_progress = if config.resume {
+        let prev_progress = if config.resume && !config.force {
             load_progress(&prog_path)
         } else {
             None
         };
+        if config.force {
+            delete_progress(&prog_path);
+        }
 
         // Track whether we have a prior-MD5 mismatch so we also wipe the
         // partial file, not just the sidecar.
@@ -743,7 +749,11 @@ pub async fn download_file(
         delete_progress(&prog_path);
     } else {
         // --- Single-stream fallback (with resume support) ---
-        let existing_size = if config.resume && output_path.exists() {
+        // `--force` short-circuits resume: otherwise an already-complete
+        // file on disk leaves `bytes_remaining = 0`, creating a
+        // progress bar with `total = 0` that ticks to the real file
+        // size (displays "X MiB/0 B") while the download re-runs.
+        let existing_size = if config.resume && !config.force && output_path.exists() {
             tokio::fs::metadata(output_path).await?.len()
         } else {
             0


### PR DESCRIPTION
## Summary

`download_file` had two resume checks that ignored `config.force`, letting stale state from a prior run leak into a fresh `-f` download.

- **chunked path** (`download/mod.rs:514`): loaded the `.sracha-progress` sidecar whenever `config.resume` was on. A stale sidecar could short-circuit a forced download.
- **single-stream fallback** (`download/mod.rs:746`, used for files < 32 MiB): read `existing_size` off disk whenever the file was present and resume was on. When a complete file was already on disk, `bytes_remaining` came out as 0, the progress bar was created with `total = 0`, and the re-download ticked it against a zero total — hence the cosmetic `11.92 MiB / 0 B` display. Under vhs/ttyd the zero-total bar also broke indicatif's in-place redraws, producing stacked lines instead of one animating bar.

Both branches now gate on `config.resume && !config.force`, and the chunked path wipes any stale sidecar on a forced run so the next attempt can't pick it back up.

Found while recording the new `readme.gif` tape — the `fetch` step rendered stacked progress lines because a prior `get` step left state on disk that `-f` didn't actually clear.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p sracha-core --lib download` (10 passed)
- [ ] Manual: run `sracha get SRR28588231 -O /tmp` then `sracha fetch SRR28588231 -f -O /tmp` and confirm the fetch progress bar reports `X MiB / 22.31 MiB` rather than `X MiB / 0 B`