### PR TITLE
feat(ena): add --prefer-ena fast path via ENA filereport

### DIFF
--- a/crates/sracha-core/src/ena.rs
+++ b/crates/sracha-core/src/ena.rs
@@ -1,0 +1,482 @@
+//! ENA (European Nucleotide Archive) Filereport API client.
+//!
+//! ENA mirrors all INSDC data and serves archive-generated `fastq.gz` files
+//! directly over HTTP. Using these files lets `sracha get` skip the SRA
+//! download + VDB decode + gzip compression stages entirely.
+//!
+//! The single endpoint used here — `filereport?result=read_run` — accepts
+//! both run accessions (SRR/ERR/DRR) and project accessions
+//! (PRJEB/PRJNA/ERP/SRP/DRP). Projects return one JSON row per run.
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use tokio::sync::Semaphore;
+
+use crate::error::{Error, Result};
+use crate::fastq::OutputSlot;
+
+const ENA_FILEREPORT_URL: &str = "https://www.ebi.ac.uk/ena/portal/api/filereport";
+
+/// Maximum retry attempts for HTTP 429 / 5xx responses.
+const MAX_API_RETRIES: u32 = 3;
+
+/// Concurrency cap for batch queries. ENA allows 50 req/s; 20 in-flight
+/// gives headroom for other API calls sharing the same process.
+const ENA_BATCH_CONCURRENCY: usize = 20;
+
+/// Fields requested from the filereport API. Order matters only for humans —
+/// the API returns a JSON object keyed by field name either way.
+const ENA_FIELDS: &str = "run_accession,fastq_ftp,fastq_md5,fastq_bytes";
+
+/// One downloadable FASTQ file from ENA.
+#[derive(Debug, Clone)]
+pub struct EnaFastqFile {
+    /// HTTP URL (the filereport returns `ftp://` paths; we rewrite to `http://`
+    /// because `ftp.sra.ebi.ac.uk` serves the same paths over HTTP without
+    /// authentication).
+    pub url: String,
+    /// MD5 hex digest for integrity verification post-download.
+    pub md5: String,
+    /// File size in bytes.
+    pub size: u64,
+    /// Which output slot this file maps to (Read1, Read2, Single, Unpaired).
+    pub slot: OutputSlot,
+}
+
+/// Resolved ENA download information for one run accession.
+#[derive(Debug, Clone)]
+pub struct EnaResolved {
+    /// Run accession (SRR/ERR/DRR).
+    pub accession: String,
+    /// All downloadable files for this run.
+    pub fastq_files: Vec<EnaFastqFile>,
+    /// Sum of `fastq_files[i].size`.
+    pub total_size: u64,
+}
+
+/// Raw JSON row from the filereport API.
+#[derive(Debug, Deserialize)]
+struct FilereportRow {
+    #[serde(default)]
+    run_accession: String,
+    #[serde(default)]
+    fastq_ftp: String,
+    #[serde(default)]
+    fastq_md5: String,
+    #[serde(default)]
+    fastq_bytes: String,
+}
+
+/// HTTP GET with automatic retry on 429 and 5xx errors.
+///
+/// Mirrors `sdl::http_get_with_retry` — exponential backoff (1s, 2s, 4s) plus
+/// 0-500ms jitter to avoid thundering-herd under concurrent ENA batch queries.
+async fn http_get_with_retry(
+    client: &reqwest::Client,
+    url: &str,
+) -> std::result::Result<reqwest::Response, reqwest::Error> {
+    for attempt in 0..=MAX_API_RETRIES {
+        let resp = client.get(url).send().await?;
+        let status = resp.status();
+
+        if (status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error())
+            && attempt < MAX_API_RETRIES
+        {
+            let base = std::time::Duration::from_secs(1 << attempt);
+            let jitter = std::time::Duration::from_millis(rand_jitter_ms());
+            let delay = base + jitter;
+            tracing::info!(
+                "HTTP {status} from ENA {url}, retry {}/{MAX_API_RETRIES} in {delay:?}",
+                attempt + 1
+            );
+            tokio::time::sleep(delay).await;
+            continue;
+        }
+
+        return Ok(resp);
+    }
+    unreachable!()
+}
+
+fn rand_jitter_ms() -> u64 {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos();
+    (nanos % 500) as u64
+}
+
+/// Build the filereport URL for a given accession (run or project).
+fn build_url(accession: &str) -> String {
+    // `url::Url` would percent-encode `accession=SRR000001` identically; keep
+    // it simple since accessions are ASCII alphanumeric.
+    format!(
+        "{ENA_FILEREPORT_URL}?accession={accession}&result=read_run&fields={ENA_FIELDS}&format=json"
+    )
+}
+
+/// Fetch + parse raw filereport rows for an accession.
+async fn fetch_rows(client: &reqwest::Client, accession: &str) -> Result<Vec<FilereportRow>> {
+    let url = build_url(accession);
+    tracing::debug!("ENA request: {url}");
+
+    let resp = http_get_with_retry(client, &url)
+        .await
+        .map_err(|e| Error::Ena {
+            message: e.to_string(),
+        })?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(Vec::new());
+    }
+    if !resp.status().is_success() {
+        return Err(Error::Ena {
+            message: format!("HTTP {} for accession {}", resp.status(), accession),
+        });
+    }
+
+    let body = resp.text().await.map_err(|e| Error::Ena {
+        message: e.to_string(),
+    })?;
+    tracing::debug!("ENA response for {accession}: {body}");
+
+    // ENA returns `[]` for unknown accessions with format=json.
+    if body.trim().is_empty() || body.trim() == "[]" {
+        return Ok(Vec::new());
+    }
+
+    let rows: Vec<FilereportRow> = serde_json::from_str(&body).map_err(|e| Error::Ena {
+        message: format!("parse filereport for {accession}: {e}"),
+    })?;
+    Ok(rows)
+}
+
+/// Convert a single filereport row into `EnaResolved`, or `None` if the row
+/// has no FASTQ payload (some runs list only BAM/submitted files).
+fn row_to_resolved(row: FilereportRow) -> Option<EnaResolved> {
+    let accession = row.run_accession;
+    if accession.is_empty() {
+        return None;
+    }
+
+    let ftps: Vec<&str> = split_or_empty(&row.fastq_ftp);
+    if ftps.is_empty() {
+        return None;
+    }
+    let md5s: Vec<&str> = split_or_empty(&row.fastq_md5);
+    let bytes: Vec<&str> = split_or_empty(&row.fastq_bytes);
+
+    // ENA guarantees equal field counts when fastq_ftp is populated, but be
+    // defensive: missing parallel data disqualifies the row from the fast
+    // path (we need size + MD5 to use download_file safely).
+    if md5s.len() != ftps.len() || bytes.len() != ftps.len() {
+        tracing::warn!(
+            "ENA filereport for {accession}: mismatched field counts \
+             (ftp={}, md5={}, bytes={}); skipping",
+            ftps.len(),
+            md5s.len(),
+            bytes.len(),
+        );
+        return None;
+    }
+
+    let slots = assign_slots(&ftps);
+    let mut files = Vec::with_capacity(ftps.len());
+    let mut total: u64 = 0;
+    for (i, ftp) in ftps.iter().enumerate() {
+        let size: u64 = bytes[i].parse().unwrap_or(0);
+        if size == 0 || md5s[i].is_empty() {
+            // A row without size/md5 is unusable for the fast path.
+            return None;
+        }
+        files.push(EnaFastqFile {
+            url: ftp_to_http(ftp),
+            md5: md5s[i].to_string(),
+            size,
+            slot: slots[i],
+        });
+        total += size;
+    }
+
+    Some(EnaResolved {
+        accession,
+        fastq_files: files,
+        total_size: total,
+    })
+}
+
+fn split_or_empty(s: &str) -> Vec<&str> {
+    if s.is_empty() {
+        Vec::new()
+    } else {
+        s.split(';').collect()
+    }
+}
+
+/// Normalize a `fastq_ftp` value from ENA to an `http://` URL.
+///
+/// ENA's filereport returns values in one of three forms:
+/// `ftp://ftp.sra.ebi.ac.uk/...`, `ftp.sra.ebi.ac.uk/...` (scheme-less,
+/// the common case today), or `http://ftp.sra.ebi.ac.uk/...`. ENA serves
+/// the same paths over HTTP on the same host, so we normalize all three
+/// to `http://...`. HTTP avoids FTP client baggage (PASV, separate
+/// control/data connections) and lets the existing parallel chunked
+/// downloader reuse HTTP connection pools.
+fn ftp_to_http(url: &str) -> String {
+    if let Some(rest) = url.strip_prefix("ftp://") {
+        format!("http://{rest}")
+    } else if url.starts_with("http://") || url.starts_with("https://") {
+        url.to_string()
+    } else {
+        format!("http://{url}")
+    }
+}
+
+/// Assign `OutputSlot` to each file based on its filename suffix.
+///
+/// Naming conventions ENA uses:
+/// - `{ACC}.fastq.gz` → `Single` (single-end) or `Unpaired` (orphan in paired runs)
+/// - `{ACC}_1.fastq.gz` → `Read1`
+/// - `{ACC}_2.fastq.gz` → `Read2`
+///
+/// When a paired run also has unpaired reads, ENA returns three files; the
+/// bare-name file is the orphan and maps to `Unpaired` (same filename slot as
+/// fasterq-dump's split-3 orphan). Single-end runs return one bare-name file
+/// which maps to `Single`.
+fn assign_slots(ftps: &[&str]) -> Vec<OutputSlot> {
+    let has_r1 = ftps.iter().any(|u| has_suffix(u, "_1.fastq.gz"));
+    let has_r2 = ftps.iter().any(|u| has_suffix(u, "_2.fastq.gz"));
+    let paired = has_r1 && has_r2;
+
+    ftps.iter()
+        .map(|u| {
+            if has_suffix(u, "_1.fastq.gz") {
+                OutputSlot::Read1
+            } else if has_suffix(u, "_2.fastq.gz") {
+                OutputSlot::Read2
+            } else if paired {
+                OutputSlot::Unpaired
+            } else {
+                OutputSlot::Single
+            }
+        })
+        .collect()
+}
+
+fn has_suffix(url: &str, suffix: &str) -> bool {
+    // Match against the filename portion, ignoring query strings.
+    let path = url.split('?').next().unwrap_or(url);
+    path.ends_with(suffix)
+}
+
+/// Resolve a single run accession to its ENA FASTQ files.
+///
+/// Returns `Ok(None)` when ENA has no FASTQ for this accession (the caller
+/// should then fall back to the NCBI path). Returns `Err` only for API /
+/// network failures.
+pub async fn resolve_ena(client: &reqwest::Client, accession: &str) -> Result<Option<EnaResolved>> {
+    let rows = fetch_rows(client, accession).await?;
+    // For a run accession, filereport returns 0 or 1 row.
+    Ok(rows.into_iter().find_map(row_to_resolved))
+}
+
+/// Resolve a batch of run accessions concurrently (up to 20 in flight).
+///
+/// Preserves input order. Each result is `(accession, Option<EnaResolved>)`
+/// where `None` means "no FASTQ on ENA" OR "ENA API failed for this one"; the
+/// specific failure is logged via `tracing::warn!` but does not abort the
+/// batch, matching the forgiving behavior of SDL batch resolution.
+pub async fn resolve_ena_many(
+    client: &reqwest::Client,
+    accessions: &[String],
+) -> Vec<(String, Option<EnaResolved>)> {
+    let sem = Arc::new(Semaphore::new(ENA_BATCH_CONCURRENCY));
+    let mut handles = Vec::with_capacity(accessions.len());
+    for acc in accessions {
+        let client = client.clone();
+        let sem = sem.clone();
+        let acc = acc.clone();
+        handles.push(tokio::spawn(async move {
+            let _permit = sem.acquire_owned().await.expect("semaphore closed");
+            let result = resolve_ena(&client, &acc).await;
+            match result {
+                Ok(r) => (acc, r),
+                Err(e) => {
+                    tracing::warn!("ENA resolve failed for {acc}: {e}; treating as no FASTQ");
+                    (acc, None)
+                }
+            }
+        }));
+    }
+
+    let mut out = Vec::with_capacity(handles.len());
+    for h in handles {
+        match h.await {
+            Ok(pair) => out.push(pair),
+            Err(join_err) => {
+                tracing::warn!("ENA resolve task panicked: {join_err}");
+            }
+        }
+    }
+    out
+}
+
+/// Resolve a project/study accession to all its runs via the same filereport
+/// endpoint. Accepts PRJEB/PRJNA/ERP/SRP/DRP.
+///
+/// Returns an empty vec when the project has no runs with FASTQ payloads
+/// (caller should fall back to NCBI EUtils).
+pub async fn resolve_ena_project(
+    client: &reqwest::Client,
+    project: &str,
+) -> Result<Vec<EnaResolved>> {
+    let rows = fetch_rows(client, project).await?;
+    Ok(rows.into_iter().filter_map(row_to_resolved).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ftp_to_http_rewrites_scheme() {
+        assert_eq!(
+            ftp_to_http("ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"),
+            "http://ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"
+        );
+    }
+
+    #[test]
+    fn ftp_to_http_passes_http_through() {
+        assert_eq!(
+            ftp_to_http("http://example.com/x.fastq.gz"),
+            "http://example.com/x.fastq.gz"
+        );
+    }
+
+    #[test]
+    fn ftp_to_http_passes_https_through() {
+        assert_eq!(
+            ftp_to_http("https://example.com/x.fastq.gz"),
+            "https://example.com/x.fastq.gz"
+        );
+    }
+
+    #[test]
+    fn ftp_to_http_prepends_when_schemeless() {
+        // ENA's filereport often returns schemeless paths like this.
+        assert_eq!(
+            ftp_to_http("ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"),
+            "http://ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"
+        );
+    }
+
+    #[test]
+    fn slots_single_end() {
+        let ftps = vec!["ftp://host/SRR1.fastq.gz"];
+        assert_eq!(assign_slots(&ftps), vec![OutputSlot::Single]);
+    }
+
+    #[test]
+    fn slots_paired_end() {
+        let ftps = vec!["ftp://host/SRR1_1.fastq.gz", "ftp://host/SRR1_2.fastq.gz"];
+        assert_eq!(
+            assign_slots(&ftps),
+            vec![OutputSlot::Read1, OutputSlot::Read2]
+        );
+    }
+
+    #[test]
+    fn slots_paired_plus_unpaired() {
+        // Three-file case: paired mates plus orphan bare-name file.
+        let ftps = vec![
+            "ftp://host/SRR1.fastq.gz",
+            "ftp://host/SRR1_1.fastq.gz",
+            "ftp://host/SRR1_2.fastq.gz",
+        ];
+        assert_eq!(
+            assign_slots(&ftps),
+            vec![OutputSlot::Unpaired, OutputSlot::Read1, OutputSlot::Read2]
+        );
+    }
+
+    #[test]
+    fn row_to_resolved_single_end() {
+        let row = FilereportRow {
+            run_accession: "SRR000001".into(),
+            fastq_ftp: "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001.fastq.gz"
+                .into(),
+            fastq_md5: "abc123".into(),
+            fastq_bytes: "12345".into(),
+        };
+        let resolved = row_to_resolved(row).expect("should resolve");
+        assert_eq!(resolved.accession, "SRR000001");
+        assert_eq!(resolved.fastq_files.len(), 1);
+        assert_eq!(resolved.fastq_files[0].slot, OutputSlot::Single);
+        assert_eq!(resolved.fastq_files[0].md5, "abc123");
+        assert_eq!(resolved.fastq_files[0].size, 12345);
+        assert_eq!(resolved.total_size, 12345);
+        assert!(resolved.fastq_files[0].url.starts_with("http://"));
+    }
+
+    #[test]
+    fn row_to_resolved_paired() {
+        let row = FilereportRow {
+            run_accession: "SRR123".into(),
+            fastq_ftp: "ftp://host/SRR123_1.fastq.gz;ftp://host/SRR123_2.fastq.gz".into(),
+            fastq_md5: "aaa;bbb".into(),
+            fastq_bytes: "100;200".into(),
+        };
+        let r = row_to_resolved(row).expect("should resolve");
+        assert_eq!(r.fastq_files.len(), 2);
+        assert_eq!(r.fastq_files[0].slot, OutputSlot::Read1);
+        assert_eq!(r.fastq_files[1].slot, OutputSlot::Read2);
+        assert_eq!(r.total_size, 300);
+    }
+
+    #[test]
+    fn row_to_resolved_empty_ftp_is_none() {
+        let row = FilereportRow {
+            run_accession: "SRR999".into(),
+            fastq_ftp: "".into(),
+            fastq_md5: "".into(),
+            fastq_bytes: "".into(),
+        };
+        assert!(row_to_resolved(row).is_none());
+    }
+
+    #[test]
+    fn row_to_resolved_mismatched_counts_is_none() {
+        let row = FilereportRow {
+            run_accession: "SRR1".into(),
+            fastq_ftp: "ftp://a;ftp://b".into(),
+            fastq_md5: "aaa".into(), // only one MD5 for two files
+            fastq_bytes: "1;2".into(),
+        };
+        assert!(row_to_resolved(row).is_none());
+    }
+
+    #[test]
+    fn row_to_resolved_missing_size_or_md5_is_none() {
+        let row = FilereportRow {
+            run_accession: "SRR1".into(),
+            fastq_ftp: "ftp://host/SRR1.fastq.gz".into(),
+            fastq_md5: "".into(),
+            fastq_bytes: "1".into(),
+        };
+        assert!(row_to_resolved(row).is_none());
+    }
+
+    #[test]
+    fn build_url_shape() {
+        let url = build_url("SRR000001");
+        assert!(url.contains("accession=SRR000001"));
+        assert!(url.contains("result=read_run"));
+        assert!(url.contains("format=json"));
+        assert!(url.contains("run_accession"));
+        assert!(url.contains("fastq_ftp"));
+        assert!(url.contains("fastq_md5"));
+        assert!(url.contains("fastq_bytes"));
+    }
+}

--- a/crates/sracha-core/src/error.rs
+++ b/crates/sracha-core/src/error.rs
@@ -11,6 +11,9 @@ pub enum Error {
     #[error("SDL API error: {message}")]
     Sdl { message: String },
 
+    #[error("ENA API error: {message}")]
+    Ena { message: String },
+
     #[error("download failed for {accession}: {message}")]
     Download { accession: String, message: String },
 

--- a/crates/sracha-core/src/lib.rs
+++ b/crates/sracha-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod accession;
 pub mod compress;
 pub mod download;
+pub mod ena;
 pub mod error;
 pub mod fastq;
 pub mod http;

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -1473,6 +1473,91 @@ pub async fn download_sra(
     })
 }
 
