### PR TITLE
test: close audit holes in regression/integration suite

### DIFF
--- a/crates/sracha-core/tests/download.rs
+++ b/crates/sracha-core/tests/download.rs
@@ -268,3 +268,14 @@ async fn download_file_force_overwrites_existing_even_when_complete() {
     );
     assert_eq!(std::fs::read(&out).unwrap(), payload);
 }
+
+// NOTE — a full sidecar-driven resume test (pre-populated `.sracha-progress`
+// + partial file → only missing chunks re-fetched) is deliberately absent.
+// The sidecar-aware branch in `download_file` only engages when
+// `file_size >= SMALL_FILE` (32 MiB) so the parallel path is chosen, AND
+// when the existing file doesn't already pass the pre-download MD5
+// shortcut. Crossing both thresholds with an in-process mock requires a
+// Range-aware HTTP server (wiremock's matchers can't condition the
+// response body on the `Range` header), plus a 32+ MiB payload per
+// invocation. Left as a follow-up once either constraint is addressed
+// (custom hyper-based mock, or a tunable SMALL_FILE exposed in config).

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -140,6 +140,98 @@ fn ensure_srr33907345() -> PathBuf {
     path
 }
 
+/// Ensure the SRR000001 fixture (LS454 / 454 GS FLX).
+///
+/// Covers the legacy-platform rejection path end-to-end: 454 is in the
+/// `UNSUPPORTED_PLATFORMS` list in pipeline/mod.rs, and decode_and_write
+/// must surface `Error::UnsupportedPlatform` when it encounters one
+/// rather than panicking or producing garbage FASTQ. The unit test at
+/// `unsupported_platforms_rejected` only covers the string check in
+/// isolation; this test exercises the rejection against a real archive's
+/// parsed platform code.
+fn ensure_srr000001() -> PathBuf {
+    static DOWNLOAD: Once = Once::new();
+    let path = fixtures_dir().join("SRR000001.sra");
+
+    DOWNLOAD.call_once(|| {
+        if path.exists() {
+            return;
+        }
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let url = "https://sra-pub-run-odp.s3.amazonaws.com/sra/SRR000001/SRR000001";
+        eprintln!("downloading SRR000001 fixture from {url} ... (large, 312 MiB)");
+
+        let resp = reqwest::blocking::get(url)
+            .unwrap_or_else(|e| panic!("failed to download SRR000001: {e}"));
+        assert!(
+            resp.status().is_success(),
+            "HTTP {} downloading SRR000001 fixture",
+            resp.status()
+        );
+        let bytes = resp.bytes().unwrap();
+        std::fs::write(&path, &bytes).unwrap();
+    });
+
+    assert!(path.exists(), "fixture not found at {}", path.display());
+    path
+}
+
+/// Ensure the VDB-3418 fixture (BAM-loaded cSRA, 12 MiB, 985 SEQUENCE /
+/// 938 PRIMARY_ALIGNMENT rows; schema `NCBI:align:db:alignment_sorted#1.3`).
+///
+/// Used by every `csra_*` test to exercise reference-compressed alignment
+/// decode (HAS_MISMATCH / REF_OFFSET / align_restore_read) end-to-end.
+/// The fixture is shipped with ncbi-vdb's test suite and fetched from its
+/// GitHub mirror; pinning to `master` is tolerable since this is a long-
+/// lived test asset — if upstream deletes or reshapes it the download 404s
+/// and we notice at test time rather than silently skipping.
+fn ensure_vdb_3418() -> PathBuf {
+    static DOWNLOAD: Once = Once::new();
+    let path = fixtures_dir().join("VDB-3418.sra");
+    const EXPECTED_SIZE: u64 = 12_887_839;
+    const EXPECTED_MD5: &str = "7d66f3f346db0f916a8c723d40087b6c";
+
+    DOWNLOAD.call_once(|| {
+        if path.exists() {
+            return;
+        }
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let url = "https://raw.githubusercontent.com/ncbi/ncbi-vdb/master/test/vdb/db/VDB-3418.sra";
+        eprintln!("downloading VDB-3418 fixture from {url} ...");
+
+        let resp = reqwest::blocking::get(url)
+            .unwrap_or_else(|e| panic!("failed to download VDB-3418: {e}"));
+        assert!(
+            resp.status().is_success(),
+            "HTTP {} downloading VDB-3418 fixture",
+            resp.status()
+        );
+        let bytes = resp.bytes().unwrap();
+        assert_eq!(
+            bytes.len() as u64,
+            EXPECTED_SIZE,
+            "VDB-3418 size changed upstream — expected {EXPECTED_SIZE}, got {}",
+            bytes.len()
+        );
+        std::fs::write(&path, &bytes).unwrap();
+    });
+
+    assert!(path.exists(), "fixture not found at {}", path.display());
+    // Cross-check content on every call — cheap (12 MiB) and catches
+    // truncated-download artifacts that the Once block would otherwise
+    // cache. md5 mismatch here means either upstream edited the file or a
+    // partial write landed on disk; either way the cSRA tests below would
+    // start producing garbage we'd have to debug, so fail loud now.
+    let got_md5 = md5_file(&path);
+    assert_eq!(
+        got_md5, EXPECTED_MD5,
+        "VDB-3418 fixture md5 mismatch — upstream changed or file is corrupt"
+    );
+    path
+}
+
 /// Build a `PipelineConfig` suitable for testing.
 fn test_config(
     output_dir: &std::path::Path,
@@ -698,15 +790,7 @@ fn csra_alignment_columns_open() {
     use sracha_core::vdb::alignment::AlignmentCursor;
     use sracha_core::vdb::kar::KarArchive;
 
-    let path = fixtures_dir().join("VDB-3418.sra");
-    if !path.exists() {
-        eprintln!(
-            "skipping csra_alignment_columns_open: {} not present",
-            path.display()
-        );
-        return;
-    }
-
+    let path = ensure_vdb_3418();
     let file = std::fs::File::open(&path).unwrap();
     let mut archive = KarArchive::open(std::io::BufReader::new(file)).unwrap();
     let cur = AlignmentCursor::open(&mut archive, &path).unwrap();
@@ -755,15 +839,7 @@ fn csra_reference_fetch_span() {
     use sracha_core::vdb::kar::KarArchive;
     use sracha_core::vdb::reference::ReferenceCursor;
 
-    let path = fixtures_dir().join("VDB-3418.sra");
-    if !path.exists() {
-        eprintln!(
-            "skipping csra_reference_fetch_span: {} not present",
-            path.display()
-        );
-        return;
-    }
-
+    let path = ensure_vdb_3418();
     let file = std::fs::File::open(&path).unwrap();
     let mut archive = KarArchive::open(std::io::BufReader::new(file)).unwrap();
     let refs = ReferenceCursor::open(&mut archive, &path).unwrap();
@@ -819,12 +895,7 @@ fn csra_align_restore_read_row_1() {
     use sracha_core::vdb::reference::ReferenceCursor;
     use sracha_core::vdb::restore::{align_restore_read, fourna_to_ascii};
 
-    let path = fixtures_dir().join("VDB-3418.sra");
-    if !path.exists() {
-        eprintln!("skipping: {} not present", path.display());
-        return;
-    }
-
+    let path = ensure_vdb_3418();
     let file = std::fs::File::open(&path).unwrap();
     let mut archive = KarArchive::open(std::io::BufReader::new(file)).unwrap();
     let align = AlignmentCursor::open(&mut archive, &path).unwrap();
@@ -873,12 +944,7 @@ fn csra_seq_restore_read_row_1() {
         SRA_READ_TYPE_REVERSE, align_restore_read, fourna_to_ascii, seq_restore_read,
     };
 
-    let path = fixtures_dir().join("VDB-3418.sra");
-    if !path.exists() {
-        eprintln!("skipping: {} not present", path.display());
-        return;
-    }
-
+    let path = ensure_vdb_3418();
     let file = std::fs::File::open(&path).unwrap();
     let mut archive = KarArchive::open(std::io::BufReader::new(file)).unwrap();
     let align = AlignmentCursor::open(&mut archive, &path).unwrap();
@@ -936,12 +1002,7 @@ fn csra_cursor_read_spot_row_1() {
     use sracha_core::vdb::kar::KarArchive;
     use sracha_core::vdb::restore::fourna_to_ascii;
 
-    let path = fixtures_dir().join("VDB-3418.sra");
-    if !path.exists() {
-        eprintln!("skipping: {} not present", path.display());
-        return;
-    }
-
+    let path = ensure_vdb_3418();
     let file = std::fs::File::open(&path).unwrap();
     let mut archive = KarArchive::open(std::io::BufReader::new(file)).unwrap();
     let csra = CsraCursor::open(&mut archive, &path).unwrap();
@@ -973,12 +1034,7 @@ fn csra_full_archive_matches_fasterq_dump() {
     use sracha_core::vdb::csra::CsraCursor;
     use sracha_core::vdb::kar::KarArchive;
 
-    let path = fixtures_dir().join("VDB-3418.sra");
-    if !path.exists() {
-        eprintln!("skipping: {} not present", path.display());
-        return;
-    }
-
+    let path = ensure_vdb_3418();
     let file = std::fs::File::open(&path).unwrap();
     let mut archive = KarArchive::open(std::io::BufReader::new(file)).unwrap();
     let csra = CsraCursor::open(&mut archive, &path).unwrap();
@@ -1214,6 +1270,126 @@ fn ctrl_c_before_decode_aborts_with_cancelled_error() {
     );
     // Sanity: flag was observed.
     assert!(cancelled.load(Ordering::Relaxed));
+}
+
+#[ignore]
+#[test]
+fn ls454_platform_is_rejected_end_to_end() {
+    // Legacy-platform hard reject: 454 (`LS454`) is in the
+    // UNSUPPORTED_PLATFORMS set. The existing unit test covers the
+    // string-match helper in isolation; this test drives run_fastq against
+    // a real 454 archive (SRR000001) to verify the rejection is actually
+    // wired into the decode_and_write entry point — a refactor that moved
+    // the platform check past first decode would pass the unit test but
+    // fail here.
+    let sra_path = ensure_srr000001();
+    let tmp = tempfile::tempdir().unwrap();
+    let config = test_config(tmp.path(), SplitMode::Split3, CompressionMode::None);
+
+    let result = sracha_core::pipeline::run_fastq(&sra_path, Some("SRR000001"), &config);
+    match result {
+        Err(sracha_core::error::Error::UnsupportedPlatform { platform }) => {
+            assert_eq!(
+                platform, "LS454",
+                "expected LS454 rejection, got {platform}",
+            );
+        }
+        Ok(stats) => panic!(
+            "LS454 must be rejected, but decode succeeded with {} spots",
+            stats.spots_read,
+        ),
+        Err(e) => panic!("unexpected non-UnsupportedPlatform error: {e}"),
+    }
+
+    // No output files should have been created.
+    let files: Vec<_> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let n = e.file_name().to_string_lossy().into_owned();
+            n.ends_with(".fastq") || n.ends_with(".partial")
+        })
+        .collect();
+    assert!(
+        files.is_empty(),
+        "no FASTQ output should be written for rejected platform, found: {:?}",
+        files.iter().map(|e| e.file_name()).collect::<Vec<_>>(),
+    );
+}
+
+#[ignore]
+#[test]
+fn ctrl_c_mid_decode_cleans_up_partials() {
+    // Complementary to the pre-flipped cancel test: here the pipeline has
+    // genuinely started writing output when the flag flips, exercising the
+    // "ran for a while then cancelled" cleanup path rather than the
+    // "abort at first poll" path.
+    //
+    // A watcher thread polls the output directory and flips the flag the
+    // first time it sees a `.partial` file appear — so cancellation lands
+    // strictly after the pipeline has created at least one output handle.
+    // On a very fast machine the whole decode may finish before the first
+    // poll sees anything; we tolerate that by accepting `Ok(_)` with a
+    // warning, and only assert the cleanup invariant when cancellation
+    // actually fired.
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::{Duration, Instant};
+
+    let path = ensure_srr33907345(); // larger fixture — more likely to race
+    let out = tempfile::tempdir().unwrap();
+    let out_dir = out.path().to_path_buf();
+    let cancelled = Arc::new(AtomicBool::new(false));
+
+    let mut config = test_config(&out_dir, SplitMode::Split3, CompressionMode::None);
+    config.cancelled = Some(Arc::clone(&cancelled));
+
+    // Spawn a thread that polls for a `.partial` file and flips cancel the
+    // first time it sees one. Bounded so the test can't hang if decode
+    // never produces partials for some reason.
+    let flag = Arc::clone(&cancelled);
+    let poll_dir = out_dir.clone();
+    let watcher = std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while Instant::now() < deadline {
+            if let Ok(entries) = std::fs::read_dir(&poll_dir) {
+                for e in entries.flatten() {
+                    if e.file_name().to_string_lossy().ends_with(".partial") {
+                        flag.store(true, Ordering::Relaxed);
+                        return true;
+                    }
+                }
+            }
+            std::thread::sleep(Duration::from_millis(2));
+        }
+        false
+    });
+
+    let result = sracha_core::pipeline::run_fastq(&path, Some("SRR33907345"), &config);
+    let fired = watcher.join().unwrap();
+
+    match result {
+        Err(sracha_core::error::Error::Cancelled { .. }) => {
+            assert!(fired, "cancel fired without a prior .partial sighting");
+            let partials: Vec<_> = std::fs::read_dir(&out_dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_name().to_string_lossy().ends_with(".partial"))
+                .collect();
+            assert!(
+                partials.is_empty(),
+                "mid-decode cancellation must delete .partial files, found: {:?}",
+                partials.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+            );
+        }
+        Ok(_) => {
+            // Decode completed before the watcher could observe a .partial
+            // — rare but possible on fast machines; the cleanup invariant
+            // isn't exercised here. Not a failure.
+            eprintln!("decode completed before mid-decode cancel could fire");
+        }
+        Err(e) => panic!("unexpected non-cancel error: {e}"),
+    }
 }
 
 #[ignore]

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -1319,18 +1319,18 @@ fn ls454_platform_is_rejected_end_to_end() {
 
 #[ignore]
 #[test]
-fn ctrl_c_mid_decode_cleans_up_partials() {
+fn ctrl_c_mid_decode_returns_partial_paths() {
     // Complementary to the pre-flipped cancel test: here the pipeline has
     // genuinely started writing output when the flag flips, exercising the
-    // "ran for a while then cancelled" cleanup path rather than the
-    // "abort at first poll" path.
+    // "ran for a while then cancelled" path rather than the "abort at
+    // first poll" path.
     //
     // A watcher thread polls the output directory and flips the flag the
     // first time it sees a `.partial` file appear — so cancellation lands
     // strictly after the pipeline has created at least one output handle.
     // On a very fast machine the whole decode may finish before the first
     // poll sees anything; we tolerate that by accepting `Ok(_)` with a
-    // warning, and only assert the cleanup invariant when cancellation
+    // warning, and only assert the partial-path contract when cancellation
     // actually fired.
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -1369,17 +1369,29 @@ fn ctrl_c_mid_decode_cleans_up_partials() {
     let fired = watcher.join().unwrap();
 
     match result {
-        Err(sracha_core::error::Error::Cancelled { .. }) => {
+        Err(sracha_core::error::Error::Cancelled { output_files }) => {
             assert!(fired, "cancel fired without a prior .partial sighting");
-            let partials: Vec<_> = std::fs::read_dir(&out_dir)
+            // `run_fastq` contract (pipeline/mod.rs:856): it does NOT delete
+            // partial files itself — it returns `Error::Cancelled` with the
+            // list of partials so the higher-level `run_get` wrapper can
+            // clean them up (see pipeline/mod.rs:1641). The contract we
+            // fence here is that the error actually names the partials that
+            // were on disk when cancellation fired.
+            let on_disk: std::collections::HashSet<PathBuf> = std::fs::read_dir(&out_dir)
                 .unwrap()
                 .filter_map(|e| e.ok())
                 .filter(|e| e.file_name().to_string_lossy().ends_with(".partial"))
+                .map(|e| e.path())
                 .collect();
             assert!(
-                partials.is_empty(),
-                "mid-decode cancellation must delete .partial files, found: {:?}",
-                partials.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+                !on_disk.is_empty(),
+                "watcher fired on .partial but they're gone — unexpected",
+            );
+            let named: std::collections::HashSet<PathBuf> = output_files.iter().cloned().collect();
+            assert_eq!(
+                on_disk, named,
+                "Error::Cancelled.output_files must match the .partial files left \
+                 on disk so the CLI can clean them up",
             );
         }
         Ok(_) => {

--- a/crates/sracha-vdb/src/blob.rs
+++ b/crates/sracha-vdb/src/blob.rs
@@ -2851,4 +2851,143 @@ mod tests {
             .collect();
         assert_eq!(vals, vec![1000, 2000, 1015, 1990]);
     }
+
+    // -----------------------------------------------------------------------
+    // PageMap property tests — regression fence for issue-#22 class bugs
+    //
+    // Every `expand_*` method had silent-wrong-output failure modes when
+    // variable `data_runs` interacted with heterogeneous row lengths. These
+    // tests compare against a naive "obvious" reference expansion over
+    // randomly-shaped page maps to catch any such divergence.
+    // -----------------------------------------------------------------------
+
+    use proptest::prelude::*;
+
+    /// Build a PageMap from `(data_run, length)` pairs — one per data record.
+    /// The on-disk format assumes rows within the same data-run share a
+    /// length, so we expand + RLE to produce canonical `lengths`/`leng_runs`.
+    fn page_map_from_pairs(pairs: &[(u32, u32)]) -> PageMap {
+        let mut logical_lens: Vec<u32> = Vec::new();
+        for &(run, len) in pairs {
+            for _ in 0..run {
+                logical_lens.push(len);
+            }
+        }
+        let mut lengths: Vec<u32> = Vec::new();
+        let mut leng_runs: Vec<u32> = Vec::new();
+        for &l in &logical_lens {
+            match lengths.last() {
+                Some(&last) if last == l => *leng_runs.last_mut().unwrap() += 1,
+                _ => {
+                    lengths.push(l);
+                    leng_runs.push(1);
+                }
+            }
+        }
+        PageMap {
+            data_recs: pairs.len() as u64,
+            lengths,
+            leng_runs,
+            data_runs: pairs.iter().map(|&(r, _)| r).collect(),
+        }
+    }
+
+    proptest! {
+        /// expand_variable_data_runs matches the naive "emit record i's
+        /// bytes data_runs[i] times" expansion for every well-formed page
+        /// map. Direct fence against issue #22: the original bug silently
+        /// skipped expansion whenever `lengths` wasn't all-equal, and a
+        /// property test like this one would have caught it before landing.
+        #[test]
+        fn prop_expand_variable_matches_reference(
+            pairs in proptest::collection::vec(
+                (1u32..=4u32, 0u32..=8u32),
+                1..12,
+            ),
+        ) {
+            let pm = page_map_from_pairs(&pairs);
+            let record_lens: Vec<u32> = pairs.iter().map(|&(_, l)| l).collect();
+            let data_runs: Vec<u32> = pairs.iter().map(|&(r, _)| r).collect();
+
+            // data: record i is `length` bytes of value `i as u8`. Picking
+            // per-record distinct bytes lets a mis-stitched output be
+            // detected by vec-equality alone.
+            let mut data = Vec::new();
+            for (i, &len) in record_lens.iter().enumerate() {
+                for _ in 0..len {
+                    data.push(i as u8);
+                }
+            }
+
+            let got = pm.expand_variable_data_runs(&data).unwrap();
+
+            let mut expected = Vec::new();
+            let mut cursor = 0usize;
+            for (i, &len) in record_lens.iter().enumerate() {
+                let chunk = &data[cursor..cursor + len as usize];
+                for _ in 0..data_runs[i] as usize {
+                    expected.extend_from_slice(chunk);
+                }
+                cursor += len as usize;
+            }
+            prop_assert_eq!(got, expected);
+        }
+
+        /// expand_data_runs (fixed-element) matches a flat_map expansion
+        /// for every well-formed `data_runs`.
+        #[test]
+        fn prop_expand_data_runs_fixed_matches_reference(
+            runs in proptest::collection::vec(1u32..=4u32, 1..15),
+        ) {
+            let data: Vec<u32> = (0..runs.len() as u32).collect();
+            let total_rows: u32 = runs.iter().sum();
+            // expand_data_runs doesn't consult `lengths`, so the trivial
+            // (lengths=[1], leng_runs=[total]) parametrisation suffices.
+            let pm = PageMap {
+                data_recs: data.len() as u64,
+                lengths: vec![1],
+                leng_runs: vec![total_rows],
+                data_runs: runs.clone(),
+            };
+            let got = pm.expand_data_runs(&data);
+            let expected: Vec<u32> = data
+                .iter()
+                .zip(runs.iter())
+                .flat_map(|(&v, &r)| std::iter::repeat_n(v, r as usize))
+                .collect();
+            prop_assert_eq!(got, expected);
+        }
+
+        /// data_record_lengths reproduces the per-record `length` input.
+        /// Round-trip over the RLE (`lengths`/`leng_runs`) + `data_runs`.
+        #[test]
+        fn prop_data_record_lengths_round_trip(
+            pairs in proptest::collection::vec(
+                (1u32..=4u32, 0u32..=8u32),
+                1..12,
+            ),
+        ) {
+            let pm = page_map_from_pairs(&pairs);
+            let got = pm.data_record_lengths();
+            let expected: Vec<u32> = pairs.iter().map(|&(_, l)| l).collect();
+            prop_assert_eq!(got, expected);
+        }
+
+        /// total_rows always equals both sum(leng_runs) and sum(data_runs)
+        /// for well-formed page maps. Cross-checks the two RLE encodings.
+        #[test]
+        fn prop_total_rows_consistent(
+            pairs in proptest::collection::vec(
+                (1u32..=4u32, 0u32..=8u32),
+                1..12,
+            ),
+        ) {
+            let pm = page_map_from_pairs(&pairs);
+            let total = pm.total_rows();
+            let sum_leng: u64 = pm.leng_runs.iter().map(|&r| u64::from(r)).sum();
+            let sum_data: u64 = pm.data_runs.iter().map(|&r| u64::from(r)).sum();
+            prop_assert_eq!(total, sum_leng);
+            prop_assert_eq!(total, sum_data);
+        }
+    }
 }

--- a/crates/sracha/Cargo.toml
+++ b/crates/sracha/Cargo.toml
@@ -29,3 +29,5 @@ libc = "0.2"
 
 [dev-dependencies]
 tempfile.workspace = true
+assert_cmd = "2"
+predicates = "3"

--- a/crates/sracha/tests/cli.rs
+++ b/crates/sracha/tests/cli.rs
@@ -1,0 +1,243 @@
+//! CLI black-box tests for the `sracha` binary.
+//!
+//! Fills the audit gap: the unit tests in `main.rs` only cover helper
+//! functions (argument collection, confirmation, disk-space preflight).
+//! Here we actually exec the built binary to verify exit codes, argument
+//! parsing, flag conflicts, and end-to-end FASTQ output.
+//!
+//! Tests that need a real SRA file are marked `#[ignore]` and rely on the
+//! cached `SRR28588231.sra` fixture from `sracha-core`'s integration tests.
+//! Run with `cargo test -p sracha -- --ignored` once the fixture exists.
+
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn bin() -> Command {
+    Command::cargo_bin("sracha").expect("sracha binary must build")
+}
+
+/// Path to the shared fixtures directory under sracha-core (where
+/// `pipeline.rs` integration tests download SRR28588231.sra on first run).
+fn shared_fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("sracha-core")
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+// ---------------------------------------------------------------------------
+// Parsing / help
+// ---------------------------------------------------------------------------
+
+#[test]
+fn prints_top_level_help() {
+    bin()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("fastq"))
+        .stdout(predicate::str::contains("fetch"))
+        .stdout(predicate::str::contains("get"))
+        .stdout(predicate::str::contains("validate"));
+}
+
+#[test]
+fn prints_subcommand_help() {
+    bin()
+        .args(["fastq", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--split"))
+        .stdout(predicate::str::contains("--stdout"));
+}
+
+#[test]
+fn errors_on_missing_subcommand() {
+    bin().assert().failure();
+}
+
+// ---------------------------------------------------------------------------
+// Flag conflicts — clap declares these, so breaking the #[arg(conflicts_with_all)]
+// annotations would silently let them through. These tests fence the conflict
+// surface so the next person to touch FastqArgs doesn't regress it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stdout_conflicts_with_zstd() {
+    bin()
+        .args(["fastq", "--stdout", "--zstd", "dummy.sra"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn stdout_conflicts_with_gzip_level() {
+    bin()
+        .args(["fastq", "--stdout", "--gzip-level", "6", "dummy.sra"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn no_gzip_conflicts_with_zstd() {
+    bin()
+        .args(["fastq", "--no-gzip", "--zstd", "dummy.sra"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn zstd_level_out_of_range_rejected() {
+    // value_parser range(1..=22) — 99 must fail at parse time.
+    bin()
+        .args(["fastq", "--zstd", "--zstd-level", "99", "dummy.sra"])
+        .assert()
+        .failure();
+}
+
+// ---------------------------------------------------------------------------
+// Error handling on missing input
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fastq_missing_file_reports_error() {
+    // Current behaviour: `sracha fastq <missing>` prints an error to
+    // stderr but exits 0 (multi-file input continues on per-file
+    // failures). This test fences the error-reporting contract — a future
+    // refactor that silently swallowed the missing input would break it.
+    // Exit-code semantics are left deliberately unasserted; if that policy
+    // changes, add the `.failure()` expectation alongside.
+    let tmp = tempfile::tempdir().unwrap();
+    bin()
+        .args(["fastq", "/definitely-does-not-exist-sracha-test.sra", "-O"])
+        .arg(tmp.path())
+        .args(["--no-gzip", "--no-progress"])
+        .assert()
+        .stderr(predicate::str::contains("file not found"));
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: convert a cached fixture (requires the sracha-core fixture
+// to be present; skip when absent so CI without the fixture passes).
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore] // requires SRR28588231.sra fixture from sracha-core integration tests
+fn fastq_end_to_end_produces_paired_files() {
+    let fixture = shared_fixture("SRR28588231.sra");
+    if !fixture.exists() {
+        eprintln!(
+            "skipping: fixture not present at {}; run sracha-core integration tests first",
+            fixture.display()
+        );
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    bin()
+        .args(["fastq"])
+        .arg(&fixture)
+        .args(["-O"])
+        .arg(tmp.path())
+        .args(["--no-gzip", "--no-progress", "--force"])
+        .assert()
+        .success();
+
+    // Split-3 default on paired-end data produces SRR28588231_1.fastq and _2.fastq.
+    let r1 = tmp.path().join("SRR28588231_1.fastq");
+    let r2 = tmp.path().join("SRR28588231_2.fastq");
+    assert!(r1.exists(), "R1 missing at {}", r1.display());
+    assert!(r2.exists(), "R2 missing at {}", r2.display());
+
+    let r1_bytes = std::fs::read(&r1).unwrap();
+    assert!(!r1_bytes.is_empty(), "R1 empty");
+    assert!(
+        r1_bytes.starts_with(b"@SRR28588231"),
+        "R1 defline unexpected"
+    );
+}
+
+#[test]
+#[ignore] // requires SRR28588231.sra fixture
+fn fastq_stdout_mode_streams_fastq() {
+    // Covers the stdout-mode code path end-to-end (PipelineConfig.stdout =
+    // true). No cleaner way to test this in-process: the pipeline calls
+    // `std::io::stdout()` directly, so a subprocess + captured stdout is
+    // the only faithful harness.
+    let fixture = shared_fixture("SRR28588231.sra");
+    if !fixture.exists() {
+        eprintln!("skipping: fixture not present at {}", fixture.display());
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let assert = bin()
+        .args(["fastq", "--stdout"])
+        .arg(&fixture)
+        .args(["-O"])
+        .arg(tmp.path())
+        .args(["--no-progress"])
+        .assert()
+        .success();
+
+    // Stdout mode produces a single interleaved stream of FASTQ records.
+    // We check only the first few bytes to avoid pulling the full 66k-spot
+    // output into the test harness.
+    let out = assert.get_output().stdout.clone();
+    assert!(!out.is_empty(), "stdout mode produced no output");
+    assert!(
+        out.starts_with(b"@SRR28588231"),
+        "stdout FASTQ should start with '@SRR28588231' defline, got: {:?}",
+        &out[..out.len().min(80)],
+    );
+    // Quick structural check: at least one newline-separated record exists.
+    let lines: Vec<&[u8]> = out.split(|&b| b == b'\n').take(4).collect();
+    assert!(lines.len() >= 4, "expected ≥4 lines in stdout stream");
+    assert!(
+        lines[2].starts_with(b"+"),
+        "line 3 of first record should be '+', got {:?}",
+        std::str::from_utf8(lines[2]).unwrap_or("<non-utf8>"),
+    );
+
+    // In stdout mode no output files should land in -O.
+    let files: Vec<_> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name())
+        .collect();
+    let fastqs: Vec<_> = files
+        .iter()
+        .filter(|f| f.to_string_lossy().ends_with(".fastq"))
+        .collect();
+    assert!(
+        fastqs.is_empty(),
+        "stdout mode should not create files in -O, found: {fastqs:?}",
+    );
+}
+
+#[test]
+fn fastq_corrupt_input_reports_error() {
+    // Garbage content at a valid path — the CLI must at least surface the
+    // decode error on stderr. Exit-code policy (see
+    // `fastq_missing_file_reports_error`) is intentionally not asserted:
+    // whether garbage input should terminate the process or just log an
+    // error and move on to the next input is a policy decision, but a
+    // silent success here would always be wrong.
+    let tmp = tempfile::tempdir().unwrap();
+    let corrupt = tmp.path().join("corrupt.sra");
+    std::fs::write(&corrupt, b"not a valid VDB archive").unwrap();
+
+    bin()
+        .args(["fastq"])
+        .arg(&corrupt)
+        .args(["-O"])
+        .arg(tmp.path())
+        .args(["--no-gzip", "--no-progress"])
+        .assert()
+        .stderr(predicate::str::contains("error").or(predicate::str::contains("Error")));
+}


### PR DESCRIPTION
Net-new coverage:

- VDB-3418 cSRA fixture now auto-downloads from the ncbi-vdb GitHub mirror with a committed size+md5 guard; every `csra_*` test previously silently passed when the fixture was absent.
- LS454 rejection fence: drive `run_fastq` against a real 454 archive (SRR000001) and assert `Error::UnsupportedPlatform` end-to-end. The prior unit test only covered the string-match helper in isolation.
- Mid-decode cancellation: complement the pre-flipped cancel test with one that waits until `.partial` output files appear before flipping the flag, exercising the "ran for a while then cancelled" cleanup path rather than the first-poll abort.
- PageMap property tests (proptest): compare `expand_variable_data_runs`, `expand_data_runs`, `data_record_lengths`, and `total_rows` against a naive reference across random valid page maps. Direct regression fence for issue-#22-class silent-wrong-output decoder bugs.
- `assert_cmd`-based black-box CLI tests: --help rendering, flag conflicts (--stdout vs --zstd/--gzip-level, --no-gzip vs --zstd), value-range validation, error-on-missing-subcommand, stderr-on-missing or corrupt input, end-to-end paired FASTQ conversion, and --stdout streaming mode (which can only be faithfully tested via subprocess).

The sidecar-aware parallel-resume branch in `download_file` is left uncovered with a comment documenting why: wiremock can't condition responses on the Range header, and the branch only engages above SMALL_FILE=32 MiB. A follow-up would need a custom hyper-based mock or a tunable threshold.