### PR TITLE
feat(get): write metadata sidecar (TSV/JSON) per run (closes #37)

### DIFF
--- a/crates/sracha-core/benches/decode.rs
+++ b/crates/sracha-core/benches/decode.rs
@@ -53,6 +53,11 @@ fn config(out: &std::path::Path, threads: usize, compression: CompressionMode) -
         strict: false,
         http_client: None,
         keep_sra: false,
+        metadata: None,
+        metadata_url: None,
+        metadata_md5: None,
+        metadata_size: None,
+        metadata_service: None,
     }
 }
 

--- a/crates/sracha-core/src/lib.rs
+++ b/crates/sracha-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 pub mod fastq;
 pub mod http;
 pub mod info;
+pub mod metadata;
 pub mod pipeline;
 pub mod s3;
 pub mod sdl;

--- a/crates/sracha-core/src/metadata/mod.rs
+++ b/crates/sracha-core/src/metadata/mod.rs
@@ -1,0 +1,299 @@
+//! Run-metadata sidecar writer for `sracha get`.
+//!
+//! Emits a per-run TSV/JSON sidecar with BioSample, library, instrument and
+//! sequencing metrics resolved from NCBI EUtils RunInfo plus the download
+//! mirror chosen at fetch time. Intended for downstream pipelines that need
+//! to link FASTQ files to sample-level metadata without re-querying NCBI.
+
+use std::io::Write;
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::error::Result;
+use crate::sdl::ResolvedAccession;
+
+/// Sidecar output format selected by the `--metadata` CLI flag.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MetadataFormat {
+    /// Tab-separated values (one header row + one row per run).
+    Tsv,
+    /// JSON array of run-metadata objects, pretty-printed.
+    Json,
+    /// Both `.metadata.tsv` and `.metadata.json` side by side.
+    Both,
+}
+
+/// One row of run metadata — the full set of fields written to the sidecar.
+#[derive(Clone, Debug, Serialize)]
+pub struct RunMetadata {
+    pub accession: String,
+    pub url: Option<String>,
+    pub size_bytes: Option<u64>,
+    pub md5: Option<String>,
+    pub source_service: Option<String>,
+    pub spots: Option<u64>,
+    pub spot_len: Option<u32>,
+    pub nreads: Option<usize>,
+    pub avg_read_len: Vec<u32>,
+    pub platform: Option<String>,
+    pub instrument_model: Option<String>,
+    pub library_strategy: Option<String>,
+    pub library_source: Option<String>,
+    pub library_selection: Option<String>,
+    pub library_layout: Option<String>,
+    pub library_name: Option<String>,
+    pub experiment: Option<String>,
+    pub study: Option<String>,
+    pub bioproject: Option<String>,
+    pub sample: Option<String>,
+    pub biosample: Option<String>,
+    pub scientific_name: Option<String>,
+    pub tax_id: Option<u32>,
+    pub bases: Option<u64>,
+    pub size_mb: Option<u64>,
+    pub release_date: Option<String>,
+    pub load_date: Option<String>,
+}
+
+impl RunMetadata {
+    /// Build a `RunMetadata` row from a [`ResolvedAccession`], copying the
+    /// primary mirror's URL/service plus everything we know from EUtils
+    /// RunInfo. Missing fields stay `None`.
+    pub fn from_resolved(r: &ResolvedAccession) -> Self {
+        let primary = r.sra_file.mirrors.first();
+        let ri = r.run_info.as_ref();
+        Self {
+            accession: r.accession.clone(),
+            url: primary.map(|m| m.url.clone()),
+            size_bytes: Some(r.sra_file.size),
+            md5: r.sra_file.md5.clone(),
+            source_service: primary.map(|m| m.service.clone()),
+            spots: ri.and_then(|x| x.spots),
+            spot_len: ri.map(|x| x.spot_len),
+            nreads: ri.map(|x| x.nreads),
+            avg_read_len: ri.map(|x| x.avg_read_len.clone()).unwrap_or_default(),
+            platform: ri.and_then(|x| x.platform.clone()),
+            instrument_model: ri.and_then(|x| x.instrument_model.clone()),
+            library_strategy: ri.and_then(|x| x.library_strategy.clone()),
+            library_source: ri.and_then(|x| x.library_source.clone()),
+            library_selection: ri.and_then(|x| x.library_selection.clone()),
+            library_layout: ri.and_then(|x| x.library_layout.clone()),
+            library_name: ri.and_then(|x| x.library_name.clone()),
+            experiment: ri.and_then(|x| x.experiment.clone()),
+            study: ri.and_then(|x| x.study.clone()),
+            bioproject: ri.and_then(|x| x.bioproject.clone()),
+            sample: ri.and_then(|x| x.sample.clone()),
+            biosample: ri.and_then(|x| x.biosample.clone()),
+            scientific_name: ri.and_then(|x| x.scientific_name.clone()),
+            tax_id: ri.and_then(|x| x.tax_id),
+            bases: ri.and_then(|x| x.bases),
+            size_mb: ri.and_then(|x| x.size_mb),
+            release_date: ri.and_then(|x| x.release_date.clone()),
+            load_date: ri.and_then(|x| x.load_date.clone()),
+        }
+    }
+}
+
+const TSV_HEADER: &str = "accession\turl\tsize_bytes\tmd5\tsource_service\tspots\tspot_len\tnreads\tavg_read_len\tplatform\tinstrument_model\tlibrary_strategy\tlibrary_source\tlibrary_selection\tlibrary_layout\tlibrary_name\texperiment\tstudy\tbioproject\tsample\tbiosample\tscientific_name\ttax_id\tbases\tsize_mb\trelease_date\tload_date";
+
+fn opt_str(v: &Option<String>) -> &str {
+    v.as_deref().unwrap_or("")
+}
+
+fn opt_num<T: std::fmt::Display>(v: &Option<T>) -> String {
+    v.as_ref().map(|x| x.to_string()).unwrap_or_default()
+}
+
+/// Write a TSV sidecar to `path`, overwriting if present.
+pub fn write_tsv(path: &Path, rows: &[RunMetadata]) -> Result<()> {
+    let mut f = std::fs::File::create(path)?;
+    writeln!(f, "{}", TSV_HEADER)?;
+    for r in rows {
+        let avg = r
+            .avg_read_len
+            .iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        writeln!(
+            f,
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            r.accession,
+            opt_str(&r.url),
+            opt_num(&r.size_bytes),
+            opt_str(&r.md5),
+            opt_str(&r.source_service),
+            opt_num(&r.spots),
+            opt_num(&r.spot_len),
+            opt_num(&r.nreads),
+            avg,
+            opt_str(&r.platform),
+            opt_str(&r.instrument_model),
+            opt_str(&r.library_strategy),
+            opt_str(&r.library_source),
+            opt_str(&r.library_selection),
+            opt_str(&r.library_layout),
+            opt_str(&r.library_name),
+            opt_str(&r.experiment),
+            opt_str(&r.study),
+            opt_str(&r.bioproject),
+            opt_str(&r.sample),
+            opt_str(&r.biosample),
+            opt_str(&r.scientific_name),
+            opt_num(&r.tax_id),
+            opt_num(&r.bases),
+            opt_num(&r.size_mb),
+            opt_str(&r.release_date),
+            opt_str(&r.load_date),
+        )?;
+    }
+    Ok(())
+}
+
+/// Write a JSON sidecar to `path` (array of objects, pretty-printed),
+/// overwriting if present.
+pub fn write_json(path: &Path, rows: &[RunMetadata]) -> Result<()> {
+    let f = std::fs::File::create(path)?;
+    serde_json::to_writer_pretty(f, rows)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdl::{ResolvedFile, ResolvedMirror, RunInfo};
+
+    fn sample_resolved() -> ResolvedAccession {
+        ResolvedAccession {
+            accession: "SRR111222".into(),
+            sra_file: ResolvedFile {
+                mirrors: vec![ResolvedMirror {
+                    url: "https://s3.example.com/SRR111222".into(),
+                    service: "s3".into(),
+                }],
+                size: 9_876_543,
+                md5: Some("deadbeef".into()),
+                is_lite: false,
+            },
+            vdbcache_file: None,
+            run_info: Some(RunInfo {
+                nreads: 2,
+                avg_read_len: vec![151, 151],
+                spot_len: 302,
+                platform: Some("ILLUMINA".into()),
+                spots: Some(1_000),
+                library_strategy: Some("RNA-Seq".into()),
+                library_source: Some("TRANSCRIPTOMIC".into()),
+                library_selection: Some("cDNA".into()),
+                library_layout: Some("PAIRED".into()),
+                library_name: Some("lib_X".into()),
+                instrument_model: Some("Illumina NovaSeq 6000".into()),
+                experiment: Some("SRX111".into()),
+                study: Some("SRP222".into()),
+                bioproject: Some("PRJNA333".into()),
+                sample: Some("SRS444".into()),
+                biosample: Some("SAMN555".into()),
+                scientific_name: Some("Homo sapiens".into()),
+                tax_id: Some(9606),
+                bases: Some(302_000),
+                size_mb: Some(10),
+                release_date: Some("2024-01-01".into()),
+                load_date: Some("2024-01-02".into()),
+            }),
+        }
+    }
+
+    #[test]
+    fn from_resolved_copies_all_fields() {
+        let r = sample_resolved();
+        let m = RunMetadata::from_resolved(&r);
+        assert_eq!(m.accession, "SRR111222");
+        assert_eq!(m.url.as_deref(), Some("https://s3.example.com/SRR111222"));
+        assert_eq!(m.size_bytes, Some(9_876_543));
+        assert_eq!(m.md5.as_deref(), Some("deadbeef"));
+        assert_eq!(m.source_service.as_deref(), Some("s3"));
+        assert_eq!(m.spots, Some(1_000));
+        assert_eq!(m.spot_len, Some(302));
+        assert_eq!(m.nreads, Some(2));
+        assert_eq!(m.avg_read_len, vec![151, 151]);
+        assert_eq!(m.platform.as_deref(), Some("ILLUMINA"));
+        assert_eq!(m.instrument_model.as_deref(), Some("Illumina NovaSeq 6000"));
+        assert_eq!(m.library_strategy.as_deref(), Some("RNA-Seq"));
+        assert_eq!(m.library_source.as_deref(), Some("TRANSCRIPTOMIC"));
+        assert_eq!(m.library_selection.as_deref(), Some("cDNA"));
+        assert_eq!(m.library_layout.as_deref(), Some("PAIRED"));
+        assert_eq!(m.library_name.as_deref(), Some("lib_X"));
+        assert_eq!(m.experiment.as_deref(), Some("SRX111"));
+        assert_eq!(m.study.as_deref(), Some("SRP222"));
+        assert_eq!(m.bioproject.as_deref(), Some("PRJNA333"));
+        assert_eq!(m.sample.as_deref(), Some("SRS444"));
+        assert_eq!(m.biosample.as_deref(), Some("SAMN555"));
+        assert_eq!(m.scientific_name.as_deref(), Some("Homo sapiens"));
+        assert_eq!(m.tax_id, Some(9606));
+        assert_eq!(m.bases, Some(302_000));
+        assert_eq!(m.size_mb, Some(10));
+        assert_eq!(m.release_date.as_deref(), Some("2024-01-01"));
+        assert_eq!(m.load_date.as_deref(), Some("2024-01-02"));
+    }
+
+    #[test]
+    fn from_resolved_without_run_info_leaves_optional_fields_empty() {
+        let mut r = sample_resolved();
+        r.run_info = None;
+        let m = RunMetadata::from_resolved(&r);
+        // URL + size still come from the SDL response.
+        assert_eq!(m.url.as_deref(), Some("https://s3.example.com/SRR111222"));
+        assert_eq!(m.size_bytes, Some(9_876_543));
+        // RunInfo-derived fields default to None / empty.
+        assert!(m.spots.is_none());
+        assert!(m.platform.is_none());
+        assert!(m.biosample.is_none());
+        assert!(m.avg_read_len.is_empty());
+    }
+
+    #[test]
+    fn write_tsv_emits_header_and_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("SRR111222.metadata.tsv");
+        let row = RunMetadata::from_resolved(&sample_resolved());
+        write_tsv(&path, &[row]).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let mut lines = content.lines();
+        assert_eq!(lines.next(), Some(TSV_HEADER));
+        let data = lines.next().expect("data row present");
+        assert!(lines.next().is_none(), "exactly one data row");
+
+        // Spot-check selected columns appear in the expected order.
+        let cols: Vec<&str> = data.split('\t').collect();
+        assert_eq!(cols.len(), 27, "27 columns per row");
+        assert_eq!(cols[0], "SRR111222");
+        assert_eq!(cols[1], "https://s3.example.com/SRR111222");
+        assert_eq!(cols[2], "9876543");
+        assert_eq!(cols[3], "deadbeef");
+        assert_eq!(cols[4], "s3");
+        assert_eq!(cols[8], "151,151"); // avg_read_len joined by comma
+        assert_eq!(cols[9], "ILLUMINA");
+        assert_eq!(cols[20], "SAMN555");
+    }
+
+    #[test]
+    fn write_json_emits_array_of_one_object() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("SRR111222.metadata.json");
+        let row = RunMetadata::from_resolved(&sample_resolved());
+        write_json(&path, &[row]).unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let array = value.as_array().expect("array at the top level");
+        assert_eq!(array.len(), 1);
+        let obj = array[0].as_object().expect("first element is object");
+        assert_eq!(obj["accession"], "SRR111222");
+        assert_eq!(obj["biosample"], "SAMN555");
+        assert_eq!(obj["tax_id"], 9606);
+        assert!(obj.contains_key("library_strategy"));
+        assert!(obj.contains_key("avg_read_len"));
+    }
+}

