### PR TITLE
feat(pipeline): make strict integrity checking the default

### DIFF
--- a/crates/sracha-core/src/fastq/mod.rs
+++ b/crates/sracha-core/src/fastq/mod.rs
@@ -12,8 +12,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// Populated by [`format_read`] / [`format_spot`] and aggregated upstream by
 /// the pipeline. A non-zero count indicates that the run produced output that
 /// had to be repaired (quality padded, invalid bytes coerced to Q30, mate
-/// invariants violated, etc.); surface these to the user and, in
-/// `--strict` mode, treat any non-zero count as a hard failure.
+/// invariants violated, etc.). Under default (strict) mode the pipeline treats
+/// any counter flagged by [`IntegrityDiag::any_strict_fatal`] as a hard failure
+/// and the remaining benign-fallback counters
+/// ([`all_zero_quality_blobs`](Self::all_zero_quality_blobs),
+/// [`truncated_spots`](Self::truncated_spots)) as warnings.
+/// `--no-strict` downgrades all counters to warnings.
 #[derive(Default, Debug)]
 pub struct IntegrityDiag {
     /// Reads whose quality length did not match their sequence length.
@@ -42,6 +46,18 @@ impl IntegrityDiag {
             || self.all_zero_quality_blobs.load(Ordering::Relaxed) != 0
             || self.paired_spot_violations.load(Ordering::Relaxed) != 0
             || self.truncated_spots.load(Ordering::Relaxed) != 0
+    }
+
+    /// Return `true` if any counter that should abort a strict-mode run is
+    /// non-zero. Excludes [`Self::all_zero_quality_blobs`] (expected for
+    /// SRA-lite archives, which ship synthesized quality by design) and
+    /// [`Self::truncated_spots`] (decoder-side truncation fallback — small
+    /// non-zero counts are noise rather than silent corruption).
+    pub fn any_strict_fatal(&self) -> bool {
+        self.quality_length_mismatches.load(Ordering::Relaxed) != 0
+            || self.quality_invalid_bytes.load(Ordering::Relaxed) != 0
+            || self.quality_overruns.load(Ordering::Relaxed) != 0
+            || self.paired_spot_violations.load(Ordering::Relaxed) != 0
     }
 
     /// Human-readable summary used by pipeline stats and stats.json.

--- a/crates/sracha-core/src/pipeline/config.rs
+++ b/crates/sracha-core/src/pipeline/config.rs
@@ -70,7 +70,8 @@ pub struct PipelineStats {
     pub total_sra_size: u64,
     /// Paths of all output files created.
     pub output_files: Vec<PathBuf>,
-    /// Data-integrity counters captured during decode. Inspect these (or
-    /// run with `--strict`) to detect silent corruption.
+    /// Data-integrity counters captured during decode. Strict mode is the
+    /// default; pass `--no-strict` to downgrade any non-zero counter from a
+    /// hard failure to a warning and inspect these values instead.
     pub integrity: Arc<IntegrityDiag>,
 }

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -1013,7 +1013,7 @@ pub fn run_fastq(
 
     if diag.any() {
         let summary = diag.summary();
-        if config.strict {
+        if config.strict && diag.any_strict_fatal() {
             return Err(Error::IntegrityFailure {
                 accession: acc,
                 summary,
@@ -1747,7 +1747,7 @@ pub fn decode_sra(downloaded: &DownloadedSra, config: &PipelineConfig) -> Result
 
     if diag.any() {
         let summary = diag.summary();
-        if config.strict {
+        if config.strict && diag.any_strict_fatal() {
             return Err(Error::IntegrityFailure {
                 accession: downloaded.accession.clone(),
                 summary,

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -319,10 +319,14 @@ pub struct FastqArgs {
     #[arg(long)]
     pub no_progress: bool,
 
-    /// Fail on any data-integrity anomaly (quality length mismatch,
-    /// paired-spot violations, truncated reads). Off by default.
+    /// Disable strict integrity checking. By default, sracha fails on any
+    /// data-integrity anomaly it cannot silently fall back on (quality length
+    /// mismatch, invalid quality bytes, quality overruns, paired-spot
+    /// violations); pass this flag to downgrade those failures to warnings.
+    /// Benign-fallback counters (SRA-lite all-zero quality blobs and
+    /// truncated-spot recovery) stay informational either way.
     #[arg(long, help_heading = "Advanced")]
-    pub strict: bool,
+    pub no_strict: bool,
 }
 
 #[derive(Args)]
@@ -436,10 +440,14 @@ pub struct GetArgs {
     #[arg(long, help_heading = "Advanced")]
     pub prefer_sdl: bool,
 
-    /// Fail on any data-integrity anomaly (quality length mismatch,
-    /// paired-spot violations, truncated reads). Off by default.
+    /// Disable strict integrity checking. By default, sracha fails on any
+    /// data-integrity anomaly it cannot silently fall back on (quality length
+    /// mismatch, invalid quality bytes, quality overruns, paired-spot
+    /// violations); pass this flag to downgrade those failures to warnings.
+    /// Benign-fallback counters (SRA-lite all-zero quality blobs and
+    /// truncated-spot recovery) stay informational either way.
     #[arg(long, help_heading = "Advanced")]
-    pub strict: bool,
+    pub no_strict: bool,
 
     /// Keep the downloaded SRA file in the output directory instead of
     /// deleting it after decode. Useful for validation runs that want

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -321,7 +321,7 @@ async fn main() -> Result<()> {
                     stdout: args.stdout,
                     cancelled: None,
                     http_client: None,
-                    strict: args.strict,
+                    strict: !args.no_strict,
                     keep_sra: false,
                 };
 
@@ -509,7 +509,7 @@ async fn main() -> Result<()> {
                     resume: !args.no_resume,
                     stdout: args.stdout,
                     cancelled: Some(cancelled.clone()),
-                    strict: args.strict,
+                    strict: !args.no_strict,
                     http_client: Some(http_client.clone()),
                     keep_sra: args.keep_sra,
                 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -102,7 +102,7 @@ sracha get [OPTIONS] [ACCESSION]...
 | `--prefetch-depth <N>` | `2` | Number of accessions to download ahead of the decoder. Larger values hide slow networks behind decode at the cost of one extra temp SRA file per step. Multi-accession `get` only |
 | `--keep-sra` | | Keep the downloaded SRA file in the output directory instead of deleting it after decode |
 | `--no-progress` | | Disable progress bar |
-| `--strict` | | Fail on data-integrity anomalies (quality length mismatch, paired-spot violations, truncated reads) |
+| `--no-strict` | | Downgrade strict-fatal data-integrity anomalies (quality length mismatch, invalid quality bytes, quality overruns, paired-spot violations) from hard failures to warnings. Strict is the default. Benign-fallback counters (SRA-lite all-zero quality blobs, truncated-spot recovery) stay informational either way |
 
 ---
 
@@ -180,7 +180,7 @@ sracha fastq [OPTIONS] <INPUT>...
 | `-O, --output-dir <DIR>` | `.` | Output directory |
 | `-f, --force` | | Overwrite existing files |
 | `--no-progress` | | Disable progress bar |
-| `--strict` | | Fail on data-integrity anomalies (quality length mismatch, paired-spot violations, truncated reads) |
+| `--no-strict` | | Downgrade strict-fatal data-integrity anomalies (quality length mismatch, invalid quality bytes, quality overruns, paired-spot violations) from hard failures to warnings. Strict is the default. Benign-fallback counters (SRA-lite all-zero quality blobs, truncated-spot recovery) stay informational either way |
 
 ---
 


### PR DESCRIPTION
## Summary

- Flip the CLI surface from opt-in `--strict` to opt-out `--no-strict` so silent-corruption counters (quality length mismatches, invalid quality bytes, quality overruns, paired-spot violations) abort the run by default.
- Split the integrity counters into strict-fatal vs. benign-fallback via `IntegrityDiag::any_strict_fatal`. `all_zero_quality_blobs` (SRA-lite synthetic quality by design) and `truncated_spots` (decoder-side truncation recovery) stay informational in both modes — they are expected fallbacks, not silent-data-loss signals.

## Why

Under opt-in `--strict`, a run with real data corruption (say, invalid Phred bytes being silently coerced to Q30) produces technically-valid FASTQ that a downstream pipeline will happily consume. Strict-by-default catches that class of bug at decode time rather than at analysis time. The benign-counter carve-out keeps strict-by-default usable: SRA-lite archives ship all-zero quality blobs on purpose, and low-count truncation recoveries (a handful of spots out of millions) are noise rather than corruption.

## Validation

30-accession random corpus via `validation/random_corpus.sh`:

| status | count |
|---|---|
| PASS_CONTENT | 19 |
| PASS_MD5 | 3 |
| REJECT_VARIANT2 | 3 |
| FAIL_COUNT | 2 |
| FAIL_SEQ | 3 |

Zero `FAIL_SRACHA` (strict aborts). The 5 `FAIL_COUNT`/`FAIL_SEQ` cases are pre-existing decoder-correctness bugs unrelated to this change; they'll be tracked separately.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --profile release`
- [x] 30-accession random corpus (`validation/random_corpus.sh --sbatch`) — zero strict-mode aborts
- [x] Spot-checked the two accessions (DRR032843, DRR034452) that regressed under naïve strict-default: both now complete with warnings only