+/// Download pre-computed ENA FASTQ.gz files directly — no VDB decode involved.
+///
+/// Each file listed in `ena` is fetched via [`download_file`] (parallel chunked
+/// HTTP + resume + MD5 verify) to its final output path. The caller guarantees
+/// the pipeline config is compatible (gzip + split-3/split-files + no fasta +
+/// no stdout); incompatible configs should be routed to [`download_sra`] +
+/// [`decode_sra`] instead.
+///
+/// On cancellation, any partially-written output files are left on disk so the
+/// `download_file` resume machinery can finish them on the next run.
+pub async fn download_ena_fastq(
+    ena: &crate::ena::EnaResolved,
+    config: &PipelineConfig,
+) -> Result<PipelineStats> {
+    let accession = &ena.accession;
+    tokio::fs::create_dir_all(&config.output_dir).await?;
+
+    let dl_config = DownloadConfig {
+        connections: config.connections,
+        chunk_size: 0,
+        force: config.force,
+        validate: true,
+        progress: config.progress,
+        resume: config.resume,
+        client: config.http_client.clone(),
+    };
+
+    let mut output_files: Vec<PathBuf> = Vec::with_capacity(ena.fastq_files.len());
+    let mut bytes_transferred: u64 = 0;
+
+    for file in &ena.fastq_files {
+        // Honor Ctrl-C between files; download_file itself doesn't poll
+        // `config.cancelled`, so check here and surface partial outputs.
+        if let Some(ref flag) = config.cancelled
+            && flag.load(Ordering::Relaxed)
+        {
+            return Err(Error::Cancelled {
+                output_files: output_files.clone(),
+            });
+        }
+
+        let name = output_filename(accession, file.slot, config.fasta, &config.compression);
+        let target = config.output_dir.join(&name);
+
+        tracing::info!(
+            "{accession}: downloading ENA FASTQ {} ({}) → {}",
+            file.url,
+            crate::util::format_size(file.size),
+            target.display(),
+        );
+
+        let urls = vec![file.url.clone()];
+        let dl_future = download_file(&urls, file.size, Some(&file.md5), &target, &dl_config);
+
+        let dl_result = if let Some(ref flag) = config.cancelled {
+            let flag = flag.clone();
+            tokio::select! {
+                result = dl_future => result?,
+                _ = poll_cancelled(flag) => {
+                    tracing::info!("{accession}: ENA download cancelled");
+                    return Err(Error::Cancelled { output_files });
+                }
+            }
+        } else {
+            dl_future.await?
+        };
+
+        bytes_transferred += dl_result.bytes_transferred;
+        output_files.push(dl_result.path);
+    }
+
+    Ok(PipelineStats {
+        accession: accession.clone(),
+        // Spots/reads are unknown without decoding the gzip stream. Counting
+        // would defeat the point of the fast path, so we report 0 and the CLI
+        // emits an ENA-specific summary line.
+        spots_read: 0,
+        reads_written: 0,
+        bytes_transferred,
+        total_sra_size: ena.total_size,
+        output_files,
+        integrity: Arc::new(IntegrityDiag::default()),
+    })
+}
+
 /// Poll an `AtomicBool` flag until it becomes `true`.
 async fn poll_cancelled(flag: Arc<AtomicBool>) {
     loop {

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -236,6 +236,11 @@ pub struct FetchArgs {
     /// Skip direct S3 and resolve via the SDL API
     #[arg(long, help_heading = "Advanced")]
     pub prefer_sdl: bool,
+
+    /// Fetch pre-computed FASTQ.gz from ENA instead of the SRA binary.
+    /// Falls back to the NCBI path when ENA has no FASTQ for an accession.
+    #[arg(long, help_heading = "Advanced")]
+    pub prefer_ena: bool,
 }
 
 #[derive(Args)]
@@ -441,6 +446,12 @@ pub struct GetArgs {
     /// to re-run another tool (e.g. `fasterq-dump`) on the same input.
     #[arg(long, help_heading = "Advanced")]
     pub keep_sra: bool,
+
+    /// Try ENA FASTQ mirrors first; fall back to NCBI if ENA has no FASTQ
+    /// or the output config is incompatible. Requires gzip compression and
+    /// split-3 or split-files (Phase 1 scope). Skips VDB decode entirely.
+    #[arg(long, help_heading = "Advanced")]
+    pub prefer_ena: bool,
 }
 
 #[derive(Args)]
@@ -451,6 +462,11 @@ pub struct InfoArgs {
     /// Read accessions from a file (one per line)
     #[arg(long)]
     pub accession_list: Option<PathBuf>,
+
+    /// Query ENA's filereport API and show the FASTQ file listing
+    /// (URLs, sizes, MD5s) alongside NCBI info.
+    #[arg(long)]
+    pub prefer_ena: bool,
 }
 
 #[derive(Args)]

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -79,13 +79,93 @@ async fn main() -> Result<()> {
             let raw = collect_accessions(&args.accessions, args.accession_list.as_deref())?;
             let http_client = sracha_core::http::default_client();
             let client = SdlClient::with_client(http_client.clone());
-            let (run_accessions, has_projects) = resolve_to_runs(&raw, &client).await?;
+            let (run_accessions, has_projects) = if args.prefer_ena {
+                resolve_to_runs_via_ena(&raw, &client).await?
+            } else {
+                resolve_to_runs(&raw, &client).await?
+            };
+
+            // ENA fast path for fetch: when --prefer-ena is set, download ENA
+            // FASTQ.gz files directly instead of the SRA binary. We query ENA
+            // before SDL so we can skip the SRA resolve entirely for hits.
+            let ena_results: Vec<Option<sracha_core::ena::EnaResolved>> = if args.prefer_ena {
+                let sp = progress::Spinner::start(format!(
+                    "Querying ENA filereport for {} accession(s)",
+                    style::count(run_accessions.len()),
+                ));
+                let pairs = sracha_core::ena::resolve_ena_many(&http_client, &run_accessions).await;
+                let hits = pairs.iter().filter(|(_, v)| v.is_some()).count();
+                sp.finish(format!(
+                    "ENA serves {} of {} accession(s); rest will use NCBI",
+                    style::count(hits),
+                    style::count(run_accessions.len()),
+                ));
+                pairs.into_iter().map(|(_, v)| v).collect()
+            } else {
+                vec![None; run_accessions.len()]
+            };
+
+            tokio::fs::create_dir_all(&args.output_dir).await?;
+
+            // Handle ENA hits first (pure HTTP, no SDL involvement).
+            for (i, acc) in run_accessions.iter().enumerate() {
+                let Some(ena) = &ena_results[i] else {
+                    continue;
+                };
+                let dl_config = sracha_core::download::DownloadConfig {
+                    connections: args.connections,
+                    force: args.force,
+                    validate: !args.no_validate,
+                    progress: !args.no_progress,
+                    resume: !args.no_resume,
+                    client: Some(http_client.clone()),
+                    ..Default::default()
+                };
+                for file in &ena.fastq_files {
+                    let name = ena_fetch_filename(acc, file.slot);
+                    let out = args.output_dir.join(&name);
+                    tracing::info!(
+                        "{acc}: downloading ENA FASTQ {} ({}) to {}",
+                        file.url,
+                        format_size(file.size),
+                        out.display(),
+                    );
+                    sracha_core::download::download_file(
+                        std::slice::from_ref(&file.url),
+                        file.size,
+                        Some(&file.md5),
+                        &out,
+                        &dl_config,
+                    )
+                    .await?;
+                    eprintln!(
+                        "{}: {} downloaded from [{}]",
+                        style::header(acc),
+                        style::value(format_size(file.size)),
+                        style::value("ena"),
+                    );
+                    eprintln!("  wrote {}", style::path(out.display()));
+                }
+            }
+
+            // Resolve the remaining accessions (non-ENA) via SDL as before.
+            let ncbi_accessions: Vec<String> = run_accessions
+                .iter()
+                .zip(ena_results.iter())
+                .filter(|(_, ena)| ena.is_none())
+                .map(|(acc, _)| acc.clone())
+                .collect();
+
+            if ncbi_accessions.is_empty() {
+                return Ok(());
+            }
+
             let sp = progress::Spinner::start(format!(
                 "Resolving {} accession(s)",
-                style::count(run_accessions.len()),
+                style::count(ncbi_accessions.len()),
             ));
             let resolved_all = resolve_accessions(
-                &run_accessions,
+                &ncbi_accessions,
                 &client,
                 args.prefer_sdl,
                 false,
@@ -99,7 +179,6 @@ async fn main() -> Result<()> {
             check_download_confirmation(&resolved_all, args.yes, has_projects)?;
             check_disk_space(&resolved_all, &args.output_dir)?;
 
-            tokio::fs::create_dir_all(&args.output_dir).await?;
             for resolved in &resolved_all {
                 let acc = &resolved.accession;
                 let mirror = resolved
@@ -270,7 +349,45 @@ async fn main() -> Result<()> {
             let raw = collect_accessions(&args.accessions, args.accession_list.as_deref())?;
             let http_client = sracha_core::http::default_client();
             let sdl_client = SdlClient::with_client(http_client.clone());
-            let (run_accessions, has_projects) = resolve_to_runs(&raw, &sdl_client).await?;
+
+            let compression = cli::resolve_compression(
+                args.stdout,
+                args.zstd,
+                args.zstd_level,
+                args.threads,
+                args.no_gzip,
+                args.gzip_level,
+            );
+
+            // Phase 1 ENA fast path is only valid for gzip output, split-3 or
+            // split-files, no fasta, no stdout. Anything else falls back to
+            // the NCBI pipeline even if `--prefer-ena` is set.
+            let ena_compatible = args.prefer_ena
+                && matches!(
+                    compression,
+                    sracha_core::fastq::CompressionMode::Gzip { .. }
+                )
+                && matches!(
+                    split_mode,
+                    sracha_core::fastq::SplitMode::Split3
+                        | sracha_core::fastq::SplitMode::SplitFiles
+                )
+                && !args.fasta
+                && !args.stdout;
+
+            if args.prefer_ena && !ena_compatible {
+                tracing::info!(
+                    "--prefer-ena requested but output config is incompatible \
+                     (needs gzip + split-3/split-files + no-fasta + no-stdout); \
+                     falling back to NCBI pipeline"
+                );
+            }
+
+            let (run_accessions, has_projects) = if ena_compatible {
+                resolve_to_runs_via_ena(&raw, &sdl_client).await?
+            } else {
+                resolve_to_runs(&raw, &sdl_client).await?
+            };
             let sp = progress::Spinner::start(format!(
                 "Resolving {} accession(s)",
                 style::count(run_accessions.len()),
@@ -290,36 +407,53 @@ async fn main() -> Result<()> {
             check_download_confirmation(&resolved_all, args.yes, has_projects)?;
             check_disk_space(&resolved_all, &args.output_dir)?;
 
-            // Check platform — reject legacy platforms with complex read structures.
-            for resolved in &resolved_all {
-                if let Some(ref ri) = resolved.run_info
-                    && let Some(ref platform) = ri.platform
-                    && sracha_core::pipeline::is_unsupported_platform(platform)
-                {
-                    anyhow::bail!(
-                        "{}: unsupported platform '{}' — sracha does not support legacy sequencing platforms",
-                        resolved.accession,
-                        platform
-                    );
-                }
-            }
-
             let format_label = if args.fasta { "FASTA" } else { "FASTQ" };
             tracing::info!(
                 "get {} run accession(s) -> {format_label}",
                 resolved_all.len()
             );
 
-            let compression = cli::resolve_compression(
-                args.stdout,
-                args.zstd,
-                args.zstd_level,
-                args.threads,
-                args.no_gzip,
-                args.gzip_level,
-            );
-
             let progress = !args.no_progress && !args.stdout;
+
+            // If ENA is in play, resolve filereport metadata for every run up
+            // front. Accessions ENA can't serve (empty/None) silently fall back
+            // to the NCBI pipeline per-accession below.
+            let ena_results: Vec<Option<sracha_core::ena::EnaResolved>> = if ena_compatible {
+                let sp = progress::Spinner::start(format!(
+                    "Querying ENA filereport for {} accession(s)",
+                    style::count(resolved_all.len()),
+                ));
+                let accs: Vec<String> = resolved_all.iter().map(|r| r.accession.clone()).collect();
+                let pairs = sracha_core::ena::resolve_ena_many(&http_client, &accs).await;
+                let ena_hits = pairs.iter().filter(|(_, v)| v.is_some()).count();
+                sp.finish(format!(
+                    "ENA serves {} of {} accession(s); rest will use NCBI",
+                    style::count(ena_hits),
+                    style::count(resolved_all.len()),
+                ));
+                pairs.into_iter().map(|(_, v)| v).collect()
+            } else {
+                vec![None; resolved_all.len()]
+            };
+
+            // Check platform — reject legacy platforms with complex read structures.
+            // Only applies to accessions that will go through VDB decode; ENA
+            // serves pre-decoded FASTQ so the platform is irrelevant there.
+            for (resolved, ena) in resolved_all.iter().zip(ena_results.iter()) {
+                if ena.is_some() {
+                    continue;
+                }
+                if let Some(ref ri) = resolved.run_info
+                    && let Some(ref platform) = ri.platform
+                    && sracha_core::pipeline::is_unsupported_platform(platform)
+                {
+                    anyhow::bail!(
+                        "{}: unsupported platform '{}' — sracha does not support legacy sequencing platforms (use --prefer-ena to bypass VDB decode)",
+                        resolved.accession,
+                        platform
+                    );
+                }
+            }
 
             // -- Ctrl-C signal handling --
             use std::sync::Arc;
@@ -381,7 +515,9 @@ async fn main() -> Result<()> {
                 }
             };
 
-            // Spawn a download task for resolved_all[idx].
+            // Spawn a download task for resolved_all[idx]. Only used for the
+            // NCBI path; ENA accessions are handled inline (no decode to
+            // overlap with, so prefetching buys nothing).
             let spawn_download = |idx: usize| {
                 let resolved = resolved_all[idx].clone();
                 let config = make_config(&resolved);
@@ -390,12 +526,33 @@ async fn main() -> Result<()> {
                 })
             };
 
-            // Seed the queue with the first `prefetch_depth` downloads so
-            // iteration 0 already has accession 0 in flight (instead of
-            // paying its full download latency serially).
-            for j in 0..prefetch_depth.min(resolved_all.len()) {
-                pending_downloads.push_back(spawn_download(j));
+            // Seed the prefetch queue with the first `prefetch_depth` indices
+            // that will go through the NCBI path. Skip ENA indices — they
+            // don't need prefetching.
+            let mut seeded = 0usize;
+            for (j, ena) in ena_results.iter().enumerate() {
+                if seeded >= prefetch_depth {
+                    break;
+                }
+                if ena.is_none() {
+                    pending_downloads.push_back(spawn_download(j));
+                    seeded += 1;
+                }
             }
+
+            // Cursor for topping up the prefetch queue: the next index past
+            // the already-seeded set that still needs an NCBI download.
+            let mut next_prefetch_idx = {
+                let mut n = 0usize;
+                let mut count = 0usize;
+                while count < prefetch_depth && n < resolved_all.len() {
+                    if ena_results[n].is_none() {
+                        count += 1;
+                    }
+                    n += 1;
+                }
+                n
+            };
 
             for (i, resolved) in resolved_all.iter().enumerate() {
                 if cancelled.load(Ordering::Relaxed) {
@@ -404,6 +561,51 @@ async fn main() -> Result<()> {
 
                 let pipeline_config = make_config(resolved);
 
+                // ---- ENA fast path ------------------------------------------------
+                if let Some(ena) = &ena_results[i] {
+                    let ena_future =
+                        sracha_core::pipeline::download_ena_fastq(ena, &pipeline_config);
+                    let stats = match ena_future.await {
+                        Ok(s) => s,
+                        Err(sracha_core::error::Error::Cancelled { .. }) => {
+                            interrupted_accession = Some(resolved.accession.clone());
+                            break;
+                        }
+                        Err(e) => return Err(e.into()),
+                    };
+                    let source = "ena";
+                    if stats.bytes_transferred == 0 {
+                        eprintln!(
+                            "{}: {} of {} cached (no download needed) from [{}]",
+                            style::header(&stats.accession),
+                            style::value(format_size(stats.total_sra_size)),
+                            style::value(format_size(stats.total_sra_size)),
+                            style::value(source),
+                        );
+                    } else if stats.bytes_transferred < stats.total_sra_size {
+                        eprintln!(
+                            "{}: {} of {} transferred from [{}] (resumed)",
+                            style::header(&stats.accession),
+                            style::value(format_size(stats.bytes_transferred)),
+                            style::value(format_size(stats.total_sra_size)),
+                            style::value(source),
+                        );
+                    } else {
+                        eprintln!(
+                            "{}: {} downloaded from [{}]",
+                            style::header(&stats.accession),
+                            style::value(format_size(stats.total_sra_size)),
+                            style::value(source),
+                        );
+                    }
+                    for path in &stats.output_files {
+                        eprintln!("  wrote {}", style::path(path.display()));
+                    }
+                    completed_accessions.push(resolved.accession.clone());
+                    continue;
+                }
+
+                // ---- NCBI path ----------------------------------------------------
                 let handle = pending_downloads
                     .pop_front()
                     .expect("queue is pre-seeded and topped up per iteration");
@@ -423,11 +625,18 @@ async fn main() -> Result<()> {
                     }
                 };
 
-                // Top up the queue: keep `prefetch_depth` downloads in flight.
-                let next_idx = i + prefetch_depth;
-                if next_idx < resolved_all.len() && !cancelled.load(Ordering::Relaxed) {
-                    pending_downloads.push_back(spawn_download(next_idx));
+                // Top up the queue: find the next NCBI-bound index and spawn it.
+                while next_prefetch_idx < resolved_all.len()
+                    && ena_results[next_prefetch_idx].is_some()
+                {
+                    next_prefetch_idx += 1;
                 }
+                if next_prefetch_idx < resolved_all.len() && !cancelled.load(Ordering::Relaxed) {
+                    pending_downloads.push_back(spawn_download(next_prefetch_idx));
+                    next_prefetch_idx += 1;
+                }
+                // Skip trailing ENA indices after the one we just spawned.
+                let _ = i;
 
                 // Decode (CPU-bound) while the next download runs in the background.
                 let source = resolved
@@ -537,8 +746,13 @@ async fn main() -> Result<()> {
                 return Ok(());
             }
 
-            let client = SdlClient::with_client(sracha_core::http::default_client());
-            let (run_accessions, _has_projects) = resolve_to_runs(&accessions, &client).await?;
+            let http_client = sracha_core::http::default_client();
+            let client = SdlClient::with_client(http_client.clone());
+            let (run_accessions, _has_projects) = if args.prefer_ena {
+                resolve_to_runs_via_ena(&accessions, &client).await?
+            } else {
+                resolve_to_runs(&accessions, &client).await?
+            };
 
             let sp = progress::Spinner::start(format!(
                 "Resolving {} accession(s)",
@@ -580,6 +794,14 @@ async fn main() -> Result<()> {
                 print_info_table(&entries);
             } else if let Some(InfoEntry::Ok(r)) = entries.first() {
                 print_resolved(r);
+            }
+
+            if args.prefer_ena {
+                let accs: Vec<String> = resolved.iter().map(|r| r.accession.clone()).collect();
+                let ena = sracha_core::ena::resolve_ena_many(&http_client, &accs).await;
+                for (acc, r) in &ena {
+                    print_ena_section(acc, r.as_ref());
+                }
             }
             Ok(())
         }
@@ -780,6 +1002,39 @@ fn collect_accessions(positional: &[String], list_file: Option<&Path>) -> Result
 /// Study (SRP/ERP/DRP) and BioProject (PRJNA/PRJEB/PRJDB) accessions are
 /// resolved to their constituent runs via the NCBI EUtils API.
 async fn resolve_to_runs(inputs: &[String], client: &SdlClient) -> Result<(Vec<String>, bool)> {
+    resolve_to_runs_inner(inputs, client, false).await
+}
+
+/// Output filename for `fetch --prefer-ena`. ENA always serves gzip'd FASTQ,
+/// so the extension is fixed; the slot determines the suffix.
+fn ena_fetch_filename(accession: &str, slot: sracha_core::fastq::OutputSlot) -> String {
+    use sracha_core::fastq::OutputSlot;
+    match slot {
+        OutputSlot::Single | OutputSlot::Unpaired => format!("{accession}.fastq.gz"),
+        OutputSlot::Read1 => format!("{accession}_1.fastq.gz"),
+        OutputSlot::Read2 => format!("{accession}_2.fastq.gz"),
+        OutputSlot::ReadN(n) => format!("{accession}_{}.fastq.gz", n + 1),
+    }
+}
+
+/// Like [`resolve_to_runs`] but routes project resolution through ENA's
+/// filereport API when possible. Falls back to NCBI EUtils if ENA returns
+/// no runs for a project (rare — almost all INSDC projects are mirrored).
+///
+/// Reuses the HTTP client from the provided [`SdlClient`] so connection
+/// pools are shared between SDL and ENA calls.
+async fn resolve_to_runs_via_ena(
+    inputs: &[String],
+    client: &SdlClient,
+) -> Result<(Vec<String>, bool)> {
+    resolve_to_runs_inner(inputs, client, true).await
+}
+
+async fn resolve_to_runs_inner(
+    inputs: &[String],
+    client: &SdlClient,
+    via_ena: bool,
+) -> Result<(Vec<String>, bool)> {
     let mut run_accessions = Vec::new();
     let mut has_projects = false;
 
@@ -795,7 +1050,34 @@ async fn resolve_to_runs(inputs: &[String], client: &SdlClient) -> Result<(Vec<S
                     "{}: resolving project to run accessions",
                     style::header(&proj),
                 ));
-                let runs = client.resolve_project(&proj).await?;
+
+                let runs = if via_ena {
+                    match sracha_core::ena::resolve_ena_project(
+                        client.http_client(),
+                        &proj.to_string(),
+                    )
+                    .await
+                    {
+                        Ok(resolved) if !resolved.is_empty() => {
+                            resolved.into_iter().map(|r| r.accession).collect()
+                        }
+                        Ok(_) => {
+                            tracing::info!(
+                                "{proj}: ENA returned no runs, falling back to NCBI EUtils",
+                            );
+                            client.resolve_project(&proj).await?
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "{proj}: ENA project resolve failed ({e}), falling back to NCBI EUtils",
+                            );
+                            client.resolve_project(&proj).await?
+                        }
+                    }
+                } else {
+                    client.resolve_project(&proj).await?
+                };
+
                 sp.finish(format!(
                     "{}: found {} run(s)",
                     style::header(&proj),
@@ -1049,6 +1331,46 @@ fn print_resolved(resolved: &ResolvedAccession) {
             style::label("Mirrors:"),
             style::count(alts.len()),
             alts.join(", "),
+        );
+    }
+}
+
+/// Print the ENA FASTQ section for a single accession — shown under
+/// `sracha info --prefer-ena`. Renders URL, size, and MD5 per file, or
+/// a single "no ENA FASTQ available" line when `resolved` is None.
+fn print_ena_section(accession: &str, resolved: Option<&sracha_core::ena::EnaResolved>) {
+    println!();
+    println!("{} — ENA FASTQ", style::header(accession));
+    let Some(r) = resolved else {
+        println!("  {} no ENA FASTQ available", style::label("status:"));
+        return;
+    };
+    println!(
+        "  {}    {} across {} file(s)",
+        style::label("Total:"),
+        style::value(format_size(r.total_size)),
+        style::count(r.fastq_files.len()),
+    );
+    for f in &r.fastq_files {
+        let slot_tag = match f.slot {
+            sracha_core::fastq::OutputSlot::Single => "single",
+            sracha_core::fastq::OutputSlot::Read1 => "read1",
+            sracha_core::fastq::OutputSlot::Read2 => "read2",
+            sracha_core::fastq::OutputSlot::Unpaired => "unpaired",
+            sracha_core::fastq::OutputSlot::ReadN(_) => "readN",
+        };
+        println!(
+            "  {} [{}] {}",
+            style::label("File:"),
+            style::value(slot_tag),
+            style::path(&f.url),
+        );
+        println!(
+            "    {}  {}   {}  {}",
+            style::label("size:"),
+            style::value(format_size(f.size)),
+            style::label("md5:"),
+            style::value(&f.md5),
         );
     }
 }


### PR DESCRIPTION
Closes #6.

## Summary

- Adds `--prefer-ena` to `get`, `fetch`, and `info` — downloads pre-computed FASTQ.gz from ENA instead of SRA binary + VDB decode
- Skips the CPU-heavy decode + compression stages and the temporary `.sra` file on disk
- Fallback to NCBI path is automatic (for unsupported configs, missing ENA coverage, or failures)

## Phase 1 scope

- Compatible configs: gzip output + `split-3` / `split-files` + non-FASTA + non-stdout
- Incompatible configs (zstd/none, fasta, stdout, split-spot, interleaved) log a notice and fall back to NCBI
- Project→run resolution via ENA filereport when `--prefer-ena` is set; same endpoint works for both runs and projects
- `info --prefer-ena` shows an ENA FASTQ section (URLs, MD5, sizes)
- Platform check (LS454 etc.) bypassed on the ENA path since it doesn't touch VDB; NCBI-path error now suggests `--prefer-ena` as an escape hatch

Phase 2/3 (zstd decompress+recompress, fasta streaming, split-spot/interleaved merge, Aspera) tracked for follow-up issues.

## Files

- **new** `crates/sracha-core/src/ena.rs` — filereport client (`resolve_ena`, `resolve_ena_many`, `resolve_ena_project`) + 13 unit tests
- `pipeline/mod.rs` — `download_ena_fastq()` reuses `download_file` per-file (parallel chunked HTTP + resume + MD5 verify)
- `main.rs` — ENA dispatch in Get/Fetch/Info; prefetch queue skips ENA indices (no decode to overlap with)
- `cli.rs`, `error.rs`, `lib.rs` — CLI flag, `Error::Ena`, module export

## Test plan

- [x] 13 new unit tests in `ena.rs` (URL normalization, slot assignment, row parsing)
- [x] `cargo test` — 517 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Live smoke: `sracha info SRR000001 --prefer-ena` renders ENA section with correct URLs
- [x] Live smoke: `sracha get SRR000001 --prefer-ena` downloads 3 files (101 MiB), labels source `[ena]`, produces valid gzip FASTQ (234,982 records)
- [x] Live smoke: incompatible `--zstd` config falls back to NCBI path
- [ ] Integration tests against real ENA/NCBI APIs (gated behind `#[ignore]`; can be run with `cargo test -p sracha-core -- --ignored`)

## Caveats (documented in help text)

- ENA-generated FASTQ can differ subtly from VDB-decoded output (read names, quality encoding)
- `spots_read` / `reads_written` stats are 0 on the ENA path — counting would require a full decompression pass and defeat the point