### PR TITLE
fix(altread): decode variant-2 random-access ALTREAD via offset+length

### DIFF
--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -189,11 +189,14 @@ pub(crate) struct BlobDecodeCtx<'a> {
 /// Decode the ALTREAD blob (when present) and merge its per-base 4na
 /// ambiguity mask into `read_data`. Best-effort: small or malformed
 /// ALTREAD blobs log at debug and leave the 2na basecalls untouched
-/// rather than refusing the whole spot. One exception is the variant-2
-/// page_map shape (no data_runs + multiple distinct lengths), which
-/// can silently leak real N annotations — that case errors out with an
-/// [`sracha_vdb::Error::UnsupportedFormat`] (surfaced as [`Error::Vdb`])
-/// so we never emit wrong FASTQ.
+/// rather than refusing the whole spot. The variant-2 random-access
+/// shape (`data_runs.len() == total_rows`, multi-length, repurposed as
+/// `data_offset[]`) routes through [`PageMap::pad_random_access_rows`]
+/// to reconstruct rows from a deduplicated data buffer. The variant-2
+/// non-random-access shape (`data_runs.is_empty()`, multi-length) still
+/// errors with [`sracha_vdb::Error::UnsupportedFormat`] (surfaced as
+/// [`Error::Vdb`]) — silent skip would leak real N annotations and
+/// we don't yet have a validated decoder for that shape.
 ///
 /// `read_page_map` is the (post-data_runs) READ page_map for this blob;
 /// when ALTREAD and READ blobs share row boundaries, its per-logical-row
