### PR TITLE
feat(validation): mismatch_report harness for FAIL_SEQ diagnosis

### DIFF
--- a/validation/mismatch_report.py
+++ b/validation/mismatch_report.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Structured diagnostic report for paired FASTQ outputs that disagree.
+
+Given two FASTQs of the same records (typically sracha vs. fasterq-dump),
+classifies mismatched records and emits:
+
+  summary.tsv   — totals, record-level class counts, position-bucket histogram
+  confusion.tsv — 5x5 base confusion matrix (A/C/G/T/N)
+  positions.tsv — per-position mismatch counts across the read length
+  samples.txt   — first N mismatched records with a caret indicator
+
+Record classes:
+
+  IDENTICAL      both sequences match exactly
+  N_MASK_ONLY    equal length; every differing position has exactly one side = N
+  BASE_FLIP      equal length; no N at any differing position
+  MIXED          equal length; some N-mask positions and some base-flip positions
+  LENGTH_DIFF    sequences differ in length
+"""
+import argparse
+import os
+import sys
+from collections import Counter
+
+
+BASES = ("A", "C", "G", "T", "N")
+BASE_INDEX = {b: i for i, b in enumerate(BASES)}
+OTHER = len(BASES)  # catch-all bucket for anything outside ACGTN
+
+
+def classify_record(seq_a, seq_b):
+    """Return (class, diff_positions) for one record pair.
+
+    diff_positions is a list of (i, char_a, char_b) for each mismatched index,
+    or None if the record class is IDENTICAL or LENGTH_DIFF (no per-position
+    comparison is valid for length-mismatched reads in this pass).
+    """
+    if seq_a == seq_b:
+        return "IDENTICAL", None
+    if len(seq_a) != len(seq_b):
+        return "LENGTH_DIFF", None
+
+    diffs = [(i, seq_a[i], seq_b[i]) for i in range(len(seq_a)) if seq_a[i] != seq_b[i]]
+    saw_n_mask = False
+    saw_base_flip = False
+    for _, ca, cb in diffs:
+        if ca == "N" or cb == "N":
+            saw_n_mask = True
+        else:
+            saw_base_flip = True
+        if saw_n_mask and saw_base_flip:
+            break
+    if saw_n_mask and not saw_base_flip:
+        return "N_MASK_ONLY", diffs
+    if saw_base_flip and not saw_n_mask:
+        return "BASE_FLIP", diffs
+    return "MIXED", diffs
+
+
+def bucket_index(pos, length, n_buckets):
+    if length <= 0:
+        return 0
+    idx = int(pos * n_buckets / length)
+    return min(idx, n_buckets - 1)
+
+
+def iter_fastq(path):
+    with open(path) as fh:
+        while True:
+            defline = fh.readline()
+            if not defline:
+                return
+            seq = fh.readline()
+            plus = fh.readline()
+            qual = fh.readline()
+            if not qual:
+                return
+            yield (
+                defline.rstrip("\n"),
+                seq.rstrip("\n"),
+                plus.rstrip("\n"),
+                qual.rstrip("\n"),
+            )
+
+
+def format_sample(record_num, class_, defline_a, seq_a, defline_b, seq_b,
+                  label_a, label_b, diffs, preview_len=120):
+    # Pad the leading label column so sequence / diff rows line up under each
+    # other. Column width accommodates "  {longer_label} seq:  ".
+    col_width = max(len(label_a), len(label_b), len("diff")) + len("  _ seq:  ")
+
+    def prefix(text):
+        return f"  {text}:".ljust(col_width)
+
+    lines = [f"# record {record_num}  class={class_}"]
+    lines.append(f"{prefix(label_a + ' name')}{defline_a[:preview_len]}")
+    lines.append(f"{prefix(label_b + ' name')}{defline_b[:preview_len]}")
+
+    if class_ == "LENGTH_DIFF":
+        lines.append(
+            f"  len: {label_a}={len(seq_a)}  {label_b}={len(seq_b)}"
+        )
+        lines.append(f"{prefix(label_a + ' seq')}{seq_a[:preview_len]}")
+        lines.append(f"{prefix(label_b + ' seq')}{seq_b[:preview_len]}")
+        lines.append("")
+        return "\n".join(lines)
+
+    caret = ["."] * min(len(seq_a), preview_len)
+    for i, _, _ in diffs or []:
+        if i < preview_len:
+            caret[i] = "^"
+
+    lines.append(f"{prefix(label_a + ' seq')}{seq_a[:preview_len]}")
+    lines.append(f"{prefix(label_b + ' seq')}{seq_b[:preview_len]}")
+    lines.append(f"{prefix('diff')}{''.join(caret)}")
+    if diffs:
+        first = diffs[0]
+        lines.append(
+            f"  first diff: pos={first[0]} "
+            f"{label_a}={first[1]!r} {label_b}={first[2]!r}  "
+            f"total_diffs={len(diffs)}"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def run(file_a, file_b, out_dir, max_samples, label_a, label_b,
+        position_buckets, quiet):
+    os.makedirs(out_dir, exist_ok=True)
+
+    class_counts = Counter()
+    confusion = [[0] * (OTHER + 1) for _ in range(OTHER + 1)]
+    position_hist = [0] * position_buckets
+    total_records = 0
+    qual_mismatches = 0
+    qual_len_errors_a = 0
+    qual_len_errors_b = 0
+    saved_samples = 0
+    read_length = None  # establish from first identical-length record
+
+    samples_path = os.path.join(out_dir, "samples.txt")
+    with open(samples_path, "w") as samples_fh:
+        for (rec_a, rec_b) in zip(iter_fastq(file_a), iter_fastq(file_b)):
+            total_records += 1
+            defline_a, seq_a, _plus_a, qual_a = rec_a
+            defline_b, seq_b, _plus_b, qual_b = rec_b
+
+            # Quality length invariant (per-file)
+            if len(qual_a) != len(seq_a):
+                qual_len_errors_a += 1
+            if len(qual_b) != len(seq_b):
+                qual_len_errors_b += 1
+
+            # Quality identity (we still report, but it's not the focus)
+            if qual_a != qual_b:
+                qual_mismatches += 1
+
+            class_, diffs = classify_record(seq_a, seq_b)
+            class_counts[class_] += 1
+
+            if class_ == "IDENTICAL":
+                continue
+
+            if class_ != "LENGTH_DIFF" and read_length is None:
+                read_length = len(seq_a)
+
+            if diffs:
+                use_length = read_length if read_length is not None else max(len(seq_a), 1)
+                for pos, ca, cb in diffs:
+                    row = BASE_INDEX.get(ca, OTHER)
+                    col = BASE_INDEX.get(cb, OTHER)
+                    confusion[row][col] += 1
+                    position_hist[bucket_index(pos, use_length, position_buckets)] += 1
+
+            if saved_samples < max_samples:
+                samples_fh.write(format_sample(
+                    total_records, class_,
+                    defline_a, seq_a, defline_b, seq_b,
+                    label_a, label_b, diffs,
+                ))
+                saved_samples += 1
+
+    # zip() truncates to the shorter file; do a separate count pass so we can
+    # surface file-length mismatches.
+    count_a = sum(1 for _ in iter_fastq(file_a))
+    count_b = sum(1 for _ in iter_fastq(file_b))
+    truncated_compare = (count_a != count_b)
+
+    # Emit summary.tsv
+    summary_path = os.path.join(out_dir, "summary.tsv")
+    total_diffs = sum(sum(row) for row in confusion)
+    with open(summary_path, "w") as fh:
+        fh.write("metric\tvalue\n")
+        fh.write(f"file_a\t{file_a}\n")
+        fh.write(f"file_b\t{file_b}\n")
+        fh.write(f"label_a\t{label_a}\n")
+        fh.write(f"label_b\t{label_b}\n")
+        fh.write(f"records_compared\t{total_records}\n")
+        fh.write(f"records_in_{label_a}\t{count_a}\n")
+        fh.write(f"records_in_{label_b}\t{count_b}\n")
+        fh.write(f"file_length_mismatch\t{int(truncated_compare)}\n")
+        fh.write(f"read_length_sample\t{read_length if read_length is not None else 0}\n")
+        for cls in ("IDENTICAL", "N_MASK_ONLY", "BASE_FLIP", "MIXED", "LENGTH_DIFF"):
+            fh.write(f"class_{cls}\t{class_counts.get(cls, 0)}\n")
+        fh.write(f"quality_mismatch_records\t{qual_mismatches}\n")
+        fh.write(f"quality_length_errors_{label_a}\t{qual_len_errors_a}\n")
+        fh.write(f"quality_length_errors_{label_b}\t{qual_len_errors_b}\n")
+        fh.write(f"total_position_diffs\t{total_diffs}\n")
+
+        seq_mismatch_records = (total_records - class_counts.get("IDENTICAL", 0))
+        if seq_mismatch_records > 0:
+            n_only = class_counts.get("N_MASK_ONLY", 0)
+            fh.write(
+                f"n_mask_only_fraction\t"
+                f"{n_only / seq_mismatch_records:.4f}\n"
+            )
+        else:
+            fh.write("n_mask_only_fraction\t0.0000\n")
+
+        for i, count in enumerate(position_hist):
+            fh.write(f"position_bucket_{i}_of_{position_buckets}\t{count}\n")
+
+    # Emit confusion.tsv
+    confusion_path = os.path.join(out_dir, "confusion.tsv")
+    with open(confusion_path, "w") as fh:
+        header = [f"{label_a}\\{label_b}"] + list(BASES) + ["OTHER"]
+        fh.write("\t".join(header) + "\n")
+        for i, row_label in enumerate(list(BASES) + ["OTHER"]):
+            cells = [row_label] + [str(confusion[i][j]) for j in range(OTHER + 1)]
+            fh.write("\t".join(cells) + "\n")
+
+    # Emit positions.tsv
+    positions_path = os.path.join(out_dir, "positions.tsv")
+    with open(positions_path, "w") as fh:
+        fh.write("bucket\tstart_pos\tend_pos\tmismatches\n")
+        if read_length is not None and read_length > 0:
+            for i, count in enumerate(position_hist):
+                start = int(i * read_length / position_buckets)
+                end = int((i + 1) * read_length / position_buckets) - 1
+                fh.write(f"{i}\t{start}\t{end}\t{count}\n")
+        else:
+            for i, count in enumerate(position_hist):
+                fh.write(f"{i}\t-\t-\t{count}\n")
+
+    if not quiet:
+        print(f"=== mismatch_report: {file_a} vs {file_b} ===")
+        print(f"  records compared:  {total_records:,}")
+        if truncated_compare:
+            print(
+                f"  WARNING: file length mismatch "
+                f"({label_a}={count_a:,} {label_b}={count_b:,})"
+            )
+        for cls in ("IDENTICAL", "N_MASK_ONLY", "BASE_FLIP", "MIXED", "LENGTH_DIFF"):
+            pct = (100 * class_counts.get(cls, 0) / total_records) if total_records else 0
+            print(f"  {cls:<12} {class_counts.get(cls, 0):>12,}  ({pct:5.1f}%)")
+        print(f"  total position diffs: {total_diffs:,}")
+        if total_diffs > 0:
+            n_col = sum(confusion[i][BASE_INDEX['N']] for i in range(OTHER + 1))
+            n_row = sum(confusion[BASE_INDEX['N']][j] for j in range(OTHER + 1))
+            print(
+                f"  {label_a}→N positions: {n_row:,} "
+                f"({100 * n_row / total_diffs:.1f}%)"
+            )
+            print(
+                f"  {label_b}→N positions: {n_col:,} "
+                f"({100 * n_col / total_diffs:.1f}%)"
+            )
+        print(f"  report dir:        {out_dir}")
+
+    return {
+        "total_records": total_records,
+        "class_counts": dict(class_counts),
+        "total_diffs": total_diffs,
+        "truncated_compare": truncated_compare,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Structured mismatch report for two FASTQ files"
+    )
+    parser.add_argument("file_a", help="First FASTQ (typically sracha output)")
+    parser.add_argument("file_b", help="Second FASTQ (typically fasterq-dump output)")
+    parser.add_argument(
+        "--out-dir", default=None,
+        help="Directory to write reports (default: ./mismatch-report-<basename>)",
+    )
+    parser.add_argument("--max-samples", type=int, default=50)
+    parser.add_argument("--label-a", default="sracha")
+    parser.add_argument("--label-b", default="fasterq")
+    parser.add_argument("--position-buckets", type=int, default=20)
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args()
+
+    out_dir = args.out_dir or f"./mismatch-report-{os.path.basename(args.file_a)}"
+    stats = run(
+        args.file_a, args.file_b, out_dir,
+        args.max_samples, args.label_a, args.label_b,
+        args.position_buckets, args.quiet,
+    )
+    # Exit code: 0 if all records identical, 1 otherwise. Useful for scripting.
+    sys.exit(0 if stats["class_counts"].get("IDENTICAL", 0) == stats["total_records"]
+             and not stats["truncated_compare"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/mismatch_report.sh
+++ b/validation/mismatch_report.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# Deep-dive diagnostic on a single SRA accession (or local .sra file):
+# runs sracha fastq + fasterq-dump on the same input and produces a
+# structured mismatch report via validation/mismatch_report.py.
+#
+# Usage:
+#   bash validation/mismatch_report.sh <ACC|PATH> [--split split-3] [--out DIR]
+#
+# Example:
+#   bash validation/mismatch_report.sh DRR035183
+#   bash validation/mismatch_report.sh /path/to/local.sra
+#
+# Writes reports to:
+#   validation/mismatch-reports/<YYYYMMDD-HHMMSS>/<ACC>/<slot>/
+# where <slot> is "_1", "_2", or "unpaired" depending on split-3 output.
+
+set -uo pipefail
+
+# ---------- args ----------
+INPUT=""
+SPLIT="split-3"
+OUT_BASE=""
+MAX_SAMPLES=50
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --split)        SPLIT="$2"; shift 2 ;;
+        --out)          OUT_BASE="$2"; shift 2 ;;
+        --max-samples)  MAX_SAMPLES="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '3,15p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            if [[ -z "$INPUT" ]]; then INPUT="$1"; shift
+            else echo "unexpected arg: $1" >&2; exit 2
+            fi
+            ;;
+    esac
+done
+
+if [[ -z "$INPUT" ]]; then
+    echo "usage: $(basename "$0") <ACC|PATH> [--split MODE] [--out DIR]" >&2
+    exit 2
+fi
+
+# ---------- paths ----------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SRACHA="${SRACHA:-$ROOT_DIR/target/release/sracha}"
+REPORT_PY="$SCRIPT_DIR/mismatch_report.py"
+
+if [[ ! -x "$SRACHA" ]]; then
+    echo "ERROR: sracha binary not found at $SRACHA" >&2
+    echo "  set SRACHA=<path> or run 'cargo build --release'" >&2
+    exit 1
+fi
+
+# ---------- decide accession vs local file ----------
+if [[ -f "$INPUT" ]]; then
+    SRA_FILE="$INPUT"
+    ACC=$(basename "$INPUT" .sra)
+    ACC=$(basename "$ACC" .sralite)
+    FETCH_NEEDED=0
+else
+    ACC="$INPUT"
+    FETCH_NEEDED=1
+fi
+
+# ---------- output layout ----------
+TS=$(date +%Y%m%d-%H%M%S)
+if [[ -z "$OUT_BASE" ]]; then
+    OUT_BASE="$ROOT_DIR/validation/mismatch-reports/$TS/$ACC"
+fi
+mkdir -p "$OUT_BASE"
+WORK_DIR="$OUT_BASE/work"
+mkdir -p "$WORK_DIR" "$WORK_DIR/sracha" "$WORK_DIR/fasterq"
+
+echo "# mismatch_report driver"
+echo "#   input:       $INPUT"
+echo "#   accession:   $ACC"
+echo "#   split:       $SPLIT"
+echo "#   output dir:  $OUT_BASE"
+echo
+
+# ---------- fetch via sracha (if accession) ----------
+if [[ $FETCH_NEEDED -eq 1 ]]; then
+    echo "=== sracha fetch $ACC ==="
+    if ! "$SRACHA" fetch "$ACC" -O "$WORK_DIR" --no-progress; then
+        echo "ERROR: sracha fetch failed" >&2
+        exit 1
+    fi
+    SRA_FILE=$(find "$WORK_DIR" -maxdepth 2 -type f \( -name '*.sra' -o -name '*.sralite' \) | head -1)
+    if [[ -z "$SRA_FILE" ]]; then
+        echo "ERROR: no .sra file found after fetch" >&2
+        exit 1
+    fi
+    echo "  got: $SRA_FILE"
+    echo
+fi
+
+# ---------- sracha fastq ----------
+echo "=== sracha fastq ==="
+if ! "$SRACHA" fastq "$SRA_FILE" --split "$SPLIT" --no-gzip \
+        -O "$WORK_DIR/sracha" -f --no-progress; then
+    echo "ERROR: sracha fastq failed" >&2
+    exit 1
+fi
+echo
+
+# ---------- fasterq-dump ----------
+# Resolve fasterq-dump. Per `reference_sra_tools_module.md` the system
+# `sratoolkit/3.2.1` module ships a binary that matches sra-tools parity
+# (pixi's 3.4.1 segfaults). Use $FASTERQ_DUMP if set, else fall back to
+# PATH, else the hardcoded module path.
+echo "=== fasterq-dump ==="
+FASTERQ_DUMP="${FASTERQ_DUMP:-}"
+if [[ -z "$FASTERQ_DUMP" ]]; then
+    if command -v fasterq-dump >/dev/null 2>&1; then
+        FASTERQ_DUMP="$(command -v fasterq-dump)"
+    elif [[ -x /cluster/software/modules-sw/sratoolkit/3.2.1/bin/fasterq-dump ]]; then
+        FASTERQ_DUMP=/cluster/software/modules-sw/sratoolkit/3.2.1/bin/fasterq-dump
+    else
+        echo "ERROR: fasterq-dump not found — set FASTERQ_DUMP=<path> or 'module load sratoolkit/3.2.1'" >&2
+        exit 1
+    fi
+fi
+echo "  using: $FASTERQ_DUMP"
+mkdir -p "$WORK_DIR/fasterq/tmp"
+if ! "$FASTERQ_DUMP" "$SRA_FILE" "--${SPLIT}" -O "$WORK_DIR/fasterq" \
+        -f -t "$WORK_DIR/fasterq/tmp" >/dev/null 2>&1; then
+    echo "ERROR: fasterq-dump failed" >&2
+    exit 1
+fi
+rm -rf "$WORK_DIR/fasterq/tmp"
+echo "  fasterq-dump output ready"
+echo
+
+# ---------- pair up files by suffix ----------
+compare_pair() {
+    local srach="$1"
+    local fasterq="$2"
+    local slot="$3"
+
+    if [[ ! -f "$srach" ]]; then
+        echo "  skip $slot: sracha missing $(basename "$srach")"
+        return
+    fi
+    if [[ ! -f "$fasterq" ]]; then
+        echo "  skip $slot: fasterq-dump missing $(basename "$fasterq")"
+        return
+    fi
+
+    local slot_out="$OUT_BASE/$slot"
+    mkdir -p "$slot_out"
+    echo "--- $slot: $(basename "$srach") vs $(basename "$fasterq") ---"
+    python3 "$REPORT_PY" "$srach" "$fasterq" \
+        --out-dir "$slot_out" \
+        --max-samples "$MAX_SAMPLES" \
+        --label-a sracha --label-b fasterq
+    echo
+}
+
+case "$SPLIT" in
+    split-3)
+        compare_pair "$WORK_DIR/sracha/${ACC}_1.fastq" "$WORK_DIR/fasterq/${ACC}_1.fastq" "_1"
+        compare_pair "$WORK_DIR/sracha/${ACC}_2.fastq" "$WORK_DIR/fasterq/${ACC}_2.fastq" "_2"
+        compare_pair "$WORK_DIR/sracha/${ACC}.fastq"   "$WORK_DIR/fasterq/${ACC}.fastq"   "unpaired"
+        ;;
+    split-files)
+        for n in 1 2 3 4; do
+            compare_pair "$WORK_DIR/sracha/${ACC}_${n}.fastq" \
+                         "$WORK_DIR/fasterq/${ACC}_${n}.fastq" "_${n}"
+        done
+        ;;
+    split-spot|interleaved)
+        compare_pair "$WORK_DIR/sracha/${ACC}.fastq" "$WORK_DIR/fasterq/${ACC}.fastq" "all"
+        ;;
+    *)
+        echo "ERROR: unsupported split mode '$SPLIT'" >&2
+        exit 2
+        ;;
+esac
+
+echo "done — reports under: $OUT_BASE"


### PR DESCRIPTION
## Summary

- New `validation/mismatch_report.py` — record-level FASTQ diff that classifies each differing record as `IDENTICAL` / `N_MASK_ONLY` / `BASE_FLIP` / `MIXED` / `LENGTH_DIFF`, and emits a 5×5 A/C/G/T/N confusion matrix + per-position histogram.
- New `validation/mismatch_report.sh` — driver that fetches an accession, runs `sracha fastq` + `fasterq-dump` on the same `.sra`, and invokes the Python reporter for each `_1` / `_2` / unpaired slot.
- `FASTERQ_DUMP` and `SRACHA` env overrides so the harness doesn't need `cargo build --release` in every worktree.

## Why

`random_corpus.sh` buckets a run as `FAIL_SEQ` as soon as any sequence byte disagrees with fasterq-dump, so several of our "loud decoder bugs" were reported as opaque ~84%-94% mismatch-rate incidents with no way to tell whether sracha was emitting wrong bases or just making different masking decisions. Running the new harness on the 5 accessions recently reclassified from `FAIL_COUNT`/`FAIL_SEQ` → `FAIL_SEQ` (after PR #24) gave a definitive answer: **every single mismatch is `N_MASK_ONLY`** — zero `BASE_FLIP`, zero `MIXED`. The underlying 2na bases are correct; sracha and fasterq-dump just apply different N-masking rules.

Headline data from `DRR035183` (214bp paired ILLUMINA, 644k spots):

```
_1: 475,037 / 644,410 records N_MASK_ONLY (73.7%), 0 BASE_FLIP
    sracha→N positions: 15,229,066 (91.4%)
    fasterq→N positions:  1,429,795  (8.6%)

_2: 608,827 / 644,410 records N_MASK_ONLY (94.5%), 0 BASE_FLIP
    sracha→N positions:  7,262,236 (25.6%)
    fasterq→N positions: 21,061,507 (74.4%)
```

The masking-direction asymmetry between mates (sracha stricter on `_1`, fasterq stricter on `_2`) and the A→N skew on `_2` (17.3M vs ~1.25M each for C/G/T) are leads for the decoder investigation on `worktree-altread-data-runs`.

## Test plan

- [x] Synthetic 5-record fixture covering every record class (verified classification, confusion matrix, position buckets by hand)
- [x] DRR034519 (smallest FAIL_SEQ, 504k spots) — harness reports 100% `N_MASK_ONLY`
- [x] DRR035183 (largest FAIL_SEQ signal, 644k spots, 214bp) — harness reports 100% `N_MASK_ONLY` + surfaces the A→N skew and read-end clustering
- [ ] Run against a `PASS_CONTENT` accession from a prior corpus to confirm zero-mismatch path

## Scope

Diagnostic only. No decoder changes, no modification of `random_corpus.sh`, no CI integration. Out-of-scope follow-ups (captured for whoever picks up decoder work):

- Consider wiring `--allow-n-masking` into `random_corpus.sh`'s compare invocation so N-only disagreements get classified separately from `FAIL_SEQ`.
- Root-cause the per-mate masking rule divergence uncovered by the harness.