--- a/crates/sracha-core/src/pipeline/config.rs
+++ b/crates/sracha-core/src/pipeline/config.rs
@@ -54,6 +54,22 @@ pub struct PipelineConfig {
     /// decode instead of deleting it. Useful for validation runs that
     /// want to compare against another tool on the same input file.
     pub keep_sra: bool,
+    /// Optional run-metadata sidecar format. When `Some`, [`decode_sra`]
+    /// writes a `<accession>.metadata.{tsv,json}` file next to the FASTQ
+    /// outputs after a successful decode.
+    ///
+    /// [`decode_sra`]: crate::pipeline::decode_sra
+    pub metadata: Option<crate::metadata::MetadataFormat>,
+    /// Primary download URL recorded into the metadata sidecar. Optional
+    /// because the `fastq` subcommand (local file decode) has no URL.
+    pub metadata_url: Option<String>,
+    /// MD5 of the SRA payload recorded into the metadata sidecar.
+    pub metadata_md5: Option<String>,
+    /// SDL-reported SRA size in bytes recorded into the metadata sidecar.
+    pub metadata_size: Option<u64>,
+    /// Mirror service label (e.g. `s3`, `gs`, `ncbi`) recorded into the
+    /// metadata sidecar.
+    pub metadata_service: Option<String>,
 }
 
 /// Statistics from a completed pipeline run.

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -1661,7 +1661,7 @@ pub fn decode_sra(downloaded: &DownloadedSra, config: &PipelineConfig) -> Result
     }
 
     let diag = Arc::new(IntegrityDiag::default());
