### PR TITLE
feat(sracha): --head-concurrency for resolve fan-out

### DIFF
--- a/crates/sracha-core/src/http.rs
+++ b/crates/sracha-core/src/http.rs
@@ -8,9 +8,20 @@
 
 use std::time::Duration;
 
-/// Default HTTP client: HTTP/2 adaptive window, generous per-host pool,
-/// TCP keepalive, and a per-read timeout so a single stalled chunk
-/// can't hold up a parallel download.
+/// Default per-host idle connection pool size. Sized to match
+/// `s3::DEFAULT_PROBE_CONCURRENCY` so the resolve-phase HEAD storm
+/// can run wide without queueing on the pool.
+pub const DEFAULT_POOL_MAX_IDLE_PER_HOST: usize = 64;
+
+/// Default HTTP client at the default pool size.
+pub fn default_client() -> reqwest::Client {
+    client_with_pool(DEFAULT_POOL_MAX_IDLE_PER_HOST)
+}
+
+/// HTTP/2 adaptive window, configurable per-host pool, TCP keepalive,
+/// and a per-read timeout so a single stalled chunk can't hold up a
+/// parallel download. `pool_max_idle_per_host` is the only knob —
+/// the rest match `default_client()`.
 ///
 /// The read timeout bounds the gap between successive body reads, not
 /// the total request duration — slow-but-steady connections are fine,
@@ -20,11 +31,11 @@ use std::time::Duration;
 /// sitting on a dead TCP connection can block total download time on
 /// the slowest element, which profiling on NCBI's S3 mirror showed as
 /// a real (~6 s) tail every few runs.
-pub fn default_client() -> reqwest::Client {
+pub fn client_with_pool(pool_max_idle_per_host: usize) -> reqwest::Client {
     reqwest::Client::builder()
         .user_agent(format!("sracha/{}", env!("CARGO_PKG_VERSION")))
         .http2_adaptive_window(true)
-        .pool_max_idle_per_host(16)
+        .pool_max_idle_per_host(pool_max_idle_per_host)
         .tcp_keepalive(Some(Duration::from_secs(60)))
         .connect_timeout(Duration::from_secs(10))
         .read_timeout(Duration::from_secs(15))

--- a/crates/sracha-core/src/s3.rs
+++ b/crates/sracha-core/src/s3.rs
@@ -18,8 +18,12 @@ use crate::sdl::{ResolvedAccession, ResolvedFile, ResolvedMirror};
 
 const ODP_BASE: &str = "https://sra-pub-run-odp.s3.amazonaws.com/sra";
 
-/// Maximum concurrent HEAD probes.
-const PROBE_CONCURRENCY: usize = 16;
+/// Default concurrency for batched S3 HEAD probes. The CLI exposes this
+/// as `--head-concurrency` for users who want to widen (or narrow) the
+/// resolve fan-out on large accession lists. Should track
+/// `http::DEFAULT_POOL_MAX_IDLE_PER_HOST` so the semaphore isn't
+/// re-bottlenecked by the connection pool.
+pub const DEFAULT_PROBE_CONCURRENCY: usize = 64;
 
 /// Timeout for a single HEAD probe.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -119,14 +123,34 @@ pub async fn resolve_direct(
     })
 }
 
