### PR TITLE
fix(altread): pad variable-length rows per READ page_map widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 ### Fixes
 
+- **ALTREAD variable-row padding for N-mask byte-identity**:
+  `apply_altread_merge` was calling `pad_trimmed_rows_fixed` with a
+  uniform `row_bases = actual_bases / read_id_range` — the average row
+  length. On Illumina runs with adapter-trimmed reads (per-row base
+  counts differing by 10–200 bases) any stored record whose trimmed
+  size exceeded the average errored inside the fixed-pad helper, the
+  merge silently skipped, and ALTREAD's 4na N annotations leaked
+  through as raw 2na bases — the `N_MASK_ONLY` divergences the
+  mismatch-report harness (#26) captured on DRR035183, SRR33907345,
+  and every `FAIL_SEQ` accession reclassified after PR #24.
+  New `PageMap::pad_trimmed_rows_variable` takes per-logical-row
+  targets so each padded row matches its READ row's true width;
+  `apply_altread_merge` threads READ's page_map through and feeds its
+  expanded per-row widths in whenever ALTREAD and READ rows align
+  1:1. The old fixed path remains the fallback for mismatched-blob-
+  size layouts (DRR035866's 2:1 ALTREAD-blob case). Verified 100.0%
+  `IDENTICAL` on DRR035183 and SRR33907345 vs `fasterq-dump` 3.2.1
+  (previously 73.7% / 94.5% `N_MASK_ONLY` on DRR035183).
 - **READ 2na `data_runs` expansion for variable-length rows (#22)**:
   when a READ blob's page map has a non-empty `data_runs` run-length
   table, consecutive stored rows with identical 2na bytes are written

--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -177,10 +177,18 @@ pub(crate) struct BlobDecodeCtx<'a> {
 /// [`sracha_vdb::Error::UnsupportedFormat`] (surfaced as [`Error::Vdb`])
 /// so we never emit wrong FASTQ.
 ///
-/// Extracted from [`decode_blob_to_fastq`] — behavior unchanged.
+/// `read_page_map` is the (post-data_runs) READ page_map for this blob;
+/// when ALTREAD and READ blobs share row boundaries, its per-logical-row
+/// lengths feed `pad_trimmed_rows_variable` so each padded ALTREAD row
+/// matches its READ row's true width. Without this, variable-length
+/// Illumina runs (adapter-trimmed reads, SRR33907345 et al.) either
+/// erred inside `pad_trimmed_rows_fixed` or misaligned the padded
+/// buffer against READ, and the fallback silently leaked N annotations
+/// through as raw 2na bases (AAAAA vs NNNNN in the diff).
 fn apply_altread_merge(
     read_data: &mut [u8],
     raw: &RawBlobData<'_>,
+    read_page_map: Option<&crate::vdb::blob::PageMap>,
     actual_bases: usize,
     blob_idx: usize,
 ) -> Result<()> {
@@ -250,31 +258,85 @@ fn apply_altread_merge(
     // but ALTREAD in 8192-row blobs — pairing by blob index
     // merges ALTREAD rows 1..4096 against READ rows 4097..8192,
     // producing N's at random positions in unrelated records.
+    //
+    // When ALTREAD and READ blob rows align 1:1 (the common case),
+    // feed READ's per-logical-row lengths into the variable-target
+    // pad so each ALTREAD row matches its READ row's true width.
+    // Otherwise fall back to the uniform `row_bases` fixed path,
+    // which still covers DRR035866-style 2:1 ALTREAD-blob cases
+    // where rows are fixed-length anyway.
     let row_bases = actual_bases / raw.read_id_range.max(1) as usize;
-    let padded_ok = alt_page_map.as_ref().and_then(|pm| {
-        if row_bases > 0 && !altread_data.is_empty() {
-            match pm.pad_trimmed_rows_fixed(
-                &altread_data,
-                row_bases,
-                crate::vdb::blob::TrimSide::Leading,
-            ) {
-                Ok(v) => Some(v),
-                Err(e) => {
-                    tracing::debug!("blob {blob_idx}: ALTREAD pad_trimmed_rows_fixed err: {e}");
-                    None
+    let per_row_lens = alt_page_map.as_ref().and_then(|alt_pm| {
+        let read_pm = read_page_map?;
+        (alt_pm.total_rows() == read_pm.total_rows()).then(|| {
+            // Expand READ's per-data-record lengths via READ's own
+            // data_runs to get one entry per logical row — matches
+            // the row-by-row layout of `read_data` after the
+            // `expand_variable_data_runs` step above.
+            let rec_lens = read_pm.data_record_lengths();
+            let mut lens = Vec::with_capacity(read_pm.total_rows() as usize);
+            if read_pm.data_runs.is_empty() {
+                lens.extend_from_slice(&rec_lens);
+            } else {
+                for (i, &len) in rec_lens.iter().enumerate() {
+                    let repeat = read_pm.data_runs.get(i).copied().unwrap_or(1) as usize;
+                    for _ in 0..repeat {
+                        lens.push(len);
+                    }
                 }
             }
-        } else {
-            None
+            lens
+        })
+    });
+    let padded_ok = alt_page_map.as_ref().and_then(|pm| {
+        if altread_data.is_empty() {
+            return None;
+        }
+        if let Some(lens) = per_row_lens.as_ref() {
+            match pm.pad_trimmed_rows_variable(
+                &altread_data,
+                lens,
+                crate::vdb::blob::TrimSide::Leading,
+            ) {
+                Ok(v) => return Some(v),
+                Err(e) => {
+                    tracing::debug!("blob {blob_idx}: ALTREAD pad_trimmed_rows_variable err: {e}");
+                    return None;
+                }
+            }
+        }
+        if row_bases == 0 {
+            return None;
+        }
+        match pm.pad_trimmed_rows_fixed(
+            &altread_data,
+            row_bases,
+            crate::vdb::blob::TrimSide::Leading,
+        ) {
+            Ok(v) => Some(v),
+            Err(e) => {
+                tracing::debug!("blob {blob_idx}: ALTREAD pad_trimmed_rows_fixed err: {e}");
+                None
+            }
         }
     });
 
     match padded_ok {
         Some(padded) => {
-            // Offset into padded for READ's starting row within
-            // the ALTREAD blob. 0 when the two blobs align 1:1.
+            // 1:1 alignment (variable-length path): padded length
+            // equals `actual_bases` and row_offset is zero, so the
+            // merge runs over the whole buffer.
+            //
+            // Mismatched-blob-size alignment (fixed-length fallback):
+            // padded is `alt_total_rows * row_bases` with uniform
+            // rows, so skip `row_offset * row_bases` bytes to reach
+            // READ's first row inside the padded ALTREAD buffer.
             let row_offset = (raw.read_start_id - raw.altread_start_id).max(0) as usize;
-            let byte_offset = row_offset * row_bases;
+            let byte_offset = if per_row_lens.is_some() {
+                0
+            } else {
+                row_offset * row_bases
+            };
             if byte_offset < padded.len() {
                 let slice_end = byte_offset + actual_bases.min(padded.len() - byte_offset);
                 crate::vdb::encoding::merge_altread_bin(
@@ -406,7 +468,13 @@ pub(crate) fn decode_blob_to_fastq(
     // FAIL_SEQ divergences validated on accessions like DRR006688.
     // ------------------------------------------------------------------
     if raw.has_altread && !raw.altread_raw.is_empty() {
-        apply_altread_merge(&mut read_data, raw, actual_bases, blob_idx)?;
+        apply_altread_merge(
+            &mut read_data,
+            raw,
+            read_page_map.as_ref(),
+            actual_bases,
+            blob_idx,
+        )?;
     }
 
     // Quality fallback buffer for SRA-lite / empty quality. Default to the

--- a/crates/sracha-vdb/src/blob.rs
+++ b/crates/sracha-vdb/src/blob.rs
@@ -341,6 +341,89 @@ impl PageMap {
         Ok(out)
     }
 
+    /// Variable-target version of [`pad_trimmed_rows_fixed`].
+    ///
+    /// Used for columns whose logical rows have non-uniform true widths —
+    /// e.g. ALTREAD on Illumina runs after adapter trimming, where each
+    /// spot's base count matches that spot's `READ_LEN` sum. The stored
+    /// bytes are still left- or right-aligned inside each row depending
+    /// on `side`; the difference from the fixed variant is that every
+    /// logical row pads to its own `row_lens[logical_row]` target instead
+    /// of a single shared `row_bytes`.
+    ///
+    /// `row_lens` must have `self.total_rows()` entries (one per logical
+    /// row, after `data_runs` replication). Returns a buffer of size
+    /// `sum(row_lens)` — a flat concatenation of every logical row's
+    /// padded bytes — so callers merging against another variable-row
+    /// column can just iterate byte-for-byte.
+    ///
+    /// Fails if `row_lens` has the wrong length, if a stored record's
+    /// bytes exceed the target for any of its replicated rows, or if
+    /// `data` is shorter than the sum of per-record stored lengths.
+    pub fn pad_trimmed_rows_variable(
+        &self,
+        data: &[u8],
+        row_lens: &[u32],
+        side: TrimSide,
+    ) -> Result<Vec<u8>> {
+        let total_rows = self.total_rows() as usize;
+        if row_lens.len() != total_rows {
+            return Err(Error::Format(format!(
+                "page_map: row_lens has {} entries, expected {} (total_rows)",
+                row_lens.len(),
+                total_rows,
+            )));
+        }
+        let total_bytes: usize = row_lens.iter().map(|&l| l as usize).sum();
+        let mut out = vec![0u8; total_bytes];
+        let record_lens = self.data_record_lengths();
+
+        let mut in_off = 0usize;
+        let mut out_off = 0usize;
+        let mut logical_row = 0usize;
+        for (rec_idx, &rec_len_u32) in record_lens.iter().enumerate() {
+            let rec_len = rec_len_u32 as usize;
+            if in_off + rec_len > data.len() {
+                return Err(Error::Format(format!(
+                    "page_map: record {rec_idx} wants {rec_len} bytes at offset \
+                     {in_off} but data has only {}",
+                    data.len()
+                )));
+            }
+            let rec_data = &data[in_off..in_off + rec_len];
+            let repeat = if self.data_runs.is_empty() {
+                1
+            } else {
+                self.data_runs.get(rec_idx).copied().unwrap_or(1) as usize
+            };
+            for _ in 0..repeat {
+                if logical_row >= total_rows {
+                    return Ok(out);
+                }
+                let row_bytes = row_lens[logical_row] as usize;
+                if rec_len > row_bytes {
+                    return Err(Error::Format(format!(
+                        "page_map: record {rec_idx} stored {rec_len} bytes \
+                         exceeds row {logical_row} target {row_bytes}"
+                    )));
+                }
+                match side {
+                    TrimSide::Leading => {
+                        let offset = row_bytes - rec_len;
+                        out[out_off + offset..out_off + row_bytes].copy_from_slice(rec_data);
+                    }
+                    TrimSide::Trailing => {
+                        out[out_off..out_off + rec_len].copy_from_slice(rec_data);
+                    }
+                }
+                out_off += row_bytes;
+                logical_row += 1;
+            }
+            in_off += rec_len;
+        }
+        Ok(out)
+    }
+
     /// Expand variable-length data via data_runs.
     ///
     /// Unlike [`expand_data_runs_bytes`](Self::expand_data_runs_bytes) which
@@ -2747,6 +2830,99 @@ mod tests {
         // row_bytes=3 is shorter than the 5-byte record — must error.
         assert!(
             pm.pad_trimmed_rows_fixed(&data, 3, TrimSide::Leading)
+                .is_err()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // pad_trimmed_rows_variable — Illumina adapter-trim ALTREAD case
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pad_trimmed_rows_variable_leading_handles_mixed_row_widths() {
+        // Three logical rows, three distinct true widths (4, 6, 3).
+        // Each logical row stores its own 2-byte ALTREAD suffix; the
+        // variable pad must right-align each suffix inside its own
+        // target width, not a shared one.
+        let pm = PageMap {
+            data_recs: 3,
+            lengths: vec![2],
+            leng_runs: vec![3],
+            data_runs: vec![],
+        };
+        let data = vec![0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F];
+        let row_lens = vec![4u32, 6, 3];
+        let padded = pm
+            .pad_trimmed_rows_variable(&data, &row_lens, TrimSide::Leading)
+            .unwrap();
+        assert_eq!(
+            padded,
+            vec![
+                0x00, 0x00, 0x0A, 0x0B, // row 0 (width 4)
+                0x00, 0x00, 0x00, 0x00, 0x0C, 0x0D, // row 1 (width 6)
+                0x00, 0x0E, 0x0F, // row 2 (width 3, stored 2)
+            ]
+        );
+    }
+
+    #[test]
+    fn pad_trimmed_rows_variable_replicates_via_data_runs() {
+        // Two data records (3-byte, 2-byte). data_runs replicate record 0
+        // across two logical rows and record 1 across three. Each
+        // replicated logical row gets its own target width — mimics the
+        // ALTREAD case where deduplicated records expand into rows of
+        // differing true lengths.
+        let pm = PageMap {
+            data_recs: 2,
+            lengths: vec![3, 2],
+            leng_runs: vec![2, 3],
+            data_runs: vec![2, 3],
+        };
+        let data = vec![0xAA, 0xBB, 0xCC, 0xDD, 0xEE];
+        let row_lens = vec![5u32, 4, 3, 2, 4];
+        let padded = pm
+            .pad_trimmed_rows_variable(&data, &row_lens, TrimSide::Leading)
+            .unwrap();
+        assert_eq!(
+            padded,
+            vec![
+                0x00, 0x00, 0xAA, 0xBB, 0xCC, // row 0 (width 5, stored 3)
+                0x00, 0xAA, 0xBB, 0xCC, // row 1 (width 4, stored 3)
+                0x00, 0xDD, 0xEE, // row 2 (width 3, stored 2)
+                0xDD, 0xEE, // row 3 (width 2, stored 2 fills exactly)
+                0x00, 0x00, 0xDD, 0xEE, // row 4 (width 4, stored 2)
+            ]
+        );
+    }
+
+    #[test]
+    fn pad_trimmed_rows_variable_rejects_oversized_record() {
+        let pm = PageMap {
+            data_recs: 1,
+            lengths: vec![5],
+            leng_runs: vec![1],
+            data_runs: vec![],
+        };
+        let data = vec![1u8, 2, 3, 4, 5];
+        // Target row width 3 < stored record length 5.
+        assert!(
+            pm.pad_trimmed_rows_variable(&data, &[3], TrimSide::Leading)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn pad_trimmed_rows_variable_rejects_wrong_row_lens_length() {
+        let pm = PageMap {
+            data_recs: 2,
+            lengths: vec![1],
+            leng_runs: vec![2],
+            data_runs: vec![],
+        };
+        let data = vec![0x01, 0x02];
+        // total_rows is 2 but caller supplied only one length.
+        assert!(
+            pm.pad_trimmed_rows_variable(&data, &[4], TrimSide::Leading)
                 .is_err()
         );
     }


### PR DESCRIPTION
## Summary

- Root-cause + fix for the `N_MASK_ONLY` divergences #26's mismatch-report harness surfaced on every `FAIL_SEQ` accession reclassified after PR #24.
- Add `PageMap::pad_trimmed_rows_variable` (per-logical-row targets, still applies `data_runs` replication); `apply_altread_merge` now threads READ's page_map through and feeds its expanded per-row widths into the new helper whenever ALTREAD/READ align 1:1. Fixed-row path stays as the fallback for mismatched-blob-size layouts (DRR035866's 2:1 ALTREAD/READ case).

## Root cause

`apply_altread_merge` called `pad_trimmed_rows_fixed` with `row_bases = actual_bases / read_id_range` — the average row length, which is wrong on any run with variable per-row widths. On Illumina adapter-trimmed reads (per-row counts differing by 10–200 bases), stored ALTREAD records whose trimmed size exceeded that average errored inside the fixed-pad helper, the merge silently skipped, and ALTREAD's 4na N annotations leaked through as raw 2na bases. The 2na bases were correct the whole time — only the N positions disagreed, which is exactly why #26's harness classified 100% of mismatches as `N_MASK_ONLY` with zero `BASE_FLIP`.

## Validation

Before (from #26, on main):

```
DRR035183 _1: 475,037 / 644,410 records N_MASK_ONLY (73.7%)
DRR035183 _2: 608,827 / 644,410 records N_MASK_ONLY (94.5%)
```

After (this branch, `bash validation/mismatch_report.sh <acc>` from PR #26's harness):

```
DRR035183 _1: 644,410 / 644,410 IDENTICAL (100.0%), 0 position diffs
DRR035183 _2: 644,410 / 644,410 IDENTICAL (100.0%), 0 position diffs
SRR33907345 _1: 305,571 / 305,571 IDENTICAL (100.0%), 0 position diffs
SRR33907345 _2: 305,571 / 305,571 IDENTICAL (100.0%), 0 position diffs
```

All 28 `-- --ignored` integration tests stay green, including every byte-identity test (`illumina_paired_byte_identity`, `aligned_schema_plain_byte_identity`, `csra_full_archive_matches_fasterq_dump`) and the #22 `variable_length_data_runs_spot_count` regression.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p sracha-vdb pad_trimmed` — 4 new `pad_trimmed_rows_variable` unit tests pass (mixed row widths, `data_runs` replication, oversized-record rejection, `row_lens` length validation)
- [x] `cargo test -p sracha-core --lib` — 182/182 pass
- [x] `cargo test -p sracha-core --test pipeline -- --ignored` — 28/28 pass
- [x] Validated 100% IDENTICAL vs fasterq-dump 3.2.1 on DRR035183 and SRR33907345 via #26's mismatch-report harness