-    let (spots_read, reads_written, output_files) = match decode_and_write(
+    let (spots_read, reads_written, mut output_files) = match decode_and_write(
         &downloaded.temp_path,
         &downloaded.accession,
         config,
@@ -1729,6 +1729,119 @@ pub fn decode_sra(downloaded: &DownloadedSra, config: &PipelineConfig) -> Result
             downloaded.accession,
             downloaded.temp_path.display(),
         );
+    }
+
+    // Write run-metadata sidecar(s), if requested. Done before the
+    // completion marker so the marker records the metadata file sizes too
+    // (and rerun-skips will keep the sidecar around).
+    if !config.stdout
+        && let Some(format) = config.metadata
+    {
+        let row = crate::metadata::RunMetadata {
+            accession: downloaded.accession.clone(),
+            url: config.metadata_url.clone(),
+            size_bytes: config.metadata_size,
+            md5: config.metadata_md5.clone(),
+            source_service: config.metadata_service.clone(),
+            spots: config.run_info.as_ref().and_then(|r| r.spots),
+            spot_len: config.run_info.as_ref().map(|r| r.spot_len),
+            nreads: config.run_info.as_ref().map(|r| r.nreads),
+            avg_read_len: config
+                .run_info
+                .as_ref()
+                .map(|r| r.avg_read_len.clone())
+                .unwrap_or_default(),
+            platform: config.run_info.as_ref().and_then(|r| r.platform.clone()),
+            instrument_model: config
+                .run_info
+                .as_ref()
+                .and_then(|r| r.instrument_model.clone()),
+            library_strategy: config
+                .run_info
+                .as_ref()
+                .and_then(|r| r.library_strategy.clone()),
+            library_source: config
+                .run_info
+                .as_ref()
+                .and_then(|r| r.library_source.clone()),
+            library_selection: config
+                .run_info
+                .as_ref()
+                .and_then(|r| r.library_selection.clone()),
+            library_layout: config
+                .run_info
+                .as_ref()
+                .and_then(|r| r.library_layout.clone()),
+            library_name: config
+                .run_info
+                .as_ref()
+                .and_then(|r| r.library_name.clone()),
+            experiment: config.run_info.as_ref().and_then(|r| r.experiment.clone()),
+            study: config.run_info.as_ref().and_then(|r| r.study.clone()),
+            bioproject: config.run_info.as_ref().and_then(|r| r.bioproject.clone()),
+            sample: config.run_info.as_ref().and_then(|r| r.sample.clone()),
+            biosample: config.run_info.as_ref().and_then(|r| r.biosample.clone()),
+            scientific_name: config
+                .run_info
+                .as_ref()
+                .and_then(|r| r.scientific_name.clone()),
+            tax_id: config.run_info.as_ref().and_then(|r| r.tax_id),
+            bases: config.run_info.as_ref().and_then(|r| r.bases),
+            size_mb: config.run_info.as_ref().and_then(|r| r.size_mb),
+            release_date: config
+                .run_info
+                .as_ref()
+                .and_then(|r| r.release_date.clone()),
+            load_date: config.run_info.as_ref().and_then(|r| r.load_date.clone()),
+        };
+        let stem = config.output_dir.join(&downloaded.accession);
+        let rows = [row];
+        let tsv_path = stem.with_extension("metadata.tsv");
+        let json_path = stem.with_extension("metadata.json");
+        match format {
+            crate::metadata::MetadataFormat::Tsv => {
+                if let Err(e) = crate::metadata::write_tsv(&tsv_path, &rows) {
+                    tracing::warn!(
+                        "{}: failed to write metadata TSV {}: {e}",
+                        downloaded.accession,
+                        tsv_path.display(),
+                    );
+                } else {
+                    output_files.push(tsv_path);
+                }
+            }
+            crate::metadata::MetadataFormat::Json => {
+                if let Err(e) = crate::metadata::write_json(&json_path, &rows) {
+                    tracing::warn!(
+                        "{}: failed to write metadata JSON {}: {e}",
+                        downloaded.accession,
+                        json_path.display(),
+                    );
+                } else {
+                    output_files.push(json_path);
+                }
+            }
+            crate::metadata::MetadataFormat::Both => {
+                if let Err(e) = crate::metadata::write_tsv(&tsv_path, &rows) {
+                    tracing::warn!(
+                        "{}: failed to write metadata TSV {}: {e}",
+                        downloaded.accession,
+                        tsv_path.display(),
+                    );
+                } else {
+                    output_files.push(tsv_path);
+                }
+                if let Err(e) = crate::metadata::write_json(&json_path, &rows) {
+                    tracing::warn!(
+                        "{}: failed to write metadata JSON {}: {e}",
+                        downloaded.accession,
+                        json_path.display(),
+                    );
+                } else {
+                    output_files.push(json_path);
+                }
+            }
+        }
     }
 
     // Write completion marker so future runs can skip this accession.