-/// Resolve multiple accessions concurrently via direct S3 HEAD probes.
-///
-/// Returns a map from accession to result. Failed probes appear as `Err`.
+/// Resolve multiple accessions concurrently via direct S3 HEAD probes
+/// at the default concurrency ([`DEFAULT_PROBE_CONCURRENCY`]).
 pub async fn resolve_direct_many(
     client: &reqwest::Client,
     accessions: &[String],
 ) -> HashMap<String, Result<ResolvedAccession>> {
-    let semaphore = Arc::new(Semaphore::new(PROBE_CONCURRENCY));
+    resolve_direct_many_with_concurrency(client, accessions, DEFAULT_PROBE_CONCURRENCY).await
+}
+
+/// Resolve multiple accessions concurrently via direct S3 HEAD probes
+/// with a caller-specified concurrency. `concurrency = 0` is treated
+/// as 1.
+///
+/// Returns a map from accession to result. Failed probes appear as `Err`.
+///
+/// Note that the underlying [`reqwest::Client`] caps connections via
+/// `pool_max_idle_per_host` (default [`crate::http::DEFAULT_POOL_MAX_IDLE_PER_HOST`]
+/// in `sracha_core::http::default_client`). Setting a concurrency
+/// higher than the pool size lets requests queue inside reqwest's
+/// connection pool — useful for reducing startup latency on large
+/// lists, but won't open more sockets than the client allows.
+pub async fn resolve_direct_many_with_concurrency(
+    client: &reqwest::Client,
+    accessions: &[String],
+    concurrency: usize,
+) -> HashMap<String, Result<ResolvedAccession>> {
+    let concurrency = concurrency.max(1);
+    let semaphore = Arc::new(Semaphore::new(concurrency));
     let mut handles = Vec::with_capacity(accessions.len());
 
     for acc in accessions {

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -460,6 +460,35 @@ pub struct GetArgs {
     /// split-3 or split-files (Phase 1 scope). Skips VDB decode entirely.
     #[arg(long, help_heading = "Advanced")]
     pub prefer_ena: bool,
+
+    /// Max concurrent S3 HEAD probes during accession resolution.
+    /// Default 64; clamped to 1–256. The HTTP client's per-host
+    /// connection pool is sized to match this value at startup, so
+    /// raising it actually opens more sockets to the SRA bucket
+    /// (rather than queueing on the pool). Values above ~128 rarely
+    /// help and risk hitting bucket-side rate limits.
+    #[arg(
+        long,
+        help_heading = "Advanced",
+        value_name = "N",
+        default_value_t = sracha_core::s3::DEFAULT_PROBE_CONCURRENCY,
+        value_parser = parse_head_concurrency,
+    )]
+    pub head_concurrency: usize,
+}
+
+const HEAD_CONCURRENCY_MAX: usize = 256;
+
+fn parse_head_concurrency(s: &str) -> Result<usize, String> {
+    let n: usize = s
+        .parse()
+        .map_err(|_| format!("`{s}` is not a non-negative integer"))?;
+    if !(1..=HEAD_CONCURRENCY_MAX).contains(&n) {
+        return Err(format!(
+            "head-concurrency must be between 1 and {HEAD_CONCURRENCY_MAX} (got {n})",
+        ));
+    }
+    Ok(n)
 }
 
 #[derive(Args)]

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -171,6 +171,7 @@ async fn main() -> Result<()> {
                 args.prefer_sdl,
                 false,
                 args.format.into(),
+                sracha_core::s3::DEFAULT_PROBE_CONCURRENCY,
             )
             .await?;
             sp.finish(format!(
@@ -348,7 +349,13 @@ async fn main() -> Result<()> {
                 cli::resolve_split_mode(args.split, args.stdout).map_err(|e| anyhow::anyhow!(e))?;
 
             let raw = collect_accessions(&args.accessions, args.accession_list.as_deref())?;
-            let http_client = sracha_core::http::default_client();
+            // Size the per-host pool to whichever is larger: the user's
+            // chosen `--head-concurrency` or the default pool size, so
+            // the resolve-phase semaphore isn't pool-limited.
+            let pool_size = args
+                .head_concurrency
+                .max(sracha_core::http::DEFAULT_POOL_MAX_IDLE_PER_HOST);
+            let http_client = sracha_core::http::client_with_pool(pool_size);
             let sdl_client = SdlClient::with_client(http_client.clone());
 
             let compression = cli::resolve_compression(
@@ -399,6 +406,7 @@ async fn main() -> Result<()> {
                 args.prefer_sdl,
                 !args.no_runinfo,
                 args.format.into(),
+                args.head_concurrency,
             )
             .await?;
             sp.finish(format!(
@@ -778,6 +786,7 @@ async fn main() -> Result<()> {
                 false, // prefer_sdl
                 true,  // need_run_info
                 sracha_core::sdl::FormatPreference::Sra,
+                sracha_core::s3::DEFAULT_PROBE_CONCURRENCY,
             )
             .await
             {
@@ -1577,6 +1586,7 @@ async fn resolve_accessions(
     prefer_sdl: bool,
     need_run_info: bool,
     format: sracha_core::sdl::FormatPreference,
+    head_concurrency: usize,
 ) -> Result<Vec<ResolvedAccession>> {
     // SRA-lite files are not on the free S3 ODP bucket, so we must use SDL.
     if prefer_sdl || format == sracha_core::sdl::FormatPreference::Sralite {
@@ -1601,7 +1611,11 @@ async fn resolve_accessions(
         "probing direct S3 for {} accession(s)...",
         run_accessions.len()
     );
-    let s3_future = sracha_core::s3::resolve_direct_many(client.http_client(), run_accessions);
+    let s3_future = sracha_core::s3::resolve_direct_many_with_concurrency(
+        client.http_client(),
+        run_accessions,
+        head_concurrency,
+    );
     let run_info_future = async {
         if need_run_info {
             Some(client.fetch_run_info_batch(run_accessions).await)


### PR DESCRIPTION
## Summary

- New `sracha get --head-concurrency <N>` flag (default 64, clamped 1–256) for tuning the S3 HEAD-probe fan-out used during accession resolution.
- Bumps `sracha-core`'s built-in defaults from 16 → 64 (`http::DEFAULT_POOL_MAX_IDLE_PER_HOST`, `s3::DEFAULT_PROBE_CONCURRENCY`) so multi-accession resolves run wider out of the box.
- Adds `client_with_pool(n)` and `resolve_direct_many_with_concurrency(client, accs, n)`; the existing zero-arg helpers (`default_client`, `resolve_direct_many`) fall through to the new defaults, so non-CLI callers (downloader, SDL client) get the wider pool automatically.
- `Get` sizes the per-host pool to `max(--head-concurrency, default pool)` at startup so raising `N` actually opens more sockets rather than queueing inside reqwest.
- `fetch` and `info` keep the default concurrency (no flag) — only the `get` path needs the knob in practice. Behavior at the existing call sites is unchanged except for the wider default fan-out.

This ports the library + CLI plumbing already in flight on `streaming-fastq` (commit 2cd8a4e plus the `cli.rs` / `main.rs` wiring) over to `main` as a self-contained change, with no dependency on the rest of streaming-fastq.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (340 unit tests pass; integration tests `#[ignore]`'d as usual)
- [x] `sracha get --help` shows `--head-concurrency <N>` with `[default: 64]`
- [x] `sracha fetch --help` / `sracha info --help` do **not** advertise the flag (intentional — scoped to `get`)
- [ ] Smoke `sracha get` against a small accession list with `--head-concurrency 128` to confirm the wider pool actually opens more sockets (manual)