### PR TITLE
fix(decode): expand READ 2na data_runs for variable-length rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- **READ 2na `data_runs` expansion for variable-length rows (#22)**:
+  when a READ blob's page map has a non-empty `data_runs` run-length
+  table, consecutive stored rows with identical 2na bytes are written
+  once and replicated on read. The expansion path previously
+  short-circuited whenever `lengths` wasn't uniform, silently
+  dropping the duplicated row and producing a `SpotCountMismatch`
+  plus asymmetric paired output. SRR33907345 blob 46 is the in-tree
+  repro: 4,095 stored rows with variable 70–502-base lengths
+  covering 4,096 logical rows via one `data_runs[i]=2` entry. The
+  decoder now delegates to `PageMap::expand_variable_data_runs` —
+  same path the QUALITY column already uses — which handles both
+  uniform and variable per-row lengths correctly. Covered by the
+  new `variable_length_data_runs_spot_count` regression test.
+
 ## 0.3.2 (2026-04-24)
 
 ### Fixes

--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -330,24 +330,20 @@ pub(crate) fn decode_blob_to_fastq(
 
     // V2 blobs may deduplicate identical rows via the page map's
     // `data_runs` — e.g., two spots with identical base calls get
-    // written once and replicated on read. For fixed-row-length
-    // columns we replicate the 2na-decoded ASCII bytes accordingly so
-    // downstream slicing sees the full logical row count; without this
-    // trailing duplicate rows would drop out at blob boundaries and
-    // every subsequent spot would drift.
+    // written once and replicated on read. Without expansion the
+    // trailing duplicate rows drop out at blob boundaries and every
+    // subsequent spot drifts. Variable per-row lengths (Illumina reads
+    // vary after adapter trim) are the common case, so delegate to
+    // `expand_variable_data_runs` — same approach as the QUALITY path
+    // below. On the unpacked 2na buffer, page_map `lengths` are in
+    // bases per row, matching one byte per base in `read_data`.
     if let Some(ref pm) = read_page_map
         && !pm.data_runs.is_empty()
-        && !pm.lengths.is_empty()
-        && pm.lengths.iter().all(|&l| l == pm.lengths[0])
-        && pm.lengths[0] > 0
     {
-        let row_bytes = pm.lengths[0] as usize;
-        if read_data.len().is_multiple_of(row_bytes) {
-            match pm.expand_data_runs_bytes(&read_data, row_bytes) {
-                Ok(expanded) => read_data = expanded,
-                Err(e) => {
-                    tracing::debug!("blob {blob_idx}: READ expand_data_runs_bytes skipped: {e}");
-                }
+        match pm.expand_variable_data_runs(&read_data) {
+            Ok(expanded) => read_data = expanded,
+            Err(e) => {
+                tracing::debug!("blob {blob_idx}: READ expand_variable_data_runs skipped: {e}");
             }
         }
     }

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -100,6 +100,46 @@ fn ensure_srr10358300() -> PathBuf {
     path
 }
 
+/// Ensure the SRR33907345 fixture (Illumina paired-end, 77 MiB).
+///
+/// This accession regression-tests issue #22: one READ blob (blob 46) uses a
+/// `data_runs` page map with variable per-row base counts, so the decoder
+/// must expand the stored 2na buffer via `PageMap::expand_variable_data_runs`.
+/// The earlier fixed-row-length-only guard silently skipped expansion,
+/// dropping one spot and producing asymmetric paired output.
+fn ensure_srr33907345() -> PathBuf {
+    static DOWNLOAD: Once = Once::new();
+    let path = fixtures_dir().join("SRR33907345.sra");
+
+    DOWNLOAD.call_once(|| {
+        if path.exists() {
+            return;
+        }
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let url = "https://sra-pub-run-odp.s3.amazonaws.com/sra/SRR33907345/SRR33907345";
+        eprintln!("downloading SRR33907345 fixture from {url} ...");
+
+        let resp = reqwest::blocking::get(url)
+            .unwrap_or_else(|e| panic!("failed to download SRR33907345: {e}"));
+        assert!(
+            resp.status().is_success(),
+            "HTTP {} downloading fixture",
+            resp.status()
+        );
+        let bytes = resp.bytes().unwrap();
+        std::fs::write(&path, &bytes).unwrap();
+        eprintln!(
+            "fixture saved to {} ({} bytes)",
+            path.display(),
+            bytes.len()
+        );
+    });
+
+    assert!(path.exists(), "fixture not found at {}", path.display());
+    path
+}
+
 /// Build a `PipelineConfig` suitable for testing.
 fn test_config(
     output_dir: &std::path::Path,
@@ -314,6 +354,41 @@ fn md5_file(path: &std::path::Path) -> String {
     let data = std::fs::read(path).unwrap();
     let hash = Md5::digest(&data);
     hash.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[ignore] // requires network on first run; regression test for issue #22
+#[test]
+fn variable_length_data_runs_spot_count() {
+    // SRR33907345 has 305,571 spots × 2 reads = 611,142 reads. Blob 46's
+    // READ column uses a `data_runs` page map with variable per-row
+    // base counts; before the fix the decoder silently skipped expansion
+    // whenever `pm.lengths` wasn't all equal, dropping one spot and
+    // producing `_1 ≠ _2` asymmetry.
+    let sra_path = ensure_srr33907345();
+    let tmp = tempfile::tempdir().unwrap();
+    let config = test_config(tmp.path(), SplitMode::Split3, CompressionMode::None);
+
+    let stats = sracha_core::pipeline::run_fastq(&sra_path, Some("SRR33907345"), &config).unwrap();
+
+    assert_eq!(stats.spots_read, 305_571, "expected 305,571 spots");
+    assert_eq!(stats.reads_written, 611_142, "expected 611,142 reads");
+    assert_eq!(
+        stats.output_files.len(),
+        2,
+        "paired-end should produce _1 and _2 files"
+    );
+
+    for path in &stats.output_files {
+        let data = std::fs::read(path).unwrap();
+        assert_valid_fastq(&data);
+        let line_count = data.iter().filter(|&&b| b == b'\n').count();
+        assert_eq!(
+            line_count,
+            305_571 * 4,
+            "each paired file should have 305,571 records, got {} lines",
+            line_count,
+        );
+    }
 }
 
 #[ignore] // requires network on first run


### PR DESCRIPTION
Closes #22.

## Summary

- Root cause of SRR33907345 `spot count mismatch: expected 305571, got 305570` is **not** stale NCBI metadata, as the issue hypothesized — it's a decoder bug in sracha.
- When a READ blob's page map carries a non-empty `data_runs` table (identical consecutive 2na rows deduplicated in storage), the existing expansion guard required `pm.lengths` to be uniform. Variable-length rows (Illumina reads after adapter trim) silently skipped expansion → the duplicated row(s) dropped out → the spot count came up short and paired output drifted (`_1 ≠ _2`).
- Fix delegates to `PageMap::expand_variable_data_runs`, the same path QUALITY already uses. Works correctly for both uniform and variable per-row lengths.
- Independently verified against `fasterq-dump` on the same `.sra`: both now report `305,571 spots / 611,142 reads`.

## In-tree repro

SRR33907345 blob 46: 4,095 stored rows with lengths spanning 70–502 bases cover 4,096 logical rows via one `data_runs[i]=2` entry. Every other blob in this archive has `data_runs` empty and is unaffected.

## Test plan

- [x] `cargo test -p sracha-core` — 320 unit tests pass
- [x] `cargo test -p sracha-core -- --ignored` — 28 integration tests pass, including the new `variable_length_data_runs_spot_count` regression (SRR33907345 → 305,571 spots, 611,142 reads, both mate files equal length)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `sracha get SRR33907345` end-to-end: exits 0, 305,571 spots
- [x] Output cross-checked against `fasterq-dump --split-3` on the same archive — byte-parity divergences on this run are limited to pre-existing N-masking and NAME-column whitespace issues in blobs 0 and beyond (orthogonal to this fix; same divergences existed before on uniform-length runs)