--- a/crates/sracha-core/src/sdl/mod.rs
+++ b/crates/sracha-core/src/sdl/mod.rs
@@ -107,7 +107,7 @@ pub struct ResolvedFile {
 ///
 /// Queried from the EFetch RunInfo CSV endpoint, this provides authoritative
 /// read structure information that is more reliable than parsing VDB metadata.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RunInfo {
     /// Number of reads per spot (1 for SINGLE, 2 for PAIRED).
     pub nreads: usize,
@@ -119,6 +119,40 @@ pub struct RunInfo {
     pub platform: Option<String>,
     /// Total spot count reported by EUtils RunInfo (None if missing/unparseable).
     pub spots: Option<u64>,
+    /// Library strategy (e.g. "WGS", "RNA-Seq", "ChIP-Seq").
+    pub library_strategy: Option<String>,
+    /// Library source (e.g. "GENOMIC", "TRANSCRIPTOMIC").
+    pub library_source: Option<String>,
+    /// Library selection (e.g. "RANDOM", "PCR").
+    pub library_selection: Option<String>,
+    /// Library layout (e.g. "SINGLE", "PAIRED").
+    pub library_layout: Option<String>,
+    /// Library name.
+    pub library_name: Option<String>,
+    /// Instrument model (e.g. "Illumina NovaSeq 6000").
+    pub instrument_model: Option<String>,
+    /// SRA Experiment accession (SRX).
+    pub experiment: Option<String>,
+    /// SRA Study accession (SRP).
+    pub study: Option<String>,
+    /// NCBI BioProject accession (PRJNA / PRJEB / PRJDB).
+    pub bioproject: Option<String>,
+    /// SRA Sample accession (SRS).
+    pub sample: Option<String>,
+    /// NCBI BioSample accession (SAMN / SAMEA / SAMD).
+    pub biosample: Option<String>,
+    /// Scientific name of organism.
+    pub scientific_name: Option<String>,
+    /// NCBI Taxonomy ID.
+    pub tax_id: Option<u32>,
+    /// Total bases in the run.
+    pub bases: Option<u64>,
+    /// File size in megabytes (reported by EUtils).
+    pub size_mb: Option<u64>,
+    /// Release date.
+    pub release_date: Option<String>,
+    /// Load date.
+    pub load_date: Option<String>,
 }
 
 /// Resolved download information for a single accession.
@@ -485,6 +519,22 @@ fn parse_run_info_csv_multi(body: &str) -> HashMap<String, RunInfo> {
     let run_idx = col("Run");
     let platform_idx = col("Platform");
     let spots_idx = col("spots");
+    let library_strategy_idx = col("LibraryStrategy");
+    let library_source_idx = col("LibrarySource");
+    let library_selection_idx = col("LibrarySelection");
+    let library_name_idx = col("LibraryName");
+    let model_idx = col("Model");
+    let experiment_idx = col("Experiment");
+    let study_idx = col("SRAStudy");
+    let bioproject_idx = col("BioProject");
+    let sample_idx = col("Sample");
+    let biosample_idx = col("BioSample");
+    let scientific_name_idx = col("ScientificName");
+    let tax_id_idx = col("TaxID");
+    let bases_idx = col("bases");
+    let size_mb_idx = col("size_MB");
+    let release_date_idx = col("ReleaseDate");
+    let load_date_idx = col("LoadDate");
 
     for data in lines {
         let values: Vec<&str> = data.split(',').collect();
@@ -537,6 +587,41 @@ fn parse_run_info_csv_multi(body: &str) -> HashMap<String, RunInfo> {
 
         let spots = spots_idx.and_then(|i| values.get(i).and_then(|v| v.parse::<u64>().ok()));
 
+        // Helper closure: copy column value as Option<String>, treating empty as None.
+        let opt_str = |idx: Option<usize>| -> Option<String> {
+            idx.and_then(|i| values.get(i).copied())
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+        };
+        let opt_u64 = |idx: Option<usize>| -> Option<u64> {
+            idx.and_then(|i| values.get(i).and_then(|v| v.parse::<u64>().ok()))
+        };
+        let opt_u32 = |idx: Option<usize>| -> Option<u32> {
+            idx.and_then(|i| values.get(i).and_then(|v| v.parse::<u32>().ok()))
+        };
+
+        let library_strategy = opt_str(library_strategy_idx);
+        let library_source = opt_str(library_source_idx);
+        let library_selection = opt_str(library_selection_idx);
+        let library_layout = if layout.is_empty() {
+            None
+        } else {
+            Some(layout.to_string())
+        };
+        let library_name = opt_str(library_name_idx);
+        let instrument_model = opt_str(model_idx);
+        let experiment = opt_str(experiment_idx);
+        let study = opt_str(study_idx);
+        let bioproject = opt_str(bioproject_idx);
+        let sample = opt_str(sample_idx);
+        let biosample = opt_str(biosample_idx);
+        let scientific_name = opt_str(scientific_name_idx);
+        let tax_id = opt_u32(tax_id_idx);
+        let bases = opt_u64(bases_idx);
+        let size_mb = opt_u64(size_mb_idx);
+        let release_date = opt_str(release_date_idx);
+        let load_date = opt_str(load_date_idx);
+
         tracing::debug!(
             "{accession}: EUtils RunInfo: layout={layout}, avgLength={avg_length}, \
              nreads={nreads}, per_read_len={avg_read_len:?}, platform={platform:?}, spots={spots:?}",
@@ -550,6 +635,23 @@ fn parse_run_info_csv_multi(body: &str) -> HashMap<String, RunInfo> {
                 spot_len: avg_length,
                 platform,
                 spots,
+                library_strategy,
+                library_source,
+                library_selection,
+                library_layout,
+                library_name,
+                instrument_model,
+                experiment,
+                study,
+                bioproject,
+                sample,
+                biosample,
+                scientific_name,
+                tax_id,
+                bases,
+                size_mb,
+                release_date,
+                load_date,
             },
         );
     }
@@ -805,5 +907,68 @@ mod tests {
     fn parse_run_accessions_no_run_column() {
         let csv = "spots,bases\n100,200\n";
         assert!(parse_run_accessions_from_csv(csv).is_empty());
+    }
+
+    #[test]
+    fn parse_run_info_full_columns() {
+        // Header order chosen to mirror NCBI's EUtils RunInfo CSV. All 17 new
+        // optional columns are present so we can assert every field round-trips.
+        let csv = "Run,ReleaseDate,LoadDate,spots,bases,spots_with_mates,avgLength,\
+                   size_MB,AssemblyName,download_path,Experiment,LibraryName,\
+                   LibraryStrategy,LibrarySelection,LibrarySource,LibraryLayout,\
+                   InsertSize,InsertDev,Platform,Model,SRAStudy,BioProject,Study_Pubmed_Id,\
+                   ProjectID,Sample,BioSample,SampleType,TaxID,ScientificName,\
+                   SampleName,g1k_pop_code,source,g1k_analysis_group,Subject_ID,\
+                   Sex,Disease,Tumor,Affection_Status,Analyte_Type,Histological_Type,\
+                   Body_Site,CenterName,Submission,dbgap_study_accession,Consent,\
+                   RunHash,ReadHash\n\
+                   SRR9999999,2024-01-15,2024-01-20,123456,37000000,123456,300,\
+                   42,,https://example.com/SRR9999999.sra,SRX111222,my_library,\
+                   RNA-Seq,cDNA,TRANSCRIPTOMIC,PAIRED,0,0,ILLUMINA,Illumina NovaSeq 6000,\
+                   SRP000111,PRJNA000222,0,222,SRS000333,SAMN00000444,simple,9606,\
+                   Homo sapiens,sample-name,,size,RANDOM,subj1,female,,no,affected,\
+                   RNA,normal,blood,GEO,SRA000555,,public,abc,def\n";
+        let ri = parse_run_info_csv(csv, "SRR9999999").expect("row parses");
+
+        // Pre-existing fields still work.
+        assert_eq!(ri.nreads, 2);
+        assert_eq!(ri.spot_len, 300);
+        assert_eq!(ri.avg_read_len, vec![150, 150]);
+        assert_eq!(ri.spots, Some(123_456));
+        assert_eq!(ri.platform.as_deref(), Some("ILLUMINA"));
+
+        // All 17 new fields populated as expected.
+        assert_eq!(ri.library_strategy.as_deref(), Some("RNA-Seq"));
+        assert_eq!(ri.library_source.as_deref(), Some("TRANSCRIPTOMIC"));
+        assert_eq!(ri.library_selection.as_deref(), Some("cDNA"));
+        assert_eq!(ri.library_layout.as_deref(), Some("PAIRED"));
+        assert_eq!(ri.library_name.as_deref(), Some("my_library"));
+        assert_eq!(
+            ri.instrument_model.as_deref(),
+            Some("Illumina NovaSeq 6000")
+        );
+        assert_eq!(ri.experiment.as_deref(), Some("SRX111222"));
+        assert_eq!(ri.study.as_deref(), Some("SRP000111"));
+        assert_eq!(ri.bioproject.as_deref(), Some("PRJNA000222"));
+        assert_eq!(ri.sample.as_deref(), Some("SRS000333"));
+        assert_eq!(ri.biosample.as_deref(), Some("SAMN00000444"));
+        assert_eq!(ri.scientific_name.as_deref(), Some("Homo sapiens"));
+        assert_eq!(ri.tax_id, Some(9606));
+        assert_eq!(ri.bases, Some(37_000_000));
+        assert_eq!(ri.size_mb, Some(42));
+        assert_eq!(ri.release_date.as_deref(), Some("2024-01-15"));
+        assert_eq!(ri.load_date.as_deref(), Some("2024-01-20"));
+    }
+
+    #[test]
+    fn run_info_default_is_all_none() {
+        let ri = RunInfo::default();
+        assert_eq!(ri.nreads, 0);
+        assert!(ri.avg_read_len.is_empty());
+        assert_eq!(ri.spot_len, 0);
+        assert!(ri.platform.is_none());
+        assert!(ri.library_strategy.is_none());
+        assert!(ri.biosample.is_none());
+        assert!(ri.tax_id.is_none());
     }
 }

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -256,6 +256,11 @@ fn test_config(
         strict: false,
         http_client: None,
         keep_sra: false,
+        metadata: None,
+        metadata_url: None,
+        metadata_md5: None,
+        metadata_size: None,
+        metadata_service: None,
     }
 }
 

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -408,6 +408,11 @@ pub struct GetArgs {
     #[arg(long, default_value_t = 8)]
     pub connections: usize,
 
+    /// Write run metadata (BioSample, library, instrument, etc.) sidecar
+    /// file(s) alongside each FASTQ output.
+    #[arg(long, value_enum, help_heading = "Output")]
+    pub metadata: Option<MetadataFormat>,
+
     /// Number of accessions to download ahead of the decoder. A larger
     /// value hides slow networks behind decode, at the cost of one extra
     /// temp SRA file per depth step. Only applies to multi-accession
@@ -558,6 +563,26 @@ impl From<SraFormat> for FormatPreference {
         match f {
             SraFormat::Sra => FormatPreference::Sra,
             SraFormat::Sralite => FormatPreference::Sralite,
+        }
+    }
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub enum MetadataFormat {
+    /// Write a single TSV sidecar (`<acc>.metadata.tsv`).
+    Tsv,
+    /// Write a single JSON sidecar (`<acc>.metadata.json`).
+    Json,
+    /// Write both TSV and JSON sidecars.
+    Both,
+}
+
+impl From<MetadataFormat> for sracha_core::metadata::MetadataFormat {
+    fn from(f: MetadataFormat) -> Self {
+        match f {
+            MetadataFormat::Tsv => sracha_core::metadata::MetadataFormat::Tsv,
+            MetadataFormat::Json => sracha_core::metadata::MetadataFormat::Json,
+            MetadataFormat::Both => sracha_core::metadata::MetadataFormat::Both,
         }
     }
 }

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -325,6 +325,11 @@ async fn main() -> Result<()> {
                     http_client: None,
                     strict: !args.no_strict,
                     keep_sra: false,
+                    metadata: None,
+                    metadata_url: None,
+                    metadata_md5: None,
+                    metadata_size: None,
+                    metadata_service: None,
                 };
 
                 let stats = sracha_core::pipeline::run_fastq(sra_path, None, &pipeline_config)?;
@@ -503,24 +508,32 @@ async fn main() -> Result<()> {
             let make_config = {
                 let http_client = http_client.clone();
                 let cancelled = cancelled.clone();
-                move |resolved: &ResolvedAccession| sracha_core::pipeline::PipelineConfig {
-                    output_dir: args.output_dir.clone(),
-                    split_mode,
-                    compression,
-                    threads: args.threads,
-                    connections: args.connections,
-                    skip_technical: !args.include_technical,
-                    min_read_len: args.min_read_len,
-                    force: args.force,
-                    progress,
-                    run_info: resolved.run_info.clone(),
-                    fasta: args.fasta,
-                    resume: !args.no_resume,
-                    stdout: args.stdout,
-                    cancelled: Some(cancelled.clone()),
-                    strict: !args.no_strict,
-                    http_client: Some(http_client.clone()),
-                    keep_sra: args.keep_sra,
+                move |resolved: &ResolvedAccession| {
+                    let primary = resolved.sra_file.mirrors.first();
+                    sracha_core::pipeline::PipelineConfig {
+                        output_dir: args.output_dir.clone(),
+                        split_mode,
+                        compression,
+                        threads: args.threads,
+                        connections: args.connections,
+                        skip_technical: !args.include_technical,
+                        min_read_len: args.min_read_len,
+                        force: args.force,
+                        progress,
+                        run_info: resolved.run_info.clone(),
+                        fasta: args.fasta,
+                        resume: !args.no_resume,
+                        stdout: args.stdout,
+                        cancelled: Some(cancelled.clone()),
+                        strict: !args.no_strict,
+                        http_client: Some(http_client.clone()),
+                        keep_sra: args.keep_sra,
+                        metadata: args.metadata.map(Into::into),
+                        metadata_url: primary.map(|m| m.url.clone()),
+                        metadata_md5: resolved.sra_file.md5.clone(),
+                        metadata_size: Some(resolved.sra_file.size),
+                        metadata_service: primary.map(|m| m.service.clone()),
+                    }
                 }
             };
 


### PR DESCRIPTION
## Summary
- Adds `sracha get --metadata {tsv,json,both}` which writes a `{accession}.metadata.{tsv,json}` sidecar alongside each FASTQ output after a successful decode.
- Extends the parsed EUtils RunInfo CSV with 17 additional columns: library strategy/source/selection/layout/name, instrument model, experiment, study, BioProject, Sample (SRS), BioSample (SAMN), scientific name, tax id, bases, size_MB, release/load dates.
- New `sracha_core::metadata` module owns the flat `RunMetadata` data model + TSV/JSON writers.
- Sidecar paths are tracked in the completion marker so resume/force behave consistently.

Closes #37.

## Test plan
- [x] `cargo build`
- [x] `cargo test -p sracha-core --lib` (192 passing, includes new RunInfo parser test + metadata module tests)
- [x] `cargo test -p sracha`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual smoke: `sracha get SRR1234567 --metadata both -O /tmp/x` produces TSV and JSON sidecars with non-empty BioSample/library/instrument fields
- [ ] Manual smoke: confirm `.sracha-done-SRR…` marker lists the metadata files