@@ -237,38 +240,26 @@ fn apply_altread_merge(
     // stored bytes because `trim<0, 0>` trims from the left) using
     // the page_map, then merge byte-per-base.
     //
-    // Fail-fast on variant 2 page maps: when there's more than one
-    // distinct length value, ALTREAD stores 4na ambiguity overlays
-    // in a layout we don't have a correct decoder for. Two on-disk
-    // shapes hit this path:
-    //   - `data_runs` empty + multi-length (the original variant 2
-    //     non-random-access case validated on DRR024182 blob 162)
-    //   - `data_runs.len() == total_rows` + multi-length (variant 2
-    //     random-access; ncbi-vdb's serialiser overlays per-row
-    //     `data_offset` on the data_run slot, but ALTREAD doesn't
-    //     pad cleanly through `expand_via_page_map`'s offset path
-    //     because trim<0,0> needs row-by-row padding, not flat
-    //     row-length × row_count slabs).
-    // Silently skipping the merge would leak real N annotations
-    // into output (0.01–1.5% sequence divergence from fasterq-dump
-    // on impacted accessions). Erroring with an actionable message
-    // is the safer choice — better to refuse than produce wrong
-    // FASTQ.
+    // Fail-fast guard for the *non*-random-access flavor of v1 variant 2:
+    // `data_runs` empty + multi-length, with nonzero bytes still in the
+    // data buffer. We don't have a validated decoder or fixture for this
+    // shape (it's distinct from the variant-2 RA shape handled below),
+    // and silently skipping the merge leaks real N annotations into FASTQ
+    // (0.01–1.5% sequence divergence vs fasterq-dump). Refuse rather than
+    // emit potentially-wrong FASTQ.
     if let Some(pm) = alt_page_map.as_ref()
         && pm.lengths.len() > 1
-        && (pm.data_runs.is_empty() || pm.data_runs.len() as u64 == pm.total_rows())
+        && pm.data_runs.is_empty()
         && altread_data.iter().any(|&b| b != 0)
     {
         return Err(sracha_vdb::Error::UnsupportedFormat {
-            format: "page_map v1 variant 2 in ALTREAD".into(),
+            format: "page_map v1 variant 2 non-random-access in ALTREAD".into(),
             hint: format!(
-                "ALTREAD blob {blob_idx} stores {} rows with {} unique length \
-                 values via a variant-2 page_map (no data_runs); sracha's \
-                 decoder for this variant doesn't produce byte-identical \
-                 output vs fasterq-dump. Refusing to emit potentially-wrong \
-                 FASTQ — use fasterq-dump for this file, or file an issue \
-                 with the accession so we can add proper variant-2 support. \
-                 See comment in pipeline::decode_blob_to_fastq.",
+                "ALTREAD blob {blob_idx} stores {} rows with {} unique length values via \
+                 a variant-2 non-random-access page_map (no data_runs); sracha doesn't \
+                 have a byte-identity-validated decoder for this shape. Refusing to emit \
+                 potentially-wrong FASTQ — use fasterq-dump for this file, or file an \
+                 issue with the accession so we can add coverage.",
                 pm.leng_runs.iter().sum::<u32>(),
                 pm.lengths.len(),
             ),
@@ -312,9 +303,48 @@ fn apply_altread_merge(
             lens
         })
     });
+    // Variant-2 random-access page maps repurpose `data_runs` as
+    // `data_offset[row_count]`: each row's trimmed bytes are sliced
+    // out of `altread_data` at `data_offsets[row]` for `lengths[run]`
+    // bytes (multiple rows can share the same offset → write-time
+    // dedup, so the data buffer can be far smaller than
+    // `sum(lengths × leng_runs)`). DRR024182 blob 162 hits this:
+    // 8192 rows / 77 unique lengths / 1981 stored bytes / only 17
+    // unique offsets (6481 rows share offset=0). Detect by the data
+    // shape (`data_runs.len() == total_rows && lengths.len() > 1`)
+    // and route to the offset-aware reconstruction; everything else
+    // continues through the run-length variable padder.
+    let is_variant2_ra = alt_page_map
+        .as_ref()
+        .is_some_and(|pm| pm.lengths.len() > 1 && pm.data_runs.len() as u64 == pm.total_rows());
     let padded_ok = alt_page_map.as_ref().and_then(|pm| {
         if altread_data.is_empty() {
             return None;
+        }
+        // Variant-2 RA needs to walk every row by `data_offset[row]`
+        // and copy `lengths[run]` bytes; neither `pad_trimmed_rows_*`
+        // can do that. When the READ blob aligns 1:1 with ALTREAD,
+        // pad each row to its READ-derived logical width; otherwise
+        // (e.g. DRR035866-style 2:1 ALTREAD blob) pad to the uniform
+        // `row_bases` width across every ALTREAD row, then the merge
+        // step slices the relevant `row_offset * row_bases` portion.
+        if is_variant2_ra && row_bases > 0 {
+            let alt_total_rows = pm.total_rows() as usize;
+            let row_logical_lens: Vec<u32> = match per_row_lens.as_ref() {
+                Some(lens) => lens.clone(),
+                None => vec![row_bases as u32; alt_total_rows],
+            };
+            match pm.pad_random_access_rows(
+                &altread_data,
+                &row_logical_lens,
+                crate::vdb::blob::TrimSide::Leading,
+            ) {
+                Ok(v) => return Some(v),
+                Err(e) => {
+                    tracing::debug!("blob {blob_idx}: ALTREAD pad_random_access_rows err: {e}");
+                    return None;
+                }
+            }
         }
         if let Some(lens) = per_row_lens.as_ref() {
             match pm.pad_trimmed_rows_variable(

--- a/crates/sracha-vdb/src/blob.rs
+++ b/crates/sracha-vdb/src/blob.rs
@@ -424,6 +424,111 @@ impl PageMap {
         Ok(out)
     }
 
+    /// Reconstruct per-row bytes from a variant-2 random-access page map
+    /// (variable row lengths + per-row `data_offset[]`) used by trim-then-zip
+    /// physical columns like `.ALTREAD`.
+    ///
+    /// The on-disk layout in this variant: `lengths[]/leng_runs[]` describes
+    /// each row's *trimmed* byte count (after `trim<0,0>` stripped leading
+    /// zeros at write time), and the field this code calls `data_runs` is
+    /// actually `data_offset[row_count]` — the byte offset of each row's
+    /// trimmed bytes inside the decompressed `data` buffer. Multiple rows
+    /// may share the same offset (write-time deduplication), so the data
+    /// buffer can be much smaller than `sum(lengths × leng_runs)`.
+    ///
+    /// `row_logical_lens[r]` is the row's full pre-trim width (e.g. the
+    /// READ column's per-row base count for ALTREAD). The trimmed bytes are
+    /// placed inside a `row_logical_lens[r]` slot, right-aligned for
+    /// `TrimSide::Leading` (the trim<0,0> case) so the leading zeros that
+    /// were stripped are restored as zero bytes. Returns
+    /// `sum(row_logical_lens)` bytes — one row after another in a single
+    /// flat buffer, ready to merge byte-for-byte against another column.
+    ///
+    /// Errors when `row_logical_lens` length doesn't match `total_rows()`,
+    /// when `data_runs` (= `data_offset[]`) length doesn't match
+    /// `total_rows()` (i.e. this isn't a variant-2 RA page map), when a
+    /// trimmed length exceeds the corresponding logical width (would mean
+    /// the trim wrote more bytes than its input held), or when a row's
+    /// `(offset, trimmed_len)` slice would read past the end of `data`.
+    pub fn pad_random_access_rows(
+        &self,
+        data: &[u8],
+        row_logical_lens: &[u32],
+        side: TrimSide,
+    ) -> Result<Vec<u8>> {
+        let total_rows = self.total_rows() as usize;
+        if row_logical_lens.len() != total_rows {
+            return Err(Error::Format(format!(
+                "page_map: row_logical_lens has {} entries, expected {} (total_rows)",
+                row_logical_lens.len(),
+                total_rows,
+            )));
+        }
+        if self.data_runs.len() != total_rows {
+            return Err(Error::Format(format!(
+                "page_map: pad_random_access_rows requires data_offset[] of length \
+                 {total_rows}, got {} entries",
+                self.data_runs.len(),
+            )));
+        }
+
+        // Expand `lengths`/`leng_runs` to per-row trimmed lengths.
+        let mut row_trimmed_lens = Vec::with_capacity(total_rows);
+        for (length, &run) in self.lengths.iter().zip(self.leng_runs.iter()) {
+            for _ in 0..run {
+                row_trimmed_lens.push(*length);
+            }
+        }
+        if row_trimmed_lens.len() != total_rows {
+            return Err(Error::Format(format!(
+                "page_map: leng_runs sum to {} but total_rows() = {total_rows}",
+                row_trimmed_lens.len(),
+            )));
+        }
+
+        let total_bytes: usize = row_logical_lens.iter().map(|&l| l as usize).sum();
+        let mut out = vec![0u8; total_bytes];
+
+        let mut out_off = 0usize;
+        for r in 0..total_rows {
+            let logical = row_logical_lens[r] as usize;
+            let trimmed = row_trimmed_lens[r] as usize;
+            let offset = self.data_runs[r] as usize;
+
+            if trimmed > logical {
+                return Err(Error::Format(format!(
+                    "page_map: row {r} trimmed_len {trimmed} > logical {logical}"
+                )));
+            }
+            if trimmed > 0 {
+                let end = offset.checked_add(trimmed).ok_or_else(|| {
+                    Error::Format(format!(
+                        "page_map: row {r} offset {offset} + trimmed {trimmed} overflows usize"
+                    ))
+                })?;
+                if end > data.len() {
+                    return Err(Error::Format(format!(
+                        "page_map: row {r} wants data[{offset}..{end}] but data has only {} bytes",
+                        data.len(),
+                    )));
+                }
+                let bytes = &data[offset..end];
+                match side {
+                    TrimSide::Leading => {
+                        let pad = logical - trimmed;
+                        out[out_off + pad..out_off + logical].copy_from_slice(bytes);
+                    }
+                    TrimSide::Trailing => {
+                        out[out_off..out_off + trimmed].copy_from_slice(bytes);
+                    }
+                }
+            }
+            out_off += logical;
+        }
+
+        Ok(out)
+    }
+
     /// Expand variable-length data via data_runs.
     ///
     /// Unlike [`expand_data_runs_bytes`](Self::expand_data_runs_bytes) which
@@ -3105,6 +3210,129 @@ mod tests {
         // total_rows is 2 but caller supplied only one length.
         assert!(
             pm.pad_trimmed_rows_variable(&data, &[4], TrimSide::Leading)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn pad_random_access_rows_dedups_offset_zero_across_rows() {
+        // Variant-2 RA shape: 4 rows, two length runs (3 rows of length 2,
+        // 1 row of length 3). Rows 0-2 share offset=0; row 3 sits at
+        // offset 2. Logical width 5 — leading-trim restoration leaves
+        // `width - trimmed` zero bytes at the start of each row.
+        let pm = PageMap {
+            data_recs: 4,
+            lengths: vec![2, 3],
+            leng_runs: vec![3, 1],
+            data_runs: vec![0, 0, 0, 2], // repurposed as data_offset[]
+        };
+        // data: bytes 0..2 = the dedup'd 2-byte payload for the first
+        // run; bytes 2..5 = the unique 3-byte payload for the last row.
+        let data = vec![0x0a, 0x0b, 0xcc, 0xdd, 0xee];
+        let widths = [5u32; 4];
+        let out = pm
+            .pad_random_access_rows(&data, &widths, TrimSide::Leading)
+            .unwrap();
+        // Each output row is 5 bytes; trimmed bytes right-aligned with
+        // leading zeros padding the gap.
+        assert_eq!(
+            out,
+            vec![
+                0, 0, 0, 0x0a, 0x0b, // row 0
+                0, 0, 0, 0x0a, 0x0b, // row 1 (shares offset)
+                0, 0, 0, 0x0a, 0x0b, // row 2 (shares offset)
+                0, 0, 0xcc, 0xdd, 0xee, // row 3
+            ]
+        );
+    }
+
+    #[test]
+    fn pad_random_access_rows_zero_trim_emits_all_zeros() {
+        // A zero-trim run means "no overlay for these rows" — the output
+        // width should still be respected; bytes stay zero.
+        let pm = PageMap {
+            data_recs: 2,
+            lengths: vec![0],
+            leng_runs: vec![2],
+            data_runs: vec![0, 0],
+        };
+        let data = vec![];
+        let out = pm
+            .pad_random_access_rows(&data, &[4, 4], TrimSide::Leading)
+            .unwrap();
+        assert_eq!(out, vec![0u8; 8]);
+    }
+
+    #[test]
+    fn pad_random_access_rows_trailing_side_left_aligns() {
+        // TrimSide::Trailing: trim<0,0> with side=1 strips trailing
+        // zeros, so restoration places stored bytes at the start of
+        // each row.
+        let pm = PageMap {
+            data_recs: 2,
+            lengths: vec![2],
+            leng_runs: vec![2],
+            data_runs: vec![0, 0],
+        };
+        let data = vec![0x11, 0x22];
+        let out = pm
+            .pad_random_access_rows(&data, &[5, 5], TrimSide::Trailing)
+            .unwrap();
+        assert_eq!(
+            out,
+            vec![
+                0x11, 0x22, 0, 0, 0, // row 0
+                0x11, 0x22, 0, 0, 0, // row 1
+            ]
+        );
+    }
+
+    #[test]
+    fn pad_random_access_rows_rejects_trim_greater_than_logical() {
+        // A trimmed length wider than the row's logical width would mean
+        // trim<0,0> output more bytes than its input held — corrupt
+        // page_map. Refuse.
+        let pm = PageMap {
+            data_recs: 1,
+            lengths: vec![10],
+            leng_runs: vec![1],
+            data_runs: vec![0],
+        };
+        let data = vec![0u8; 10];
+        assert!(
+            pm.pad_random_access_rows(&data, &[5], TrimSide::Leading)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn pad_random_access_rows_rejects_offset_past_data_end() {
+        // Offset+length out of bounds. Loud failure beats silent bad
+        // FASTQ; the caller logs the error and skips the merge.
+        let pm = PageMap {
+            data_recs: 1,
+            lengths: vec![3],
+            leng_runs: vec![1],
+            data_runs: vec![5], // 5 + 3 = 8 > data.len() = 6
+        };
+        let data = vec![0u8; 6];
+        assert!(
+            pm.pad_random_access_rows(&data, &[5], TrimSide::Leading)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn pad_random_access_rows_rejects_wrong_logical_lens_count() {
+        let pm = PageMap {
+            data_recs: 2,
+            lengths: vec![1],
+            leng_runs: vec![2],
+            data_runs: vec![0, 0],
+        };
+        let data = vec![0x01];
+        assert!(
+            pm.pad_random_access_rows(&data, &[4], TrimSide::Leading)
                 .is_err()
         );
     }


### PR DESCRIPTION
## Summary
- ncbi-vdb writes ALTREAD's `trim<0,0>(...)` rows under v1 variant-2 random-access page maps that overlay `data_offset[row_count]` on the `data_run` slot. Each row's post-trim bytes are sliced from the decompressed data buffer at `data_offsets[row]` for `lengths[run]` bytes; multiple rows can share an offset (write-time dedup), so the data buffer is much smaller than `sum(lengths × leng_runs)`. DRR024182 blob 162: 8192 rows / 77 unique lengths / 1981 stored bytes / only 17 unique offsets (6481 rows share offset=0). Existing padders don't model offset+dedup, so sracha was fail-fasting on these blobs.
- Adds `PageMap::pad_random_access_rows` and routes ALTREAD through it when the page_map shape signals variant-2 RA (`data_runs.len() == total_rows && lengths.len() > 1`). Handles both 1:1 ALTREAD/READ blob alignment and the DRR035866-style ALTREAD-bigger case (uniform `row_bases` widths, then the existing `row_offset * row_bases` slice picks out the READ portion).
- Keeps the fail-fast guard for the variant-2 **non**-random-access shape (`data_runs.is_empty() && lengths.len() > 1`); we still have no validated fixture for that flavor and silent skip would leak real N annotations into FASTQ.

## Validation
- `sracha fastq` on DRR024182 (4.8M spots, 9.6M reads, 542 MiB SRA) — byte-identical R1 + R2 FASTQ vs sratoolkit 3.4.1 fasterq-dump:
  ```
  57275996f1437c6106ec5109e50166ac  sracha/DRR024182_1.fastq
  57275996f1437c6106ec5109e50166ac  fasterq/DRR024182_1.fastq
  9eb31f68f7cc76d21a8a9a56106d77a6  sracha/DRR024182_2.fastq
  9eb31f68f7cc76d21a8a9a56106d77a6  fasterq/DRR024182_2.fastq
  ```
- SRR28588231 byte-identity (regression guard): R1 + R2 still match fasterq-dump.
- All 340 `sracha-vdb` unit tests pass (was 334 + 6 new tests for `pad_random_access_rows` covering dedup, zero-trim runs, trailing-side alignment, and three error paths).
- `cargo fmt` / `clippy --all-targets --all-features -D warnings` clean.

## Test plan
- [x] `pixi run -e dev fmt`
- [x] `pixi run -e dev clippy`
- [x] `pixi run -e dev test` (all suites)
- [x] Manual: `sracha fastq DRR024182.sra` → byte-identical vs `fasterq-dump`
- [x] Manual: `sracha fastq SRR28588231.sra` regression check (byte-identical)