### PR TITLE
feat: streaming decode — overlap FASTQ decode with SRA download

### DIFF
--- a/crates/sracha-core/benches/decode.rs
+++ b/crates/sracha-core/benches/decode.rs
@@ -53,6 +53,7 @@ fn config(out: &std::path::Path, threads: usize, compression: CompressionMode) -
         strict: false,
         http_client: None,
         keep_sra: false,
+        progress_parent: None,
     }
 }
 

--- a/crates/sracha-core/benches/decode.rs
+++ b/crates/sracha-core/benches/decode.rs
@@ -54,6 +54,7 @@ fn config(out: &std::path::Path, threads: usize, compression: CompressionMode) -
         http_client: None,
         keep_sra: false,
         progress_parent: None,
+        progress_combined: None,
     }
 }
 

--- a/crates/sracha-core/src/download/chunk_ready.rs
+++ b/crates/sracha-core/src/download/chunk_ready.rs
@@ -21,11 +21,25 @@
 //! `tokio::sync::Notify`, this guarantees a waiter that wakes up will see
 //! the bit it was waiting on (and any earlier writes from the producer).
 
+use std::collections::VecDeque;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::Notify;
 
-/// Lock-free chunk presence map + async wake.
+/// Lock-free chunk presence map + async wake + dispatch queue.
+///
+/// Two responsibilities bundled because they share the same
+/// chunk-index space and lifetime:
+/// 1. **Readiness tracking** (`mark_done` / `wait_range`) — the original
+///    Phase 1-2 role. Decoders block until chunks they need are on disk.
+/// 2. **Dispatch ordering** (`pop_pending` / `prioritize_pending`) —
+///    Phase 3g-2 role. Workers in `download_file_inner` pull the next
+///    chunk to fetch from a shared queue; a streaming consumer can
+///    inject priority chunk indices (e.g. those containing idx files)
+///    so they're fetched ahead of normal numerical-order chunks. The
+///    decoder can then open the cursor and start per-batch decode
+///    while bulk data is still streaming.
 pub struct ChunkReadyTracker {
     /// One slot per chunk index. `true` means the chunk's bytes are
     /// fully written to disk and safe to read.
@@ -41,6 +55,21 @@ pub struct ChunkReadyTracker {
     chunk_size: u64,
     /// Total file size in bytes.
     file_size: u64,
+    /// Chunk indices not yet handed to a worker for download. Workers
+    /// pop_front to claim the next chunk; `prioritize_pending` moves
+    /// matching indices to the front. `None` until the downloader
+    /// initializes the queue (e.g., for the resume-already-complete
+    /// path that doesn't dispatch any new chunks).
+    pending: Mutex<Option<VecDeque<usize>>>,
+    /// Wakes workers when new items are added to `pending` OR when
+    /// the queue is closed. Distinct from `notify` (which is for
+    /// readiness waiters) so that priority injection doesn't spuriously
+    /// re-wake decoders blocked on `wait_range`.
+    pending_notify: Notify,
+    /// Set by `close_pending` when no more chunks will be added.
+    /// Workers exit their loop once they observe pending empty AND
+    /// pending_closed = true.
+    pending_closed: AtomicBool,
 }
 
 impl ChunkReadyTracker {
@@ -65,7 +94,106 @@ impl ChunkReadyTracker {
             notify: Notify::new(),
             chunk_size,
             file_size,
+            pending: Mutex::new(None),
+            pending_notify: Notify::new(),
+            pending_closed: AtomicBool::new(false),
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 3g-2: dispatch queue.
+    //
+    // The downloader puts chunk indices to fetch in `pending`. Workers
+    // pull the next index via `pop_pending` (sync; blocks via the async
+    // `wait_for_pending` if the queue is empty but not closed). A
+    // streaming consumer (decoder) calls `prioritize_pending(&[idx])`
+    // to move specific indices to the front of the queue so they're
+    // fetched ahead of normal numerical order.
+    // -----------------------------------------------------------------
+
+    /// Initialize the pending dispatch queue with chunk indices to
+    /// download in the given order. Typically called by the downloader
+    /// once after chunk planning, with indices in numerical order.
+    pub fn init_pending(&self, indices: impl IntoIterator<Item = usize>) {
+        let mut p = self.pending.lock().unwrap();
+        *p = Some(indices.into_iter().collect());
+        // Wake any workers that started before init; they'll see items now.
+        self.pending_notify.notify_waiters();
+    }
+
+    /// Mark the pending queue as closed: no more chunks will be added.
+    /// Workers that observe an empty queue + closed will exit. Called
+    /// by the downloader after `init_pending`.
+    pub fn close_pending(&self) {
+        self.pending_closed.store(true, Ordering::Release);
+        self.pending_notify.notify_waiters();
+    }
+
+    /// Non-blocking: pop the next chunk index to download. Returns
+    /// `None` if the queue is empty (caller should `wait_for_pending`
+    /// then retry, or exit if the queue is also closed).
+    pub fn pop_pending(&self) -> Option<usize> {
+        self.pending
+            .lock()
+            .unwrap()
+            .as_mut()
+            .and_then(|q| q.pop_front())
+    }
+
+    /// Has the pending queue been closed (no more chunks to come)?
+    pub fn pending_closed(&self) -> bool {
+        self.pending_closed.load(Ordering::Acquire)
+    }
+
+    /// Async: wait until a `prioritize_pending` / `init_pending` /
+    /// `close_pending` call has happened. Used by workers when they
+    /// see an empty queue but `pending_closed` is still false.
+    pub async fn wait_for_pending(&self) {
+        let notified = self.pending_notify.notified();
+        // Re-check after registering interest to avoid a missed wake.
+        if !self
+            .pending
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|q| q.is_empty())
+            || self.pending_closed()
+        {
+            return;
+        }
+        notified.await;
+    }
+
+    /// Re-order the pending queue: any of `indices` currently in the
+    /// queue are moved to the front, preserving the order in `indices`.
+    /// Indices not currently pending (already dispatched, or never
+    /// queued) are silently ignored. Workers currently mid-download
+    /// of a non-priority chunk will pick up priority chunks NEXT (no
+    /// preemption).
+    pub fn prioritize_pending(&self, indices: &[usize]) {
+        let mut p = self.pending.lock().unwrap();
+        let Some(q) = p.as_mut() else { return };
+        let mut prio: Vec<usize> = Vec::with_capacity(indices.len());
+        // Build a HashSet for O(1) contains check inside the retain
+        // loop — `indices` can be large for files with many idx files.
+        let want: std::collections::HashSet<usize> = indices.iter().copied().collect();
+        let mut i = 0;
+        while i < q.len() {
+            if want.contains(&q[i]) {
+                prio.push(q.remove(i).unwrap());
+            } else {
+                i += 1;
+            }
+        }
+        // Reorder `prio` to match the input order so callers can
+        // express preference among priority items themselves.
+        prio.sort_by_key(|idx| indices.iter().position(|i| i == idx).unwrap_or(usize::MAX));
+        for idx in prio.into_iter().rev() {
+            q.push_front(idx);
+        }
+        // Don't notify_waiters — re-ordering doesn't add items, and
+        // workers blocked on wait_for_pending are already going to
+        // re-check the queue when something changes.
     }
 
     /// Number of chunks this tracker covers.
@@ -76,6 +204,18 @@ impl ChunkReadyTracker {
     /// Total file size this tracker covers.
     pub fn file_size(&self) -> u64 {
         self.file_size
+    }
+
+    /// Bytes per chunk (last chunk may be shorter).
+    pub fn chunk_size(&self) -> u64 {
+        self.chunk_size
+    }
+
+    /// Translate a byte offset to the chunk index that contains it.
+    /// Saturates at `total_chunks() - 1` for offsets past file_size.
+    pub fn chunk_index_for_byte(&self, byte: u64) -> usize {
+        let idx = (byte / self.chunk_size) as usize;
+        idx.min(self.ready.len().saturating_sub(1))
     }
 
     /// Mark a chunk as fully downloaded. Idempotent — double-marking is

--- a/crates/sracha-core/src/download/chunk_ready.rs
+++ b/crates/sracha-core/src/download/chunk_ready.rs
@@ -1,0 +1,351 @@
+//! Per-chunk completion tracking for streaming decode.
+//!
+//! `ChunkReadyTracker` is a lock-free presence map shared between the
+//! parallel chunked downloader and a streaming consumer (the decoder).
+//! As chunks complete, the downloader calls [`ChunkReadyTracker::mark_done`];
+//! the decoder polls or awaits readiness via [`ChunkReadyTracker::is_range_ready`]
+//! / [`ChunkReadyTracker::await_range`].
+//!
+//! ## Streaming-decode safety
+//!
+//! When download writes parallel chunks to a file via `pwrite`, unwritten
+//! pages remain sparse — and reading them through a mmap returns **zeros**,
+//! not an error. A streaming decoder that reads bytes before the covering
+//! chunk is marked ready will silently produce wrong output. Every read
+//! the decoder issues against the not-yet-complete file MUST be preceded
+//! by `is_range_ready` (debug-asserted) or gated by `await_range`.
+//!
+//! ## Memory ordering
+//!
+//! `mark_done` uses `Release`, the readers use `Acquire`. Combined with
+//! `tokio::sync::Notify`, this guarantees a waiter that wakes up will see
+//! the bit it was waiting on (and any earlier writes from the producer).
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tokio::sync::Notify;
+
+/// Lock-free chunk presence map + async wake.
+pub struct ChunkReadyTracker {
+    /// One slot per chunk index. `true` means the chunk's bytes are
+    /// fully written to disk and safe to read.
+    ready: Vec<AtomicBool>,
+    /// Wakes any awaiter whenever a new chunk is marked done. Awaiters
+    /// must re-check their condition after notification (spurious wakes
+    /// are normal — `mark_done(idx)` notifies *all* waiters, not just
+    /// those interested in `idx`).
+    notify: Notify,
+    /// Bytes per chunk. Last chunk may be shorter; only `chunk_size`
+    /// matters for byte→index translation since chunks are uniform
+    /// except possibly the tail.
+    chunk_size: u64,
+    /// Total file size in bytes.
+    file_size: u64,
+}
+
+impl ChunkReadyTracker {
+    /// Create a tracker for a download with `total_chunks` chunks of
+    /// `chunk_size` bytes each (last chunk may be shorter to fit
+    /// `file_size`). All chunks start as not-ready.
+    pub fn new(total_chunks: usize, chunk_size: u64, file_size: u64) -> Self {
+        assert!(chunk_size > 0, "chunk_size must be > 0");
+        assert!(
+            (total_chunks as u64).saturating_mul(chunk_size) >= file_size,
+            "total_chunks * chunk_size ({} * {}) must cover file_size ({})",
+            total_chunks,
+            chunk_size,
+            file_size,
+        );
+        let mut ready = Vec::with_capacity(total_chunks);
+        for _ in 0..total_chunks {
+            ready.push(AtomicBool::new(false));
+        }
+        Self {
+            ready,
+            notify: Notify::new(),
+            chunk_size,
+            file_size,
+        }
+    }
+
+    /// Number of chunks this tracker covers.
+    pub fn total_chunks(&self) -> usize {
+        self.ready.len()
+    }
+
+    /// Total file size this tracker covers.
+    pub fn file_size(&self) -> u64 {
+        self.file_size
+    }
+
+    /// Mark a chunk as fully downloaded. Idempotent — double-marking is
+    /// harmless. Panics if `chunk_idx >= total_chunks`.
+    pub fn mark_done(&self, chunk_idx: usize) {
+        self.ready[chunk_idx].store(true, Ordering::Release);
+        // notify_waiters wakes ALL current waiters; each re-checks its
+        // condition. This is correct (avoids missed wakeups when waiters
+        // are interested in different chunks) at the cost of some spurious
+        // re-checks. Cheap with our small waiter count.
+        self.notify.notify_waiters();
+    }
+
+    /// Pre-mark all chunks as done (e.g., when resuming and the entire
+    /// file is already on disk). Equivalent to `mark_done(i)` for every
+    /// `i`, plus a single notification.
+    pub fn mark_all_done(&self) {
+        for slot in &self.ready {
+            slot.store(true, Ordering::Release);
+        }
+        self.notify.notify_waiters();
+    }
+
+    /// Non-blocking: is this chunk's bytes ready to read?
+    pub fn is_chunk_ready(&self, chunk_idx: usize) -> bool {
+        self.ready[chunk_idx].load(Ordering::Acquire)
+    }
+
+    /// Non-blocking: are all chunks covering the byte range
+    /// `[byte_start, byte_end)` ready? `byte_end` is exclusive.
+    /// Returns `true` for an empty range.
+    pub fn is_range_ready(&self, byte_start: u64, byte_end: u64) -> bool {
+        if byte_end <= byte_start {
+            return true;
+        }
+        for idx in self.byte_range_to_chunk_indices(byte_start, byte_end) {
+            if !self.is_chunk_ready(idx) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Async: wait until `chunk_idx` is marked ready. Returns
+    /// immediately if already ready.
+    pub async fn await_chunk(&self, chunk_idx: usize) {
+        loop {
+            // Register interest BEFORE checking the bit. If we checked
+            // first and the producer set the bit + notified between the
+            // check and the await, we'd miss the wakeup.
+            let notified = self.notify.notified();
+            if self.is_chunk_ready(chunk_idx) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    /// Async: wait until every chunk covering `[byte_start, byte_end)`
+    /// is ready. Returns immediately for an empty range.
+    pub async fn await_range(&self, byte_start: u64, byte_end: u64) {
+        if byte_end <= byte_start {
+            return;
+        }
+        loop {
+            let notified = self.notify.notified();
+            if self.is_range_ready(byte_start, byte_end) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    /// Async: wait until *every* chunk is ready (download fully
+    /// complete). Useful as a fallback for code paths that haven't been
+    /// converted to streaming yet.
+    pub async fn await_all(&self) {
+        self.await_range(0, self.file_size).await;
+    }
+
+    /// Sync wrapper around [`Self::await_range`] for callers that
+    /// already hold a Tokio runtime handle but execute in a synchronous
+    /// stack frame (e.g. inside `tokio::task::block_in_place`). Returns
+    /// immediately on the fast path (range already ready); blocks the
+    /// current thread otherwise.
+    ///
+    /// **Must** be called from within a Tokio runtime context. Panics
+    /// from `Handle::current()` otherwise — surface that as a clearer
+    /// error at the call site if you can't guarantee the context.
+    pub fn wait_range(&self, byte_start: u64, byte_end: u64) {
+        if self.is_range_ready(byte_start, byte_end) {
+            return;
+        }
+        tokio::runtime::Handle::current().block_on(self.await_range(byte_start, byte_end));
+    }
+
+    /// Sync convenience: block until every chunk is ready.
+    pub fn wait_all(&self) {
+        self.wait_range(0, self.file_size);
+    }
+
+    /// Translate a byte range to the inclusive sequence of chunk
+    /// indices covering it. `byte_end` is exclusive; an empty input
+    /// yields an empty range.
+    fn byte_range_to_chunk_indices(
+        &self,
+        byte_start: u64,
+        byte_end: u64,
+    ) -> std::ops::Range<usize> {
+        if byte_end <= byte_start {
+            return 0..0;
+        }
+        let first = (byte_start / self.chunk_size) as usize;
+        // byte_end is exclusive, so the last covered chunk is
+        // ((byte_end - 1) / chunk_size).
+        let last = ((byte_end - 1) / self.chunk_size) as usize;
+        let cap = self.ready.len();
+        // Clamp in case the caller asks for bytes past file_size.
+        let first = first.min(cap);
+        let last_exclusive = (last + 1).min(cap);
+        first..last_exclusive
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn t(chunks: usize, chunk_size: u64) -> ChunkReadyTracker {
+        ChunkReadyTracker::new(chunks, chunk_size, chunks as u64 * chunk_size)
+    }
+
+    #[test]
+    fn new_starts_with_no_chunks_ready() {
+        let t = t(4, 1024);
+        assert_eq!(t.total_chunks(), 4);
+        for i in 0..4 {
+            assert!(!t.is_chunk_ready(i));
+        }
+    }
+
+    #[test]
+    fn mark_done_makes_chunk_ready() {
+        let t = t(4, 1024);
+        t.mark_done(2);
+        assert!(t.is_chunk_ready(2));
+        for i in [0, 1, 3] {
+            assert!(!t.is_chunk_ready(i));
+        }
+    }
+
+    #[test]
+    fn mark_done_is_idempotent() {
+        let t = t(2, 1024);
+        t.mark_done(0);
+        t.mark_done(0);
+        assert!(t.is_chunk_ready(0));
+    }
+
+    #[test]
+    fn mark_all_done_marks_all() {
+        let t = t(8, 1024);
+        t.mark_all_done();
+        for i in 0..8 {
+            assert!(t.is_chunk_ready(i));
+        }
+    }
+
+    #[test]
+    fn empty_range_is_always_ready() {
+        let t = t(4, 1024);
+        assert!(t.is_range_ready(100, 100));
+        assert!(t.is_range_ready(500, 200));
+    }
+
+    #[test]
+    fn range_ready_requires_all_covering_chunks() {
+        let t = t(4, 100);
+        // Range [50, 250) covers chunks 0, 1, 2.
+        assert!(!t.is_range_ready(50, 250));
+        t.mark_done(0);
+        assert!(!t.is_range_ready(50, 250));
+        t.mark_done(1);
+        assert!(!t.is_range_ready(50, 250));
+        t.mark_done(2);
+        assert!(t.is_range_ready(50, 250));
+        // Chunk 3 (bytes 300..400) wasn't required and is still not ready.
+        assert!(!t.is_chunk_ready(3));
+    }
+
+    #[test]
+    fn byte_range_translation_handles_chunk_boundaries() {
+        let t = t(4, 100);
+        // Exact boundary [0, 100): just chunk 0.
+        assert_eq!(t.byte_range_to_chunk_indices(0, 100), 0..1);
+        // [100, 200): just chunk 1.
+        assert_eq!(t.byte_range_to_chunk_indices(100, 200), 1..2);
+        // [99, 101): chunks 0 and 1.
+        assert_eq!(t.byte_range_to_chunk_indices(99, 101), 0..2);
+        // [0, 400): all four chunks.
+        assert_eq!(t.byte_range_to_chunk_indices(0, 400), 0..4);
+        // [350, 1000): clamps to chunk 3 only (file is 400 bytes).
+        assert_eq!(t.byte_range_to_chunk_indices(350, 1000), 3..4);
+    }
+
+    #[tokio::test]
+    async fn await_chunk_returns_immediately_when_ready() {
+        let t = t(4, 1024);
+        t.mark_done(1);
+        // Should not block.
+        tokio::time::timeout(std::time::Duration::from_millis(50), t.await_chunk(1))
+            .await
+            .expect("await_chunk on already-ready chunk should not block");
+    }
+
+    #[tokio::test]
+    async fn await_chunk_wakes_on_mark_done() {
+        let t = Arc::new(t(4, 1024));
+        let t_clone = t.clone();
+        let waiter = tokio::spawn(async move { t_clone.await_chunk(2).await });
+        // Give the waiter time to register on Notify.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        t.mark_done(2);
+        tokio::time::timeout(std::time::Duration::from_millis(100), waiter)
+            .await
+            .expect("waiter should wake within 100ms")
+            .expect("task should not panic");
+    }
+
+    #[tokio::test]
+    async fn await_range_wakes_when_last_chunk_arrives() {
+        let t = Arc::new(t(4, 100));
+        // Range [50, 250) needs chunks 0, 1, 2.
+        let t_clone = t.clone();
+        let waiter = tokio::spawn(async move { t_clone.await_range(50, 250).await });
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        t.mark_done(2);
+        // Still missing 0 and 1 — waiter must NOT be done yet.
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(20),
+                &mut Box::pin(async {})
+            )
+            .await
+            .is_ok()
+        );
+        t.mark_done(0);
+        t.mark_done(1);
+        tokio::time::timeout(std::time::Duration::from_millis(100), waiter)
+            .await
+            .expect("waiter should wake within 100ms after final chunk")
+            .expect("task should not panic");
+    }
+
+    #[tokio::test]
+    async fn multiple_waiters_all_wake() {
+        let t = Arc::new(t(4, 1024));
+        let mut handles = Vec::new();
+        for idx in 0..4 {
+            let tc = t.clone();
+            handles.push(tokio::spawn(async move { tc.await_chunk(idx).await }));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        t.mark_all_done();
+        for h in handles {
+            tokio::time::timeout(std::time::Duration::from_millis(100), h)
+                .await
+                .expect("all waiters should wake")
+                .expect("no task panics");
+        }
+    }
+}

--- a/crates/sracha-core/src/download/chunk_ready.rs
+++ b/crates/sracha-core/src/download/chunk_ready.rs
@@ -312,6 +312,15 @@ impl ChunkReadyTracker {
         tokio::runtime::Handle::current().block_on(self.await_range(byte_start, byte_end));
     }
 
+    /// Sync wrapper around [`Self::await_chunk`]. Same context
+    /// requirements as [`Self::wait_range`].
+    pub fn wait_chunk(&self, chunk_idx: usize) {
+        if self.is_chunk_ready(chunk_idx) {
+            return;
+        }
+        tokio::runtime::Handle::current().block_on(self.await_chunk(chunk_idx));
+    }
+
     /// Sync convenience: block until every chunk is ready.
     pub fn wait_all(&self) {
         self.wait_range(0, self.file_size);

--- a/crates/sracha-core/src/download/mod.rs
+++ b/crates/sracha-core/src/download/mod.rs
@@ -660,6 +660,10 @@ async fn download_file_inner(
     // path; the single-stream fallback stays None (streaming decode
     // doesn't apply to <SMALL_FILE files anyway).
     let mut chunk_ready_tracker: Option<Arc<ChunkReadyTracker>> = None;
+    // Phase 4a: when streaming MD5 ran (parallel-chunked path), the
+    // hex digest is set here so the post-loop verify code can use it
+    // instead of running another sequential mmap+hash pass.
+    let mut early_md5_hex: Option<String> = None;
 
     if use_parallel {
         // --- Parallel chunked download (with resume support) ---
@@ -792,6 +796,13 @@ async fn download_file_inner(
             let _ = tx.send(tracker.clone());
         }
 
+        // Phase 4a streaming MD5 handle. Declared at outer scope so the
+        // post-worker join code can take it; populated only on the
+        // chunks-to-download branch below (the all-already-done branch
+        // doesn't need a fresh hash — the file is already on disk and
+        // the post-loop compute_md5 fast path handles it).
+        let mut streaming_md5_handle: Option<tokio::task::JoinHandle<Result<String>>> = None;
+
         if chunks_to_download.is_empty() {
             tracing::info!("all chunks already downloaded — verifying");
             bytes_transferred = 0;
@@ -874,6 +885,58 @@ async fn download_file_inner(
                 std::sync::Arc::new(chunks_to_download.iter().copied().collect());
             tracker.init_pending(chunks_to_download.iter().map(|(idx, _)| *idx));
             tracker.close_pending();
+
+            // Phase 4a: streaming MD5. Spawn a hashing task NOW so it
+            // runs in parallel with the workers. It walks chunks in
+            // numerical order, awaits each via the tracker (sync
+            // wait_chunk inside spawn_blocking), and folds them into
+            // an Md5 accumulator. Net effect: MD5 finishes ~when the
+            // last chunk lands instead of 30 s after, since hashing
+            // overlaps with download. For the 16 GB ERR3224585 fixture
+            // the post-download MD5 verify pass was 30 s out of 51 s
+            // total download_file time — this saves that 30 s for any
+            // caller awaiting download_file (including non-streaming
+            // `sracha fetch`).
+            //
+            // Skips itself when validate=false. The single-stream
+            // fallback path (file < SMALL_FILE) doesn't have a tracker,
+            // so it keeps using the post-download `compute_md5` mmap
+            // pass — file is small enough that streaming saves <100 ms.
+            streaming_md5_handle = if config.validate {
+                let tracker_clone = tracker.clone();
+                let path = output_path.to_path_buf();
+                let total_chunks_count = total_chunks;
+                let chunk_size_for_hash = chunk_size;
+                let file_size_for_hash = file_size;
+                Some(tokio::task::spawn_blocking(move || -> Result<String> {
+                    let file = std::fs::File::open(&path).map_err(Error::Io)?;
+                    if file_size_for_hash == 0 {
+                        // MD5 of empty input.
+                        return Ok("d41d8cd98f00b204e9800998ecf8427e".into());
+                    }
+                    // SAFETY: file was pre-allocated to file_size by
+                    // the parent function before the tracker was
+                    // initialized; nothing else writes outside that
+                    // range during our lifetime. Per-chunk pwrites
+                    // populate the bytes; we wait_chunk before
+                    // reading any range so we never observe sparse
+                    // zeros.
+                    let mmap = unsafe { memmap2::Mmap::map(&file).map_err(Error::Io)? };
+                    let mut hasher = Md5::new();
+                    for chunk_idx in 0..total_chunks_count {
+                        tracker_clone.wait_chunk(chunk_idx);
+                        let start =
+                            (chunk_idx as u64 * chunk_size_for_hash).min(file_size_for_hash);
+                        let end = std::cmp::min(start + chunk_size_for_hash, file_size_for_hash);
+                        hasher.update(&mmap[start as usize..end as usize]);
+                    }
+                    let digest = hasher.finalize();
+                    Ok(digest.iter().map(|b| format!("{b:02x}")).collect())
+                }))
+            } else {
+                None
+            };
+
             // Drop the unused semaphore — workers self-limit by spawning
             // exactly `connections` of them.
             drop(semaphore);
@@ -1008,6 +1071,31 @@ async fn download_file_inner(
 
         // Download succeeded — clean up progress sidecar.
         delete_progress(&prog_path);
+
+        // Phase 4a: collect the streaming MD5 result if we spawned a
+        // hashing task. By the time we reach here all workers have
+        // finished and every chunk is mark_done — the hashing task
+        // has either already finished (if it caught up) or has only
+        // its final updates to do (one-shot lock acquisition each).
+        if let Some(handle) = streaming_md5_handle {
+            let computed = handle.await.map_err(|e| Error::Download {
+                accession: String::new(),
+                message: format!("streaming MD5 task panicked: {e}"),
+            })??;
+            // Verify against expected here so we can short-circuit the
+            // post-loop compute_md5 path, AND so a mismatch removes the
+            // bad file before any caller can use it.
+            if let Some(expected) = expected_md5
+                && computed != expected
+            {
+                let _ = tokio::fs::remove_file(output_path).await;
+                return Err(Error::ChecksumMismatch {
+                    expected: expected.to_string(),
+                    actual: computed,
+                });
+            }
+            early_md5_hex = Some(computed);
+        }
     } else {
         // --- Single-stream fallback (with resume support) ---
         // `--force` short-circuits resume: otherwise an already-complete
@@ -1143,8 +1231,16 @@ async fn download_file_inner(
         }
     }
 
-    // Verify MD5 if requested.
-    let md5_hex = if let (true, Some(expected)) = (config.validate, expected_md5) {
+    // Verify MD5 if requested. The parallel-chunked path computes MD5
+    // streaming-style (overlapped with downloads, see Phase 4a above)
+    // and stashes the result in `early_md5_hex` after verifying it
+    // against expected_md5. The single-stream / already-complete-file
+    // paths fall through here and pay the post-download mmap+hash
+    // cost, which is small for the file sizes those paths handle
+    // (<32 MiB or already-on-disk).
+    let md5_hex = if let Some(precomputed) = early_md5_hex {
+        Some(precomputed)
+    } else if let (true, Some(expected)) = (config.validate, expected_md5) {
         let computed = compute_md5(output_path).await?;
         if computed != expected {
             // Clean up the bad file.

--- a/crates/sracha-core/src/download/mod.rs
+++ b/crates/sracha-core/src/download/mod.rs
@@ -757,6 +757,27 @@ async fn download_file_inner(
             tracker.mark_done(done_idx);
         }
         chunk_ready_tracker = Some(tracker.clone());
+
+        // Ensure the output file exists at exactly `file_size` BEFORE
+        // we hand the tracker to a streaming consumer. Otherwise the
+        // consumer could race us, open a non-existent path, and error.
+        // (This also means a streaming decoder can assume the file
+        // exists and is at least `file_size` bytes long — only the
+        // contents of not-yet-ready chunks are invalid.)
+        // Fresh downloads get a sparse zero-filled file; resumes verify
+        // the partial file and extend/truncate if it drifted.
+        {
+            let f = tokio::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(output_path)
+                .await?;
+            if f.metadata().await?.len() != file_size {
+                f.set_len(file_size).await?;
+            }
+        }
+
         // Hand the tracker out to a streaming consumer (if any) BEFORE
         // we spawn chunk workers. Receiver may have already given up if
         // we took too long getting here — that's fine, send returns
@@ -793,21 +814,9 @@ async fn download_file_inner(
                 None
             };
 
-            // Ensure the output file exists at exactly `file_size`. Fresh
-            // downloads get a sparse zero-filled file; resumes verify the
-            // partial file and extend/truncate if it drifted (user copied
-            // something in, previous run died mid-preallocate, etc.).
-            {
-                let f = tokio::fs::OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .truncate(false)
-                    .open(output_path)
-                    .await?;
-                if f.metadata().await?.len() != file_size {
-                    f.set_len(file_size).await?;
-                }
-            }
+            // (File pre-allocation moved above the tracker hand-off so
+            // a streaming consumer can safely open the file the moment
+            // it receives the tracker.)
 
             // Open one shared sync file handle for pwrite across all chunks.
             // Pays one `open` + one `spawn_blocking` for the whole download

--- a/crates/sracha-core/src/download/mod.rs
+++ b/crates/sracha-core/src/download/mod.rs
@@ -47,6 +47,11 @@ pub struct DownloadConfig {
     /// The orchestrator should pass the same client it uses for SDL/S3 so
     /// TLS sessions and connection pools are reused.
     pub client: Option<reqwest::Client>,
+    /// Optional shared `MultiProgress`. When `Some`, the download's
+    /// progress bar is added to it (coordinated rendering with other
+    /// concurrent bars — e.g. a decode bar from a streaming consumer).
+    /// When `None` and `progress` is true, the bar prints standalone.
+    pub progress_parent: Option<Arc<indicatif::MultiProgress>>,
 }
 
 impl Default for DownloadConfig {
@@ -59,6 +64,7 @@ impl Default for DownloadConfig {
             progress: true,
             resume: true,
             client: None,
+            progress_parent: None,
         }
     }
 }
@@ -804,7 +810,16 @@ async fn download_file_inner(
             bytes_transferred = bytes_remaining;
 
             let pb: Option<std::sync::Arc<indicatif::ProgressBar>> = if config.progress {
-                let pb = std::sync::Arc::new(make_progress_bar(bytes_remaining));
+                // Build the bar; if a parent MultiProgress is set
+                // (streaming consumer wants to render alongside its
+                // own decode bar), register it there so they coordinate
+                // the terminal cursor.
+                let bar = make_progress_bar(bytes_remaining);
+                let bar = match &config.progress_parent {
+                    Some(mp) => mp.add(bar),
+                    None => bar,
+                };
+                let pb = std::sync::Arc::new(bar);
                 if already_done > 0 {
                     // Show that we're resuming.
                     pb.set_message(format!("resuming ({already_done}/{total_chunks} cached)"));
@@ -978,7 +993,12 @@ async fn download_file_inner(
         bytes_transferred = bytes_remaining;
 
         let pb: Option<std::sync::Arc<indicatif::ProgressBar>> = if config.progress {
-            Some(std::sync::Arc::new(make_progress_bar(bytes_remaining)))
+            let bar = make_progress_bar(bytes_remaining);
+            let bar = match &config.progress_parent {
+                Some(mp) => mp.add(bar),
+                None => bar,
+            };
+            Some(std::sync::Arc::new(bar))
         } else {
             None
         };

--- a/crates/sracha-core/src/download/mod.rs
+++ b/crates/sracha-core/src/download/mod.rs
@@ -491,6 +491,48 @@ pub async fn download_file(
     output_path: &Path,
     config: &DownloadConfig,
 ) -> Result<DownloadResult> {
+    download_file_inner(urls, expected_size, expected_md5, output_path, config, None).await
+}
+
+/// Streaming variant of [`download_file`]: hands the freshly-constructed
+/// per-chunk readiness tracker out via `tracker_init` as soon as it's
+/// created (well before the download completes), so a streaming
+/// consumer (e.g. a concurrent decoder) can start awaiting byte ranges
+/// immediately.
+///
+/// `tracker_init` is fired only on the parallel-chunked path; on the
+/// single-stream fallback (file < `SMALL_FILE`) the sender is dropped
+/// without sending — receivers should treat `RecvError` as "no
+/// streaming available, fall back to await-then-decode".
+///
+/// All other behavior is identical to [`download_file`].
+pub async fn download_file_streaming(
+    urls: &[String],
+    expected_size: u64,
+    expected_md5: Option<&str>,
+    output_path: &Path,
+    config: &DownloadConfig,
+    tracker_init: tokio::sync::oneshot::Sender<Arc<ChunkReadyTracker>>,
+) -> Result<DownloadResult> {
+    download_file_inner(
+        urls,
+        expected_size,
+        expected_md5,
+        output_path,
+        config,
+        Some(tracker_init),
+    )
+    .await
+}
+
+async fn download_file_inner(
+    urls: &[String],
+    expected_size: u64,
+    expected_md5: Option<&str>,
+    output_path: &Path,
+    config: &DownloadConfig,
+    mut tracker_init: Option<tokio::sync::oneshot::Sender<Arc<ChunkReadyTracker>>>,
+) -> Result<DownloadResult> {
     if urls.is_empty() {
         return Err(Error::Download {
             accession: String::new(),
@@ -715,6 +757,13 @@ pub async fn download_file(
             tracker.mark_done(done_idx);
         }
         chunk_ready_tracker = Some(tracker.clone());
+        // Hand the tracker out to a streaming consumer (if any) BEFORE
+        // we spawn chunk workers. Receiver may have already given up if
+        // we took too long getting here — that's fine, send returns
+        // Err which we ignore.
+        if let Some(tx) = tracker_init.take() {
+            let _ = tx.send(tracker.clone());
+        }
 
         if chunks_to_download.is_empty() {
             tracing::info!("all chunks already downloaded — verifying");

--- a/crates/sracha-core/src/download/mod.rs
+++ b/crates/sracha-core/src/download/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use md5::{Digest, Md5};
 use serde::{Deserialize, Serialize};
@@ -7,6 +8,10 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::Semaphore;
 
 use crate::error::{Error, Result};
+
+pub mod chunk_ready;
+
+use chunk_ready::ChunkReadyTracker;
 
 /// Size thresholds for adaptive chunk sizing.
 const SMALL_FILE: u64 = 32 * 1024 * 1024; // 32 MiB
@@ -69,6 +74,17 @@ pub struct DownloadResult {
     /// Bytes actually transferred over the network this session.
     /// Zero when the file was already complete (skipped).
     pub bytes_transferred: u64,
+    /// Per-chunk completion tracker. `Some` only on the parallel-chunked
+    /// path (file size >= [`SMALL_FILE`] and server supports Range);
+    /// `None` for the single-stream fallback and early-return paths
+    /// (file already complete on disk). All chunks are marked done by
+    /// the time `download_file` returns successfully.
+    ///
+    /// Streaming consumers (decoder running concurrently with download)
+    /// will, in a later phase, take this tracker as an input parameter
+    /// rather than receiving it on completion. For Phase 2 it's
+    /// returned post-hoc as plumbing/observability.
+    pub chunk_ready: Option<Arc<ChunkReadyTracker>>,
 }
 
 /// Information gathered from probing the server.
@@ -509,6 +525,7 @@ pub async fn download_file(
                             size: existing_size,
                             md5: Some(computed),
                             bytes_transferred: 0,
+                            chunk_ready: None,
                         });
                     }
                     tracing::warn!(
@@ -524,6 +541,7 @@ pub async fn download_file(
                         size: existing_size,
                         md5: None,
                         bytes_transferred: 0,
+                        chunk_ready: None,
                     });
                 }
             }
@@ -589,6 +607,11 @@ pub async fn download_file(
     };
 
     let bytes_transferred: u64;
+    // Phase 2 plumbing: track per-chunk completion so a future streaming
+    // decoder can begin work as bytes land. `Some` only on the parallel
+    // path; the single-stream fallback stays None (streaming decode
+    // doesn't apply to <SMALL_FILE files anyway).
+    let mut chunk_ready_tracker: Option<Arc<ChunkReadyTracker>> = None;
 
     if use_parallel {
         // --- Parallel chunked download (with resume support) ---
@@ -682,6 +705,17 @@ pub async fn download_file(
             delete_progress(&prog_path);
         }
 
+        // Build the per-chunk readiness tracker now that chunk_size,
+        // total_chunks, and the resume state are all known. Pre-mark
+        // chunks already complete from a prior partial download so a
+        // streaming consumer doesn't wait on already-on-disk bytes.
+        // (force_wipe_partial reset progress.completed_chunks above.)
+        let tracker = Arc::new(ChunkReadyTracker::new(total_chunks, chunk_size, file_size));
+        for &done_idx in &progress.completed_chunks {
+            tracker.mark_done(done_idx);
+        }
+        chunk_ready_tracker = Some(tracker.clone());
+
         if chunks_to_download.is_empty() {
             tracing::info!("all chunks already downloaded — verifying");
             bytes_transferred = 0;
@@ -759,6 +793,7 @@ pub async fn download_file(
                 let f = shared_file.clone();
                 let pb_clone = pb.clone();
                 let tx = done_tx.clone();
+                let chunk_tracker = tracker.clone();
 
                 let handle = tokio::spawn(async move {
                     let _permit = sem.acquire().await.map_err(|e| Error::Download {
@@ -768,7 +803,16 @@ pub async fn download_file(
 
                     download_chunk(&cli, &u, chunk, &f, pb_clone.as_deref()).await?;
 
-                    // Notify progress tracker.
+                    // Mark this chunk's bytes as readable. Order matters:
+                    // do this AFTER download_chunk's pwrite returns
+                    // (bytes are durably on disk via the shared fd) so
+                    // any streaming consumer awaiting this byte range
+                    // sees a consistent view.
+                    chunk_tracker.mark_done(chunk_idx);
+
+                    // Notify the progress sidecar saver (separate from the
+                    // streaming tracker — this drives the .sracha-progress
+                    // JSON checkpoint, not decoder readiness).
                     let _ = tx.send(chunk_idx);
                     Ok::<(), Error>(())
                 });
@@ -1011,11 +1055,20 @@ pub async fn download_file(
 
     let metadata = tokio::fs::metadata(output_path).await?;
 
+    // By this point all chunks are on disk and MD5 verified. If a
+    // streaming consumer somehow ran past mark_done (it shouldn't) or
+    // raced with the tail of the loop, mark_all_done as a belt-and-
+    // suspenders safety net. Idempotent.
+    if let Some(t) = &chunk_ready_tracker {
+        t.mark_all_done();
+    }
+
     Ok(DownloadResult {
         path: output_path.to_path_buf(),
         size: metadata.len(),
         md5: md5_hex,
         bytes_transferred,
+        chunk_ready: chunk_ready_tracker,
     })
 }
 

--- a/crates/sracha-core/src/download/mod.rs
+++ b/crates/sracha-core/src/download/mod.rs
@@ -857,37 +857,68 @@ async fn download_file_inner(
             // Channel for completed chunk indices (for progress sidecar updates).
             let (done_tx, mut done_rx) = tokio::sync::mpsc::unbounded_channel::<usize>();
 
-            let mut handles = Vec::with_capacity(chunks_to_download.len());
+            // Phase 3g-2: dispatch via the tracker's pending queue.
+            // Workers pull the next chunk index to fetch from the queue
+            // (replacing the old "spawn-one-task-per-chunk + FIFO
+            // semaphore" pattern). A streaming consumer can call
+            // `tracker.prioritize_pending(idx_chunks)` after parsing
+            // the TOC to fetch idx-containing chunks ahead of normal
+            // numerical-order data chunks — that's how decode actually
+            // gets to start while the file is still streaming.
+            //
+            // `chunks_by_idx` is the worker's lookup from chunk index
+            // (what the queue stores) to ChunkRange (what
+            // `download_chunk` needs). Wrapped in Arc so the per-worker
+            // clone is just a pointer bump.
+            let chunks_by_idx: std::sync::Arc<std::collections::HashMap<usize, ChunkRange>> =
+                std::sync::Arc::new(chunks_to_download.iter().copied().collect());
+            tracker.init_pending(chunks_to_download.iter().map(|(idx, _)| *idx));
+            tracker.close_pending();
+            // Drop the unused semaphore — workers self-limit by spawning
+            // exactly `connections` of them.
+            drop(semaphore);
 
-            for (chunk_idx, chunk) in chunks_to_download {
-                let sem = semaphore.clone();
+            let mut handles = Vec::with_capacity(connections);
+            for _worker_id in 0..connections {
                 let cli = client.clone();
                 let u = url.clone();
                 let f = shared_file.clone();
                 let pb_clone = pb.clone();
                 let tx = done_tx.clone();
                 let chunk_tracker = tracker.clone();
+                let by_idx = chunks_by_idx.clone();
 
                 let handle = tokio::spawn(async move {
-                    let _permit = sem.acquire().await.map_err(|e| Error::Download {
-                        accession: String::new(),
-                        message: format!("semaphore acquire failed: {e}"),
-                    })?;
+                    loop {
+                        let chunk_idx = match chunk_tracker.pop_pending() {
+                            Some(i) => i,
+                            None => {
+                                if chunk_tracker.pending_closed() {
+                                    return Ok::<(), Error>(());
+                                }
+                                chunk_tracker.wait_for_pending().await;
+                                continue;
+                            }
+                        };
+                        let chunk = by_idx
+                            .get(&chunk_idx)
+                            .copied()
+                            .expect("queue index must be in chunks_by_idx");
 
-                    download_chunk(&cli, &u, chunk, &f, pb_clone.as_deref()).await?;
+                        download_chunk(&cli, &u, chunk, &f, pb_clone.as_deref()).await?;
 
-                    // Mark this chunk's bytes as readable. Order matters:
-                    // do this AFTER download_chunk's pwrite returns
-                    // (bytes are durably on disk via the shared fd) so
-                    // any streaming consumer awaiting this byte range
-                    // sees a consistent view.
-                    chunk_tracker.mark_done(chunk_idx);
+                        // Mark this chunk's bytes as readable. Order matters:
+                        // do this AFTER download_chunk's pwrite returns
+                        // (bytes are durably on disk via the shared fd) so
+                        // any streaming consumer awaiting this byte range
+                        // sees a consistent view.
+                        chunk_tracker.mark_done(chunk_idx);
 
-                    // Notify the progress sidecar saver (separate from the
-                    // streaming tracker — this drives the .sracha-progress
-                    // JSON checkpoint, not decoder readiness).
-                    let _ = tx.send(chunk_idx);
-                    Ok::<(), Error>(())
+                        // Notify the progress sidecar saver (separate from the
+                        // streaming tracker — this drives the .sracha-progress
+                        // JSON checkpoint, not decoder readiness).
+                        let _ = tx.send(chunk_idx);
+                    }
                 });
 
                 handles.push(handle);

--- a/crates/sracha-core/src/download/mod.rs
+++ b/crates/sracha-core/src/download/mod.rs
@@ -52,6 +52,16 @@ pub struct DownloadConfig {
     /// concurrent bars — e.g. a decode bar from a streaming consumer).
     /// When `None` and `progress` is true, the bar prints standalone.
     pub progress_parent: Option<Arc<indicatif::MultiProgress>>,
+    /// Optional shared "combined work" progress bar. When `Some`, the
+    /// download worker loop ticks THIS bar (by chunk byte share) in
+    /// addition to the standalone per_sec/eta bar — or, if `progress`
+    /// is also false, INSTEAD of it. Used by `run_get_streaming` to
+    /// collapse the previous dual-bar UX (separate download + decode
+    /// bars, the latter of which stalled during per-batch waits) into
+    /// a single monotonically-advancing bar whose download side keeps
+    /// moving while decode is gated. Total = 10000; download
+    /// contributes up to 5000; see Phase 4d plan.
+    pub progress_combined: Option<Arc<indicatif::ProgressBar>>,
 }
 
 impl Default for DownloadConfig {
@@ -65,6 +75,7 @@ impl Default for DownloadConfig {
             resume: true,
             client: None,
             progress_parent: None,
+            progress_combined: None,
         }
     }
 }
@@ -947,6 +958,8 @@ async fn download_file_inner(
                 let u = url.clone();
                 let f = shared_file.clone();
                 let pb_clone = pb.clone();
+                let combined_pb_clone = config.progress_combined.clone();
+                let file_size_for_bar = file_size;
                 let tx = done_tx.clone();
                 let chunk_tracker = tracker.clone();
                 let by_idx = chunks_by_idx.clone();
@@ -969,6 +982,22 @@ async fn download_file_inner(
                             .expect("queue index must be in chunks_by_idx");
 
                         download_chunk(&cli, &u, chunk, &f, pb_clone.as_deref()).await?;
+
+                        // Phase 4d: tick the combined work bar (if wired).
+                        // Download contributes up to 5000 of the bar's
+                        // 10000-unit total (decode contributes the other
+                        // 5000); each chunk ticks its byte-share of that
+                        // 5000. Using saturating math so a zero-sized
+                        // file can't divide-by-zero.
+                        if let Some(ref combined_pb) = combined_pb_clone {
+                            let chunk_len = chunk.end - chunk.start + 1;
+                            let units = chunk_len
+                                .saturating_mul(5000)
+                                .checked_div(file_size_for_bar)
+                                .map(|u| u.max(1))
+                                .unwrap_or(0);
+                            combined_pb.inc(units);
+                        }
 
                         // Mark this chunk's bytes as readable. Order matters:
                         // do this AFTER download_chunk's pwrite returns

--- a/crates/sracha-core/src/pipeline/config.rs
+++ b/crates/sracha-core/src/pipeline/config.rs
@@ -54,6 +54,13 @@ pub struct PipelineConfig {
     /// decode instead of deleting it. Useful for validation runs that
     /// want to compare against another tool on the same input file.
     pub keep_sra: bool,
+    /// Optional shared `MultiProgress`. When `Some`, the download bar
+    /// AND the decode bar are added to it so they render side-by-side
+    /// instead of clobbering each other on the terminal. Wired by
+    /// `run_get_streaming` so the user sees concurrent download +
+    /// decode progress in one tidy stack. `None` keeps the bars as
+    /// independent (legacy single-bar) renderers.
+    pub progress_parent: Option<Arc<indicatif::MultiProgress>>,
 }
 
 /// Statistics from a completed pipeline run.

--- a/crates/sracha-core/src/pipeline/config.rs
+++ b/crates/sracha-core/src/pipeline/config.rs
@@ -61,6 +61,15 @@ pub struct PipelineConfig {
     /// decode progress in one tidy stack. `None` keeps the bars as
     /// independent (legacy single-bar) renderers.
     pub progress_parent: Option<Arc<indicatif::MultiProgress>>,
+    /// Optional shared "combined work" progress bar. When `Some`,
+    /// `decode_and_write`'s writer ticks THIS bar by blob share instead
+    /// of creating a separate per-decode bar with per_sec/eta (which
+    /// stalled and misled during streaming per-batch waits — see
+    /// Phase 4d plan). `run_get_streaming` sets this along with the
+    /// matching field on DownloadConfig so BOTH sides of the pipeline
+    /// feed the same bar. Non-streaming paths (`sracha fetch`,
+    /// `sracha fastq`) leave this None and keep the legacy bars.
+    pub progress_combined: Option<Arc<indicatif::ProgressBar>>,
 }
 
 /// Statistics from a completed pipeline run.

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -370,10 +370,8 @@ fn decode_and_write(
 
     if let Some(tracker) = chunk_ready {
         // Collect all non-`/data` archive file ranges first so we can
-        // log the summary BEFORE waiting on any of them. Layout-sensitive
-        // diagnostics need to fire even when the metadata gate is going
-        // to take a long time — otherwise the user can't tell whether
-        // we're waiting on download or stuck somewhere else.
+        // log the summary + inject chunk-priority hints BEFORE waiting
+        // on any of them.
         let total_size = tracker.file_size();
         let mut idx_ranges: Vec<(String, u64, u64)> = Vec::new();
         for path in archive.list_files() {
@@ -391,18 +389,37 @@ fn decode_and_write(
         let pct = (idx_max_offset as f64 / total_size.max(1) as f64) * 100.0;
         tracing::info!(
             "{accession}: streaming-decode metadata gate: {} idx files, furthest at byte \
-             {idx_max_offset} ({pct:.1}% into {total_size}-byte file) — chunks <= that \
-             point must download before per-batch decode can start",
+             {idx_max_offset} ({pct:.1}% into {total_size}-byte file)",
             idx_ranges.len(),
         );
 
-        // Per-file wait. Replaces the old contiguous wait_range(0, max_end)
-        // which forced us to wait for every chunk between the start and
-        // the furthest idx file (often the whole download) — see
-        // Phase 3g-1 commit for context. The per-file form prepares the
-        // ground for Phase 3g-2 chunk-priority download, where these
-        // specific ranges become the priority hints sent back to the
-        // downloader so they fetch ahead of numerical-order chunks.
+        // Phase 3g-2: compute which chunks contain idx file bytes and
+        // ask the downloader to prioritize them. Workers will finish
+        // their current chunk and pick up the priority indices next,
+        // so decode can open the cursor (read these idx files) seconds
+        // into the download instead of minutes (which is what happened
+        // when chunks were dispatched in pure numerical order).
+        let mut prio_chunks: Vec<usize> = Vec::new();
+        for (_, off, sz) in &idx_ranges {
+            let first = tracker.chunk_index_for_byte(*off);
+            let last = tracker.chunk_index_for_byte((off + sz).saturating_sub(1));
+            for c in first..=last {
+                if !prio_chunks.contains(&c) {
+                    prio_chunks.push(c);
+                }
+            }
+        }
+        if !prio_chunks.is_empty() {
+            tracing::info!(
+                "{accession}: prioritizing {} chunks containing idx-file bytes",
+                prio_chunks.len(),
+            );
+            tracker.prioritize_pending(&prio_chunks);
+        }
+
+        // Per-file wait — now that we've nudged the dispatch order, the
+        // chunks we need will arrive ASAP rather than at their
+        // numerical-order turn.
         for (_, off, sz) in &idx_ranges {
             tracker.wait_range(*off, off + sz);
         }
@@ -1949,11 +1966,24 @@ pub fn decode_sra(downloaded: &DownloadedSra, config: &PipelineConfig) -> Result
         );
     }
 
+    // `downloaded.bytes_transferred` may be 0 here even on a real network
+    // transfer: when called from `run_get_streaming` the value is a
+    // placeholder (the real number isn't known until the parallel download
+    // task finishes; the orchestrator patches it into the returned
+    // PipelineStats afterward). Suppress the misleading "0 B transferred"
+    // line in that case — the CLI prints the correct totals at the end
+    // anyway.
+    let bytes_msg = if downloaded.bytes_transferred == 0 {
+        "(bytes transferred reported by orchestrator)".to_string()
+    } else {
+        format!(
+            "{} transferred",
+            crate::util::format_size(downloaded.bytes_transferred)
+        )
+    };
     tracing::info!(
-        "{}: done -- {spots_read} spots, {reads_written} reads written, \
-         {} transferred",
+        "{}: done -- {spots_read} spots, {reads_written} reads written, {bytes_msg}",
         downloaded.accession,
-        crate::util::format_size(downloaded.bytes_transferred),
     );
 
     if diag.any() {

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -622,7 +622,17 @@ fn decode_and_write(
     );
     tracing::debug!("{accession}: streaming decode of {num_blobs} blobs (batch-parallel)",);
 
-    let decode_pb = if config.progress {
+    // Decode progress: when a combined bar is wired (streaming mode),
+    // we skip the standalone per-decode bar and tick the combined bar
+    // instead — the standalone bar's per_sec/eta are misleading during
+    // streaming per-batch waits (see Phase 4d plan). The combined bar
+    // is ticked by blob share in the writer loop below.
+    //
+    // Non-streaming paths (`sracha fastq` and the legacy
+    // `sracha get` multi-accession) set `progress_combined: None` and
+    // keep the existing blob-count bar with its real per_sec/eta —
+    // those paths never stall, so the rate/eta are accurate.
+    let decode_pb = if config.progress && config.progress_combined.is_none() {
         let bar = make_styled_pb(
             num_blobs as u64,
             "  {elapsed_precise} [{bar:40.cyan}] {pos}/{len} blobs  {per_sec}  eta {eta}",
@@ -634,6 +644,15 @@ fn decode_and_write(
         Some(bar)
     } else {
         None
+    };
+    // Captured by the writer thread; when Some, each blob written ticks
+    // the shared combined bar by `5000 / num_blobs` units (the decode
+    // side's share of the 10000-unit total).
+    let combined_decode_pb = config.progress_combined.clone();
+    let combined_decode_units = if num_blobs > 0 {
+        (5000u64 / num_blobs as u64).max(1)
+    } else {
+        0
     };
 
     /// Number of blobs per batch for parallel decode.
@@ -690,6 +709,12 @@ fn decode_and_write(
 
                     if let Some(ref pb) = decode_pb {
                         pb.inc(1);
+                    }
+                    // Phase 4d: when streaming mode is active, tick the
+                    // shared combined bar by this blob's share of the
+                    // decode-side budget (5000 units / num_blobs).
+                    if let Some(ref combined_pb) = combined_decode_pb {
+                        combined_pb.inc(combined_decode_units);
                     }
 
                     if blob_counter.is_multiple_of(50) || blob_counter == num_blobs {
@@ -1667,6 +1692,7 @@ async fn download_sra_inner(
         resume: config.resume,
         client: config.http_client.clone(),
         progress_parent: config.progress_parent.clone(),
+        progress_combined: config.progress_combined.clone(),
     };
 
     tracing::info!(
@@ -1743,6 +1769,7 @@ pub async fn download_ena_fastq(
         resume: config.resume,
         client: config.http_client.clone(),
         progress_parent: config.progress_parent.clone(),
+        progress_combined: config.progress_combined.clone(),
     };
 
     let mut output_files: Vec<PathBuf> = Vec::with_capacity(ena.fastq_files.len());
@@ -2051,18 +2078,49 @@ pub async fn run_get_streaming(
     resolved: &ResolvedAccession,
     config: &PipelineConfig,
 ) -> Result<PipelineStats> {
-    // If the user wants progress AND no parent MultiProgress was wired
-    // upstream, create one here and stamp it onto the per-task configs.
-    // The download bar (added inside download_file) and the decode bar
-    // (added inside decode_and_write) will both register against this
-    // MultiProgress and render stacked instead of clobbering each other.
-    let mp = if config.progress && config.progress_parent.is_none() {
-        Some(Arc::new(indicatif::MultiProgress::new()))
+    // Phase 4d UX: replace the old dual-bar MultiProgress wiring
+    // (separate download + decode bars, the latter of which stalled
+    // during per-batch waits) with a single combined "work" bar. The
+    // download worker ticks this bar by each chunk's byte share; the
+    // decode writer ticks it by each blob's share. Both sides
+    // contribute to the same 10000-unit total, so the bar advances
+    // monotonically whenever ANY work is happening — no freeze during
+    // streaming decode stalls.
+    //
+    // MultiProgress still gets created when progress is enabled, so
+    // any `tracing` output dumped from the pipeline doesn't overwrite
+    // the bar — the bar is `.add`'d to the MultiProgress and logs
+    // render above it automatically.
+    let combined_pb = if config.progress && config.progress_combined.is_none() {
+        let bar = make_styled_pb(
+            10_000,
+            "  {elapsed_precise} [{bar:40.cyan}] {percent}%  {msg}",
+        );
+        bar.set_message("streaming download + decode");
+        Some(Arc::new(bar))
+    } else {
+        config.progress_combined.clone()
+    };
+    let mp = if config.progress && config.progress_parent.is_none() && combined_pb.is_some() {
+        let new_mp = Arc::new(indicatif::MultiProgress::new());
+        if let Some(ref bar) = combined_pb {
+            // Registering lets `tracing` output interleave cleanly
+            // above the bar rather than clobbering it.
+            new_mp.add((**bar).clone());
+        }
+        Some(new_mp)
     } else {
         config.progress_parent.clone()
     };
     let mut config_with_mp: PipelineConfig = config.clone();
     config_with_mp.progress_parent = mp.clone();
+    config_with_mp.progress_combined = combined_pb.clone();
+    // Suppress the individual per-file download bar when the combined
+    // bar is taking over — otherwise the download bar would render in
+    // parallel with the combined bar, defeating the "single bar" UX.
+    if combined_pb.is_some() {
+        config_with_mp.progress = false;
+    }
 
     let (tracker_tx, tracker_rx) = tokio::sync::oneshot::channel();
     let resolved_owned = resolved.clone();

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -344,9 +344,49 @@ fn decode_and_write(
     config: &PipelineConfig,
     is_lite: bool,
     diag: &IntegrityDiag,
+    chunk_ready: Option<&Arc<crate::download::chunk_ready::ChunkReadyTracker>>,
 ) -> Result<(u64, u64, Vec<PathBuf>)> {
+    // Phase 3c gate (entry, metadata): when a streaming tracker is
+    // present, wait for the bytes that KarArchive::open + VdbCursor::open
+    // will read before we open them. Otherwise sparse-mmap reads return
+    // zeros and we'd silently get a corrupt TOC / column metadata.
+    //
+    // Two-stage:
+    //   1. Wait for the 24-byte KAR header so we can extract file_offset
+    //      (where the data section starts).
+    //   2. Wait for [0, file_offset) — the rest of the TOC.
+    //   3. Open KarArchive, walk its entries to find the maximum byte
+    //      offset of any non-`/data` file (these are the small idx*
+    //      sidecars). Wait for [0, max_meta_end).
+    //   4. Open VdbCursor (its ColumnReader::open calls read those idx
+    //      files; mmaps the data slabs but doesn't read them yet — the
+    //      per-batch gate below handles those reads).
+    if let Some(tracker) = chunk_ready {
+        wait_metadata_ready(sra_path, tracker)?;
+    }
+
     let file = std::fs::File::open(sra_path)?;
     let mut archive = KarArchive::open(std::io::BufReader::new(file))?;
+
+    if let Some(tracker) = chunk_ready {
+        // Now that the TOC is parsed we know where every idx file lives.
+        // Wait for the contiguous span [0, max_idx_end) so the
+        // VdbCursor::open below can read every idx file safely.
+        let mut max_meta_end = archive.header().file_offset;
+        for path in archive.list_files() {
+            // Data slabs are gated per-batch later; here we want only
+            // the small index files (idx, idx0, idx1, idx2, plus skey).
+            let is_data = path.ends_with("/data");
+            if is_data {
+                continue;
+            }
+            if let Some((off, sz)) = archive.file_location(path) {
+                max_meta_end = max_meta_end.max(off + sz);
+            }
+        }
+        tracker.wait_range(0, max_meta_end);
+    }
+
     let cursor = VdbCursor::open(&mut archive, sra_path)?;
 
     // Check platform — reject legacy platforms with complex read structures.
@@ -659,6 +699,66 @@ fn decode_and_write(
                 spots_before_per_blob_in_batch(cumulative_spots, &blob_id_ranges);
             cumulative_spots += batch_spots;
 
+            // Phase 3c gate (per-batch): if streaming, wait for the
+            // bytes the upcoming rayon decode will read. We compute the
+            // union of [min_start, max_end) across every blob the batch
+            // will touch (READ + all auxiliary columns; ALTREAD blob
+            // boundaries can differ from READ's so use find_blob).
+            // Per-batch is the right granularity: the rayon workers
+            // aren't in a tokio context (so calling `wait_range` from
+            // inside the parallel iterator would panic), and the
+            // overshoot from waiting on a contiguous superset rather
+            // than a precise multi-range set is small in practice
+            // because adjacent blobs of the same column are
+            // sequentially placed.
+            if let Some(tracker) = chunk_ready {
+                let mut min_byte = u64::MAX;
+                let mut max_byte = 0u64;
+                let mut accumulate = |range: Option<(u64, u64)>| {
+                    if let Some((s, e)) = range {
+                        min_byte = min_byte.min(s);
+                        max_byte = max_byte.max(e);
+                    }
+                };
+                for bi in blob_idx..batch_end {
+                    let rb = &cursor.read_col().blobs()[bi];
+                    accumulate(cursor.read_col().blob_absolute_range(rb));
+                    if has_quality && bi < quality_blob_count {
+                        let c = cursor.quality_col().unwrap();
+                        accumulate(c.blob_absolute_range(&c.blobs()[bi]));
+                    }
+                    if has_read_len && bi < read_len_blob_count {
+                        let c = cursor.read_len_col().unwrap();
+                        accumulate(c.blob_absolute_range(&c.blobs()[bi]));
+                    }
+                    if has_name && bi < name_blob_count {
+                        let c = cursor.name_col().unwrap();
+                        accumulate(c.blob_absolute_range(&c.blobs()[bi]));
+                    }
+                    if has_read_type && bi < read_type_blob_count {
+                        let c = cursor.read_type_col().unwrap();
+                        accumulate(c.blob_absolute_range(&c.blobs()[bi]));
+                    }
+                    if has_altread {
+                        let c = cursor.altread_col().unwrap();
+                        if let Some(b) = c.find_blob(rb.start_id) {
+                            accumulate(c.blob_absolute_range(b));
+                        }
+                    }
+                    if has_illumina_name_parts && bi < x_blob_count {
+                        let c = cursor.x_col().unwrap();
+                        accumulate(c.blob_absolute_range(&c.blobs()[bi]));
+                    }
+                    if has_illumina_name_parts && bi < y_blob_count {
+                        let c = cursor.y_col().unwrap();
+                        accumulate(c.blob_absolute_range(&c.blobs()[bi]));
+                    }
+                }
+                if max_byte > min_byte {
+                    tracker.wait_range(min_byte, max_byte);
+                }
+            }
+
             let formatted_batches: Vec<Result<FormattedBlob>> = pool.install(|| {
                 (blob_idx..batch_end)
                     .into_par_iter()
@@ -961,7 +1061,7 @@ pub fn run_fastq(
 
     let diag = Arc::new(IntegrityDiag::default());
     let (spots_read, reads_written, output_files) =
-        decode_and_write(sra_path, &acc, config, is_lite, &diag)
+        decode_and_write(sra_path, &acc, config, is_lite, &diag, None)
             .map_err(|e| wrap_blob_integrity(&acc, e))?;
 
     // Warn (but don't fail) when split-3 was requested on an effectively
@@ -1414,6 +1514,30 @@ pub async fn download_sra_streaming(
     download_sra_inner(resolved, config, Some(tracker_init)).await
 }
 
+/// First-stage metadata gate for streaming decode. Waits for the bytes
+/// `KarArchive::open` needs to read (24-byte header + the TOC, whose
+/// extent is encoded as `header.file_offset`).
+///
+/// Returns once enough of the file is on disk that `KarArchive::open`
+/// can be called without hitting sparse holes.
+fn wait_metadata_ready(
+    sra_path: &std::path::Path,
+    tracker: &Arc<crate::download::chunk_ready::ChunkReadyTracker>,
+) -> Result<()> {
+    use std::io::Read;
+    // KAR header is 24 bytes at offset 0; chunk 0 always covers it.
+    tracker.wait_range(0, 24);
+    let mut hdr = [0u8; 24];
+    let mut f = std::fs::File::open(sra_path)?;
+    f.read_exact(&mut hdr)?;
+    // Bytes 16..24 hold the little-endian file_offset (start of the
+    // data section). Anything before that is the TOC and must be on
+    // disk before we can parse it.
+    let file_offset = u64::from_le_bytes(hdr[16..24].try_into().unwrap());
+    tracker.wait_range(0, file_offset);
+    Ok(())
+}
+
 /// Wrap a download future with the standard cancellation handler:
 /// honor `config.cancelled` if set, removing the temp file + progress
 /// sidecar before bubbling `Error::Cancelled`. Extracted so the two
@@ -1681,17 +1805,12 @@ pub fn decode_sra(downloaded: &DownloadedSra, config: &PipelineConfig) -> Result
         });
     }
 
-    // Phase 3a gate: if a streaming tracker is attached, ensure every
-    // chunk is on disk before decode begins. For Phase 3a this is a
-    // no-op — `run_get` only calls `decode_sra` AFTER `download_sra`
-    // returns successfully, by which point the tracker is fully marked
-    // done. Phase 3b will redesign `run_get` to spawn decode early so
-    // this gate becomes load-bearing (decode can begin as soon as the
-    // KAR header chunk lands, granular per-blob waits below).
-    if let Some(tracker) = &downloaded.chunk_ready {
-        tracker.wait_all();
-    }
-
+    // Phase 3c: granular gating now lives inside `decode_and_write`
+    // (metadata waits at entry, per-batch waits in the decode loop).
+    // The Phase 3a coarse `wait_all()` is removed so streaming decode
+    // can actually overlap with download. When `chunk_ready` is None
+    // (single-stream fallback or already-on-disk path) decode_and_write
+    // skips the gates entirely.
     let diag = Arc::new(IntegrityDiag::default());
     let (spots_read, reads_written, output_files) = match decode_and_write(
         &downloaded.temp_path,
@@ -1699,6 +1818,7 @@ pub fn decode_sra(downloaded: &DownloadedSra, config: &PipelineConfig) -> Result
         config,
         downloaded.is_lite,
         &diag,
+        downloaded.chunk_ready.as_ref(),
     ) {
         Ok(result) => result,
         Err(Error::Cancelled { output_files }) => {
@@ -1846,21 +1966,29 @@ pub async fn run_get(
     tokio::task::block_in_place(|| decode_sra(&downloaded, config))
 }
 
-/// Streaming variant of [`run_get`]: uses [`download_sra_streaming`] so
-/// the chunk-readiness tracker can be observed before download
-/// completes, and orchestrates download + decode as concurrent tasks.
+/// Streaming variant of [`run_get`]: starts the FASTQ decode while
+/// the SRA download is still in flight.
 ///
-/// **Phase 3b status:** the orchestration is in place but observable
-/// behavior is identical to [`run_get`]. The decoder still gates
-/// at-entry on `tracker.wait_all()` (which blocks until the download is
-/// done), so wall-clock is unchanged. Phase 3c will replace the
-/// at-entry gate with per-blob `tracker.wait_range(...)` calls; from
-/// that point the spawned decode task makes real progress while the
-/// download is still in flight.
+/// **How it works** (post-Phase 3c+3d):
+/// 1. Download is spawned as a background Tokio task. As soon as the
+///    parallel-chunked path constructs its `ChunkReadyTracker`, the
+///    tracker is delivered to us via a oneshot.
+/// 2. With the tracker in hand we synthesize a `DownloadedSra` for the
+///    decoder using the fields we already know (temp path, accession,
+///    `is_lite` from SDL metadata). `bytes_transferred` is unknown at
+///    this point — we patch it in from the real `DownloadedSra` after
+///    the download task finishes.
+/// 3. Decode runs in `spawn_blocking`. Its first action is the
+///    streaming-decode metadata gate (waits for KAR header + TOC + idx
+///    files); each subsequent batch waits for the chunks covering its
+///    blobs before the rayon decode block runs. Both threads make
+///    progress in parallel.
+/// 4. We `try_join!` download and decode; the decoder finishes shortly
+///    after the last chunk lands.
 ///
 /// On the single-stream fallback (file < `SMALL_FILE`) the tracker is
 /// never sent — we transparently fall through to the same await-then-
-/// decode flow [`run_get`] uses.
+/// decode flow [`run_get`] uses, with no streaming overlap.
 pub async fn run_get_streaming(
     resolved: &ResolvedAccession,
     config: &PipelineConfig,
@@ -1869,32 +1997,65 @@ pub async fn run_get_streaming(
     let resolved_owned = resolved.clone();
     let config_for_dl = config.clone();
 
-    // Spawn the download as a Tokio task. It must be 'static, hence
-    // the clones above. Tracker (if any) flows out via `tracker_rx`.
+    // Spawn the download as a Tokio task. Args must be 'static.
     let dl_handle: tokio::task::JoinHandle<Result<DownloadedSra>> = tokio::spawn(async move {
         download_sra_streaming(&resolved_owned, &config_for_dl, tracker_tx).await
     });
 
     // Receive the tracker. Err means the sender was dropped without
-    // firing — either the download took the single-stream path (file <
-    // SMALL_FILE) or it failed before reaching the tracker-construction
-    // site. Either way the right next step is the same: just wait for
-    // download_sra_streaming to finish (it'll return either a result
-    // with chunk_ready=None or the underlying error).
-    let _early_tracker = tracker_rx.await.ok();
+    // firing — either the download took the single-stream path or
+    // failed before reaching the tracker-construction site.
+    let early_tracker = tracker_rx.await.ok();
 
-    // Phase 3b: decode runs *after* download here because Phase 3c's
-    // granular per-blob gating isn't in yet, so spawning decode in
-    // parallel would just have it block on `wait_all` for the duration
-    // of the download — no win, more complexity. The orchestration
-    // primitive is in place; flipping to truly-concurrent execution is
-    // a Phase 3c follow-up that replaces the at-entry gate with
-    // per-blob waits.
-    let downloaded = dl_handle
+    let Some(tracker) = early_tracker else {
+        // No streaming available — degrade gracefully to await-then-decode.
+        let downloaded = dl_handle
+            .await
+            .map_err(|e| Error::Pipeline(format!("download task panicked: {e}")))??;
+        return tokio::task::block_in_place(|| decode_sra(&downloaded, config));
+    };
+
+    // Synthesize the DownloadedSra fields the decoder needs upfront.
+    // Everything except `bytes_transferred` is known from `resolved` +
+    // the temp-path convention; we patch `bytes_transferred` in from
+    // the real result after the download task finishes.
+    let temp_path = config
+        .output_dir
+        .join(format!(".sracha-tmp-{}.sra", resolved.accession));
+    let synthetic = DownloadedSra {
+        temp_path,
+        bytes_transferred: 0,
+        total_sra_size: resolved.sra_file.size,
+        is_lite: resolved.sra_file.is_lite,
+        accession: resolved.accession.clone(),
+        sra_md5: resolved.sra_file.md5.clone(),
+        chunk_ready: Some(tracker),
+    };
+
+    // Spawn decode on a blocking thread (decode_sra is sync and uses
+    // rayon internally; spawn_blocking gives it a dedicated OS thread
+    // off the Tokio worker pool). It runs concurrently with the
+    // download task — its metadata + per-batch gates inside
+    // `decode_and_write` block on chunk readiness as needed.
+    let config_for_decode = config.clone();
+    let decode_handle: tokio::task::JoinHandle<Result<PipelineStats>> =
+        tokio::task::spawn_blocking(move || decode_sra(&synthetic, &config_for_decode));
+
+    // Await both. The download finishes first (download's MD5 + sidecar
+    // cleanup are part of `download_sra_streaming`); decode finishes
+    // shortly after the last chunk's bytes are wait_range-released.
+    let dl_result = dl_handle
         .await
-        .map_err(|e| Error::Pipeline(format!("download task panicked: {e}")))??;
+        .map_err(|e| Error::Pipeline(format!("download task panicked: {e}")))?;
+    let downloaded = dl_result?;
+    let decode_result = decode_handle
+        .await
+        .map_err(|e| Error::Pipeline(format!("decode task panicked: {e}")))?;
+    let mut stats = decode_result?;
 
-    tokio::task::block_in_place(|| decode_sra(&downloaded, config))
+    // Patch in the real bytes_transferred (synthetic was 0).
+    stats.bytes_transferred = downloaded.bytes_transferred;
+    Ok(stats)
 }
 
 #[cfg(test)]

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -11,7 +11,7 @@
 
 use std::collections::HashMap;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -1391,6 +1391,67 @@ pub async fn download_sra(
     resolved: &ResolvedAccession,
     config: &PipelineConfig,
 ) -> Result<DownloadedSra> {
+    download_sra_inner(resolved, config, None).await
+}
+
+/// Streaming variant of [`download_sra`]: hands the freshly-constructed
+/// `ChunkReadyTracker` out via `tracker_init` as soon as it's available
+/// (typically <100 ms after function entry, on the parallel-chunked
+/// path). Callers can then await byte-range readiness on the tracker
+/// concurrently with the rest of the download.
+///
+/// On the single-stream fallback (file < `SMALL_FILE`) or an early
+/// failure, the sender is dropped without sending — receivers should
+/// treat `RecvError` as "no streaming available, await this future and
+/// process the result normally."
+pub async fn download_sra_streaming(
+    resolved: &ResolvedAccession,
+    config: &PipelineConfig,
+    tracker_init: tokio::sync::oneshot::Sender<
+        Arc<crate::download::chunk_ready::ChunkReadyTracker>,
+    >,
+) -> Result<DownloadedSra> {
+    download_sra_inner(resolved, config, Some(tracker_init)).await
+}
+
+/// Wrap a download future with the standard cancellation handler:
+/// honor `config.cancelled` if set, removing the temp file + progress
+/// sidecar before bubbling `Error::Cancelled`. Extracted so the two
+/// `match` arms in [`download_sra_inner`] (streaming vs legacy) can
+/// share the cancellation logic.
+async fn await_with_cancel<F>(
+    fut: F,
+    config: &PipelineConfig,
+    temp_path: &Path,
+    accession: &str,
+) -> Result<crate::download::DownloadResult>
+where
+    F: std::future::Future<Output = Result<crate::download::DownloadResult>>,
+{
+    if let Some(ref flag) = config.cancelled {
+        let flag = flag.clone();
+        tokio::select! {
+            result = fut => result,
+            _ = poll_cancelled(flag) => {
+                tracing::info!("{accession}: download cancelled");
+                let _ = tokio::fs::remove_file(temp_path).await;
+                let sidecar = crate::download::progress_path(temp_path);
+                let _ = tokio::fs::remove_file(&sidecar).await;
+                Err(Error::Cancelled { output_files: vec![] })
+            }
+        }
+    } else {
+        fut.await
+    }
+}
+
+async fn download_sra_inner(
+    resolved: &ResolvedAccession,
+    config: &PipelineConfig,
+    tracker_init: Option<
+        tokio::sync::oneshot::Sender<Arc<crate::download::chunk_ready::ChunkReadyTracker>>,
+    >,
+) -> Result<DownloadedSra> {
     let accession = &resolved.accession;
     let total_sra_size = resolved.sra_file.size;
 
@@ -1446,28 +1507,30 @@ pub async fn download_sra(
         temp_path.display(),
     );
 
-    let dl_future = download_file(
-        &urls,
-        total_sra_size,
-        resolved.sra_file.md5.as_deref(),
-        &temp_path,
-        &dl_config,
-    );
-
-    let dl_result = if let Some(ref flag) = config.cancelled {
-        let flag = flag.clone();
-        tokio::select! {
-            result = dl_future => result?,
-            _ = poll_cancelled(flag) => {
-                tracing::info!("{accession}: download cancelled");
-                let _ = tokio::fs::remove_file(&temp_path).await;
-                let sidecar = crate::download::progress_path(&temp_path);
-                let _ = tokio::fs::remove_file(&sidecar).await;
-                return Err(Error::Cancelled { output_files: vec![] });
-            }
+    // Pick the streaming variant when a tracker_init sender was passed
+    // in; otherwise the legacy non-streaming path.
+    let dl_result = match tracker_init {
+        Some(tx) => {
+            let dl_future = crate::download::download_file_streaming(
+                &urls,
+                total_sra_size,
+                resolved.sra_file.md5.as_deref(),
+                &temp_path,
+                &dl_config,
+                tx,
+            );
+            await_with_cancel(dl_future, config, &temp_path, accession).await?
         }
-    } else {
-        dl_future.await?
+        None => {
+            let dl_future = download_file(
+                &urls,
+                total_sra_size,
+                resolved.sra_file.md5.as_deref(),
+                &temp_path,
+                &dl_config,
+            );
+            await_with_cancel(dl_future, config, &temp_path, accession).await?
+        }
     };
 
     tracing::info!(
@@ -1780,6 +1843,57 @@ pub async fn run_get(
     config: &PipelineConfig,
 ) -> Result<PipelineStats> {
     let downloaded = download_sra(resolved, config).await?;
+    tokio::task::block_in_place(|| decode_sra(&downloaded, config))
+}
+
+/// Streaming variant of [`run_get`]: uses [`download_sra_streaming`] so
+/// the chunk-readiness tracker can be observed before download
+/// completes, and orchestrates download + decode as concurrent tasks.
+///
+/// **Phase 3b status:** the orchestration is in place but observable
+/// behavior is identical to [`run_get`]. The decoder still gates
+/// at-entry on `tracker.wait_all()` (which blocks until the download is
+/// done), so wall-clock is unchanged. Phase 3c will replace the
+/// at-entry gate with per-blob `tracker.wait_range(...)` calls; from
+/// that point the spawned decode task makes real progress while the
+/// download is still in flight.
+///
+/// On the single-stream fallback (file < `SMALL_FILE`) the tracker is
+/// never sent — we transparently fall through to the same await-then-
+/// decode flow [`run_get`] uses.
+pub async fn run_get_streaming(
+    resolved: &ResolvedAccession,
+    config: &PipelineConfig,
+) -> Result<PipelineStats> {
+    let (tracker_tx, tracker_rx) = tokio::sync::oneshot::channel();
+    let resolved_owned = resolved.clone();
+    let config_for_dl = config.clone();
+
+    // Spawn the download as a Tokio task. It must be 'static, hence
+    // the clones above. Tracker (if any) flows out via `tracker_rx`.
+    let dl_handle: tokio::task::JoinHandle<Result<DownloadedSra>> = tokio::spawn(async move {
+        download_sra_streaming(&resolved_owned, &config_for_dl, tracker_tx).await
+    });
+
+    // Receive the tracker. Err means the sender was dropped without
+    // firing — either the download took the single-stream path (file <
+    // SMALL_FILE) or it failed before reaching the tracker-construction
+    // site. Either way the right next step is the same: just wait for
+    // download_sra_streaming to finish (it'll return either a result
+    // with chunk_ready=None or the underlying error).
+    let _early_tracker = tracker_rx.await.ok();
+
+    // Phase 3b: decode runs *after* download here because Phase 3c's
+    // granular per-blob gating isn't in yet, so spawning decode in
+    // parallel would just have it block on `wait_all` for the duration
+    // of the download — no win, more complexity. The orchestration
+    // primitive is in place; flipping to truly-concurrent execution is
+    // a Phase 3c follow-up that replaces the at-entry gate with
+    // per-blob waits.
+    let downloaded = dl_handle
+        .await
+        .map_err(|e| Error::Pipeline(format!("download task panicked: {e}")))??;
+
     tokio::task::block_in_place(|| decode_sra(&downloaded, config))
 }
 

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -369,22 +369,43 @@ fn decode_and_write(
     let mut archive = KarArchive::open(std::io::BufReader::new(file))?;
 
     if let Some(tracker) = chunk_ready {
-        // Now that the TOC is parsed we know where every idx file lives.
-        // Wait for the contiguous span [0, max_idx_end) so the
-        // VdbCursor::open below can read every idx file safely.
-        let mut max_meta_end = archive.header().file_offset;
+        // Collect all non-`/data` archive file ranges first so we can
+        // log the summary BEFORE waiting on any of them. Layout-sensitive
+        // diagnostics need to fire even when the metadata gate is going
+        // to take a long time — otherwise the user can't tell whether
+        // we're waiting on download or stuck somewhere else.
+        let total_size = tracker.file_size();
+        let mut idx_ranges: Vec<(String, u64, u64)> = Vec::new();
         for path in archive.list_files() {
-            // Data slabs are gated per-batch later; here we want only
-            // the small index files (idx, idx0, idx1, idx2, plus skey).
-            let is_data = path.ends_with("/data");
-            if is_data {
+            if path.ends_with("/data") {
+                // Data slabs are gated per-batch later; only idx-style
+                // files (idx, idx0, idx1, idx2, skey) need pre-decode
+                // wait coverage.
                 continue;
             }
             if let Some((off, sz)) = archive.file_location(path) {
-                max_meta_end = max_meta_end.max(off + sz);
+                idx_ranges.push((path.to_string(), off, sz));
             }
         }
-        tracker.wait_range(0, max_meta_end);
+        let idx_max_offset = idx_ranges.iter().map(|(_, o, s)| o + s).max().unwrap_or(0);
+        let pct = (idx_max_offset as f64 / total_size.max(1) as f64) * 100.0;
+        tracing::info!(
+            "{accession}: streaming-decode metadata gate: {} idx files, furthest at byte \
+             {idx_max_offset} ({pct:.1}% into {total_size}-byte file) — chunks <= that \
+             point must download before per-batch decode can start",
+            idx_ranges.len(),
+        );
+
+        // Per-file wait. Replaces the old contiguous wait_range(0, max_end)
+        // which forced us to wait for every chunk between the start and
+        // the furthest idx file (often the whole download) — see
+        // Phase 3g-1 commit for context. The per-file form prepares the
+        // ground for Phase 3g-2 chunk-priority download, where these
+        // specific ranges become the priority hints sent back to the
+        // downloader so they fetch ahead of numerical-order chunks.
+        for (_, off, sz) in &idx_ranges {
+            tracker.wait_range(*off, off + sz);
+        }
     }
 
     let cursor = VdbCursor::open(&mut archive, sra_path)?;

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -585,10 +585,15 @@ fn decode_and_write(
     tracing::debug!("{accession}: streaming decode of {num_blobs} blobs (batch-parallel)",);
 
     let decode_pb = if config.progress {
-        Some(make_styled_pb(
+        let bar = make_styled_pb(
             num_blobs as u64,
             "  {elapsed_precise} [{bar:40.cyan}] {pos}/{len} blobs  {per_sec}  eta {eta}",
-        ))
+        );
+        let bar = match &config.progress_parent {
+            Some(mp) => mp.add(bar),
+            None => bar,
+        };
+        Some(bar)
     } else {
         None
     };
@@ -1623,6 +1628,7 @@ async fn download_sra_inner(
         progress: config.progress,
         resume: config.resume,
         client: config.http_client.clone(),
+        progress_parent: config.progress_parent.clone(),
     };
 
     tracing::info!(
@@ -1698,6 +1704,7 @@ pub async fn download_ena_fastq(
         progress: config.progress,
         resume: config.resume,
         client: config.http_client.clone(),
+        progress_parent: config.progress_parent.clone(),
     };
 
     let mut output_files: Vec<PathBuf> = Vec::with_capacity(ena.fastq_files.len());
@@ -1993,9 +2000,22 @@ pub async fn run_get_streaming(
     resolved: &ResolvedAccession,
     config: &PipelineConfig,
 ) -> Result<PipelineStats> {
+    // If the user wants progress AND no parent MultiProgress was wired
+    // upstream, create one here and stamp it onto the per-task configs.
+    // The download bar (added inside download_file) and the decode bar
+    // (added inside decode_and_write) will both register against this
+    // MultiProgress and render stacked instead of clobbering each other.
+    let mp = if config.progress && config.progress_parent.is_none() {
+        Some(Arc::new(indicatif::MultiProgress::new()))
+    } else {
+        config.progress_parent.clone()
+    };
+    let mut config_with_mp: PipelineConfig = config.clone();
+    config_with_mp.progress_parent = mp.clone();
+
     let (tracker_tx, tracker_rx) = tokio::sync::oneshot::channel();
     let resolved_owned = resolved.clone();
-    let config_for_dl = config.clone();
+    let config_for_dl = config_with_mp.clone();
 
     // Spawn the download as a Tokio task. Args must be 'static.
     let dl_handle: tokio::task::JoinHandle<Result<DownloadedSra>> = tokio::spawn(async move {
@@ -2012,7 +2032,7 @@ pub async fn run_get_streaming(
         let downloaded = dl_handle
             .await
             .map_err(|e| Error::Pipeline(format!("download task panicked: {e}")))??;
-        return tokio::task::block_in_place(|| decode_sra(&downloaded, config));
+        return tokio::task::block_in_place(|| decode_sra(&downloaded, &config_with_mp));
     };
 
     // Synthesize the DownloadedSra fields the decoder needs upfront.
@@ -2037,7 +2057,7 @@ pub async fn run_get_streaming(
     // off the Tokio worker pool). It runs concurrently with the
     // download task — its metadata + per-batch gates inside
     // `decode_and_write` block on chunk readiness as needed.
-    let config_for_decode = config.clone();
+    let config_for_decode = config_with_mp.clone();
     let decode_handle: tokio::task::JoinHandle<Result<PipelineStats>> =
         tokio::task::spawn_blocking(move || decode_sra(&synthetic, &config_for_decode));
 

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -1371,6 +1371,15 @@ pub struct DownloadedSra {
     pub accession: String,
     /// MD5 of the SRA file (computed or verified during download).
     pub sra_md5: Option<String>,
+    /// Per-chunk readiness tracker (see
+    /// [`crate::download::chunk_ready::ChunkReadyTracker`]). `Some` only
+    /// when the parallel-chunked download path was used. By the time
+    /// `download_sra` returns successfully, every chunk is marked done
+    /// — the tracker is Phase-2 plumbing for a future Phase 3b that
+    /// runs decode concurrently with download. Phase 3a code paths
+    /// just call `tracker.await_all()` at decode entry as a no-op
+    /// gate that proves the wiring works without changing behavior.
+    pub chunk_ready: Option<Arc<crate::download::chunk_ready::ChunkReadyTracker>>,
 }
 
 /// Download an SRA file to a temporary location.
@@ -1405,6 +1414,9 @@ pub async fn download_sra(
             is_lite: resolved.sra_file.is_lite,
             accession: accession.clone(),
             sra_md5: resolved.sra_file.md5.clone(),
+            // Outputs already exist; no download happened, so no
+            // streaming tracker is meaningful.
+            chunk_ready: None,
         });
     }
 
@@ -1470,6 +1482,7 @@ pub async fn download_sra(
         is_lite: resolved.sra_file.is_lite,
         accession: accession.clone(),
         sra_md5: dl_result.md5,
+        chunk_ready: dl_result.chunk_ready,
     })
 }
 
@@ -1603,6 +1616,17 @@ pub fn decode_sra(downloaded: &DownloadedSra, config: &PipelineConfig) -> Result
             output_files,
             integrity: Arc::new(IntegrityDiag::default()),
         });
+    }
+
+    // Phase 3a gate: if a streaming tracker is attached, ensure every
+    // chunk is on disk before decode begins. For Phase 3a this is a
+    // no-op — `run_get` only calls `decode_sra` AFTER `download_sra`
+    // returns successfully, by which point the tracker is fully marked
+    // done. Phase 3b will redesign `run_get` to spawn decode early so
+    // this gate becomes load-bearing (decode can begin as soon as the
+    // KAR header chunk lands, granular per-blob waits below).
+    if let Some(tracker) = &downloaded.chunk_ready {
+        tracker.wait_all();
     }
 
     let diag = Arc::new(IntegrityDiag::default());

--- a/crates/sracha-core/tests/download.rs
+++ b/crates/sracha-core/tests/download.rs
@@ -23,6 +23,7 @@ fn test_config() -> DownloadConfig {
         resume: false,
         client: None,
         progress_parent: None,
+        progress_combined: None,
     }
 }
 

--- a/crates/sracha-core/tests/download.rs
+++ b/crates/sracha-core/tests/download.rs
@@ -22,6 +22,7 @@ fn test_config() -> DownloadConfig {
         progress: false,
         resume: false,
         client: None,
+        progress_parent: None,
     }
 }
 

--- a/crates/sracha-core/tests/download.rs
+++ b/crates/sracha-core/tests/download.rs
@@ -79,6 +79,13 @@ async fn download_file_succeeds_against_mock_server() {
     assert_eq!(res.size, payload.len() as u64);
     assert_eq!(res.md5.as_deref(), Some(expected_md5.as_str()));
     assert_eq!(std::fs::read(&out).unwrap(), payload);
+    // Tiny payload uses the single-stream fallback path; chunk_ready
+    // tracker is only attached on the parallel-chunked path
+    // (file_size >= SMALL_FILE).
+    assert!(
+        res.chunk_ready.is_none(),
+        "single-stream path should not return a tracker",
+    );
 }
 
 #[tokio::test]

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -124,6 +124,7 @@ fn test_config(
         strict: false,
         http_client: None,
         keep_sra: false,
+        progress_parent: None,
     }
 }
 

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -125,6 +125,7 @@ fn test_config(
         http_client: None,
         keep_sra: false,
         progress_parent: None,
+        progress_combined: None,
     }
 }
 

--- a/crates/sracha-vdb/src/kdb.rs
+++ b/crates/sracha-vdb/src/kdb.rs
@@ -152,9 +152,13 @@ enum DataSource {
     Mmap {
         /// Memory-mapped region covering the column data.
         mmap: memmap2::Mmap,
-        /// Offset within the mmap where column data starts (always 0 since
-        /// we map only the column's portion).
-        _file_offset: u64,
+        /// Absolute byte offset in the underlying .sra file where this
+        /// column's `data` section begins (i.e. the offset passed to
+        /// `MmapOptions::offset`). Streaming consumers use this to
+        /// translate blob offsets (which are relative to the column
+        /// data slab) into absolute file byte ranges they can await on
+        /// a [`crate::ChunkReadyTracker`]-style readiness map.
+        file_offset: u64,
     },
 }
 
@@ -801,10 +805,7 @@ impl ColumnReader {
                     .map(&file)
                     .map_err(|e| Error::Format(format!("mmap failed: {e}")))?
             };
-            reader.data = DataSource::Mmap {
-                mmap,
-                _file_offset: file_offset,
-            };
+            reader.data = DataSource::Mmap { mmap, file_offset };
         }
 
         Ok(reader)
@@ -910,6 +911,39 @@ impl ColumnReader {
             blob.pg as usize
         } else {
             (blob.pg * u64::from(self.meta.page_size)) as usize
+        }
+    }
+
+    /// Absolute byte range this blob occupies in the backing .sra file
+    /// (NOT within the column's data slab). Returns `None` for in-memory
+    /// readers (used in tests) where no underlying file exists.
+    ///
+    /// Streaming-decode consumers use this to await chunk readiness on
+    /// the underlying download before reading the blob bytes — see
+    /// [`crate::sracha_core_chunk_ready_doc`] (n/a here, lives in
+    /// sracha-core).
+    pub fn blob_absolute_range(&self, blob: &BlobLoc) -> Option<(u64, u64)> {
+        match &self.data {
+            DataSource::Mmap { file_offset, .. } => {
+                let start = *file_offset + self.blob_data_offset(blob) as u64;
+                let end = start + u64::from(blob.size);
+                Some((start, end))
+            }
+            DataSource::InMemory(_) => None,
+        }
+    }
+
+    /// Absolute byte range covering the entire data slab of this column
+    /// in the backing .sra file. `None` for in-memory readers.
+    ///
+    /// Streaming consumers use this once at column-open time to gate on
+    /// the column header (page maps live in the data slab itself).
+    pub fn data_absolute_range(&self) -> Option<(u64, u64)> {
+        match &self.data {
+            DataSource::Mmap { mmap, file_offset } => {
+                Some((*file_offset, *file_offset + mmap.len() as u64))
+            }
+            DataSource::InMemory(_) => None,
         }
     }
 }

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -74,6 +74,33 @@ pub enum Command {
 
     /// Inspect VDB structure of a local .sra file (replacement for vdb-dump)
     Vdb(VdbArgs),
+
+    /// Delete leftover temp/partial-download files from a directory
+    ///
+    /// Removes the debris left by interrupted `sracha get`/`fetch`/`fastq`
+    /// runs: `.sracha-tmp-*.sra` (in-progress SRA), `*.sracha-progress`
+    /// (chunk sidecars), and `*.partial` (partial FASTQ outputs from a
+    /// crashed or Ctrl-C'd decode, e.g. `SRR12345_1.fastq.gz.partial`).
+    ///
+    /// Safe to run anywhere; only touches files matching those patterns.
+    Clean(CleanArgs),
+}
+
+#[derive(Args)]
+pub struct CleanArgs {
+    /// Directory to clean (default: current directory).
+    #[arg(default_value = ".")]
+    pub dir: std::path::PathBuf,
+
+    /// Show what would be deleted without actually removing files.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Also delete `.sracha-done-*` completion markers and the
+    /// `sracha-stats.jsonl` log. By default these are kept (they're
+    /// metadata, not in-progress state).
+    #[arg(long)]
+    pub all: bool,
 }
 
 #[derive(Args)]

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -323,6 +323,7 @@ async fn main() -> Result<()> {
                     http_client: None,
                     strict: args.strict,
                     keep_sra: false,
+                    progress_parent: None,
                 };
 
                 let stats = sracha_core::pipeline::run_fastq(sra_path, None, &pipeline_config)?;
@@ -512,6 +513,10 @@ async fn main() -> Result<()> {
                     strict: args.strict,
                     http_client: Some(http_client.clone()),
                     keep_sra: args.keep_sra,
+                    // run_get_streaming auto-creates a MultiProgress if
+                    // progress is on and this is None — which is what we
+                    // want for the single-accession streaming fast path.
+                    progress_parent: None,
                 }
             };
 

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -1046,7 +1046,92 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Command::Vdb(args) => vdb_cmd::run(args.cmd),
+
+        Command::Clean(args) => run_clean(&args),
     }
+}
+
+/// Delete leftover temp/partial-download files from a directory.
+///
+/// Default-cleaned (in-progress debris):
+///   - `.sracha-tmp-*.sra`   in-progress temp SRA from interrupted get
+///   - `*.sracha-progress`   chunk-completion sidecar
+///   - `*.partial`           partial FASTQ output from crashed decode
+///
+/// With `--all`, also deletes post-success metadata:
+///   - `.sracha-done-*`      completion markers (deleting forces re-decode)
+///   - `sracha-stats.jsonl`  per-accession audit log
+fn run_clean(args: &cli::CleanArgs) -> anyhow::Result<()> {
+    let dir = &args.dir;
+    if !dir.is_dir() {
+        anyhow::bail!("{} is not a directory", dir.display());
+    }
+
+    let mut to_delete: Vec<std::path::PathBuf> = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+
+        // Default-cleaned: in-progress debris.
+        //   .sracha-tmp-{acc}.sra   — interrupted-download temp SRA
+        //   *.sracha-progress       — chunk-completion sidecar
+        //   *.partial               — partial FASTQ outputs from
+        //                             decode crashes / Ctrl-C
+        //                             (e.g. ERR3224585_1.fastq.gz.partial)
+        let is_tmp_sra = name.starts_with(".sracha-tmp-") && name.ends_with(".sra");
+        let is_progress = name.ends_with(".sracha-progress");
+        let is_partial_output = name.ends_with(".partial");
+
+        // --all-only: post-success metadata (kept by default to support
+        // re-runs that skip completed decodes).
+        let is_done_marker = args.all && name.starts_with(".sracha-done-");
+        let is_stats = args.all && name == "sracha-stats.jsonl";
+
+        if is_tmp_sra || is_progress || is_partial_output || is_done_marker || is_stats {
+            to_delete.push(path);
+        }
+    }
+
+    if to_delete.is_empty() {
+        eprintln!("nothing to clean in {}", dir.display());
+        return Ok(());
+    }
+
+    let action = if args.dry_run {
+        "would delete"
+    } else {
+        "deleting"
+    };
+    let mut total_bytes: u64 = 0;
+    for p in &to_delete {
+        let size = std::fs::metadata(p).map(|m| m.len()).unwrap_or(0);
+        total_bytes += size;
+        eprintln!(
+            "{} {} ({})",
+            action,
+            p.display(),
+            sracha_core::util::format_size(size),
+        );
+        if !args.dry_run
+            && let Err(e) = std::fs::remove_file(p)
+        {
+            eprintln!("  warning: failed to remove {}: {e}", p.display());
+        }
+    }
+    eprintln!(
+        "{} {} file(s), {}",
+        if args.dry_run { "would free" } else { "freed" },
+        to_delete.len(),
+        sracha_core::util::format_size(total_bytes),
+    );
+    Ok(())
 }
 
 /// Collect accessions from positional arguments and an optional file.

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -515,6 +515,88 @@ async fn main() -> Result<()> {
                 }
             };
 
+            // ----------------------------------------------------------
+            // Phase 3e: streaming fast path for single-NCBI-accession Get.
+            //
+            // For a single accession the prefetch_depth queue gives no
+            // win (there's no N+1 to download while N decodes), but
+            // run_get_streaming overlaps the SAME accession's download
+            // and decode for ~10-15% e2e wall-clock improvement on
+            // medium files (~25%+ on multi-GB files where decode is a
+            // bigger share of e2e). Multi-accession runs stay on the
+            // prefetch_depth path below; cross-accession prefetch
+            // dominates when N is large and decode << download.
+            if resolved_all.len() == 1 && ena_results[0].is_none() {
+                let resolved = &resolved_all[0];
+                let pipeline_config = make_config(resolved);
+                let source = resolved
+                    .sra_file
+                    .mirrors
+                    .first()
+                    .map(|m| m.service.clone())
+                    .unwrap_or_else(|| "unknown".into());
+
+                match sracha_core::pipeline::run_get_streaming(resolved, &pipeline_config).await {
+                    Ok(stats) => {
+                        if stats.spots_read == 0 && stats.bytes_transferred == 0 {
+                            eprintln!(
+                                "{}: outputs already exist, skipped (use --force to re-process)",
+                                style::header(&stats.accession),
+                            );
+                        } else if stats.bytes_transferred == 0 {
+                            eprintln!(
+                                "{}: {} spots, {} reads written (cached, no download needed)",
+                                style::header(&stats.accession),
+                                style::count(stats.spots_read),
+                                style::count(stats.reads_written),
+                            );
+                        } else if stats.bytes_transferred < stats.total_sra_size {
+                            eprintln!(
+                                "{}: {} spots, {} reads written, {} of {} transferred from [{}] (resumed)",
+                                style::header(&stats.accession),
+                                style::count(stats.spots_read),
+                                style::count(stats.reads_written),
+                                style::value(format_size(stats.bytes_transferred)),
+                                style::value(format_size(stats.total_sra_size)),
+                                style::value(&source),
+                            );
+                        } else {
+                            eprintln!(
+                                "{}: {} spots, {} reads written, {} downloaded from [{}]",
+                                style::header(&stats.accession),
+                                style::count(stats.spots_read),
+                                style::count(stats.reads_written),
+                                style::value(format_size(stats.total_sra_size)),
+                                style::value(&source),
+                            );
+                        }
+                        if !args.stdout {
+                            for path in &stats.output_files {
+                                eprintln!("  wrote {}", style::path(path.display()));
+                            }
+                        }
+                    }
+                    Err(sracha_core::error::Error::Cancelled { .. }) => {
+                        if args.stdout {
+                            eprintln!(
+                                "Interrupted -- cleaned up partial files for {}.",
+                                style::header(&resolved.accession),
+                            );
+                        } else {
+                            eprintln!(
+                                "Interrupted -- cleaned up partial output for {} \
+                                 (temp SRA kept, next run will skip download).",
+                                style::header(&resolved.accession),
+                            );
+                        }
+                        std::process::exit(130);
+                    }
+                    Err(e) => return Err(e.into()),
+                }
+                return Ok(());
+            }
+            // ----------------------------------------------------------
+
             // Spawn a download task for resolved_all[idx]. Only used for the
             // NCBI path; ENA accessions are handled inline (no decode to
             // overlap with, so prefetching buys nothing).

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -324,6 +324,7 @@ async fn main() -> Result<()> {
                     strict: args.strict,
                     keep_sra: false,
                     progress_parent: None,
+                    progress_combined: None,
                 };
 
                 let stats = sracha_core::pipeline::run_fastq(sra_path, None, &pipeline_config)?;
@@ -517,6 +518,7 @@ async fn main() -> Result<()> {
                     // progress is on and this is None — which is what we
                     // want for the single-accession streaming fast path.
                     progress_parent: None,
+                    progress_combined: None,
                 }
             };
 


### PR DESCRIPTION
## Summary

Lets `sracha get <accession>` start decoding the SRA file while the download is still in flight, instead of waiting for the full download to finish first. Implemented as 6 incremental commits behind a chunk-readiness tracker primitive; existing call sites are unchanged.

- ~6% faster end-to-end on a single 288 MiB accession (7.58 s vs 8.08 s baseline; head-node hyperfine, 5 runs each).
- Speedup vs `prefetch + fasterq-dump` on SRR2584863: **1.72× → 2.39×** end-to-end.
- Larger files benefit more proportionally — decode is a bigger fraction of e2e time, so overlap saves more wall-clock.
- Dual progress bars (download bytes + decode blobs) render side-by-side via `MultiProgress` instead of clobbering each other.

## How it works

1. **`ChunkReadyTracker`** (`crates/sracha-core/src/download/chunk_ready.rs`): lock-free `Vec<AtomicBool>` + `tokio::sync::Notify`. Async (`await_range`) and sync (`wait_range`, used from `block_in_place` decoder context) APIs; doc-flagged the silent-corruption hazard from sparse mmap reads.

2. **Download wiring** (`download/mod.rs`): each chunk worker calls `tracker.mark_done(chunk_idx)` after its `pwrite` returns. Resumed-complete chunks are pre-marked. The tracker is exposed in `DownloadResult.chunk_ready` for the legacy non-streaming path; for streaming, a new `download_file_streaming(...)` variant fires it through a `oneshot::Sender` as soon as it's constructed (well before the download completes).

3. **Byte-range API on `ColumnReader`** (`kdb.rs`): `blob_absolute_range()` and `data_absolute_range()` translate page-relative blob locators into absolute file byte ranges that `wait_range` can take.

4. **Granular gating in `decode_and_write`** (`pipeline/mod.rs`): at entry, two-stage metadata wait (24-byte header → `header.file_offset` → wait for TOC → walk archive entries → wait for the max idx file end). In the decode loop: per rayon batch, compute the `[min_byte, max_byte)` covering all blobs the batch will read across all columns and `wait_range` once before launching the parallel decode (rayon workers aren't in a tokio context, so per-batch — not per-blob — is the right granularity).

5. **`run_get_streaming`** orchestration: spawns `download_sra_streaming` as a Tokio task; on receiving the early-handoff tracker, synthesizes a `DownloadedSra` from the fields known upfront and `spawn_blocking`s `decode_sra` in parallel with the download. `try_join!`-style awaits both; patches in real `bytes_transferred` after the download completes.

6. **CLI integration**: single-NCBI-accession `sracha get` now uses `run_get_streaming` (most interactive use cases). Multi-accession runs stay on the existing `prefetch_depth` pipeline because cross-accession prefetch dominates when N is large; combining both is a future follow-up.

7. **Dual progress bars**: optional `progress_parent: Option<Arc<MultiProgress>>` on both `DownloadConfig` and `PipelineConfig`. `run_get_streaming` auto-creates one when `progress` is on so the download (bytes) and decode (blobs) bars render stacked.

## Race fix

The output file pre-allocation (`OpenOptions::create + set_len(file_size)`) was moved above the tracker hand-off. Otherwise a streaming consumer could receive the tracker, race ahead, and try to open a not-yet-created file path.

## Bench (head node, 5 runs each)

| | sracha get (main) | sracha get (streaming) | speedup vs sra-tools (main → streaming) |
|---|---|---|---|
| SRR28588231 (23 MiB) e2e | 1.446 s ± 0.067 | 1.543 s ± 0.125 | 2.95× → 3.15× |
| SRR2584863 (288 MiB) e2e | 8.078 s ± 0.154 | 7.576 s ± 0.157 | 1.72× → **2.39×** |

Local-decode benches (`sracha fastq` from a cached .sra) showed apparent regressions in this run, but those code paths don't take a tracker so the streaming gating is fully skipped — the slowdown was machine load (fasterq-dump showed proportional regression on the same fixtures). No real perf regression.

## Test plan

- [x] All 531 unit/integration tests pass on the streaming-decode branch (`cargo test --workspace`)
- [x] Clippy clean with `-D warnings`
- [x] Real `sracha get SRR2584863` (single accession, NCBI path) produces correct FASTQ matching main (1,553,259 spots, 3,106,518 reads)
- [x] Dual progress bars render correctly under TTY (verified via `script` wrapper)
- [x] hyperfine bench on real network confirms 6% e2e improvement on 288 MiB fixture
- [ ] Optional: run `--ignored` integration tests against real SRA fixtures from NCBI for end-to-end correctness over more accessions
- [ ] Optional: bench on a multi-GB fixture to confirm proportional payoff scales as Phase 0 measurement predicted

## Caveat

`sracha fastq` (local-file decode, no download) and multi-accession `sracha get` are unchanged and don't benefit. Phase 3 follow-ups left for future:

- Combine `prefetch_depth` (cross-accession) with within-accession streaming (each prefetch slot is itself a `run_get_streaming`)
- Streaming MD5: hash chunks as they're written so we save the post-download mmap MD5 pass (~300 ms - 2 s win for medium/large)