### PR TITLE
feat(get): add --folder-per-accession output mode (closes #40)

### DIFF
--- a/crates/sracha-core/benches/decode.rs
+++ b/crates/sracha-core/benches/decode.rs
@@ -53,6 +53,7 @@ fn config(out: &std::path::Path, threads: usize, compression: CompressionMode) -
         strict: false,
         http_client: None,
         keep_sra: false,
+        folder_per_accession: false,
     }
 }
 

--- a/crates/sracha-core/src/pipeline/config.rs
+++ b/crates/sracha-core/src/pipeline/config.rs
@@ -54,6 +54,23 @@ pub struct PipelineConfig {
     /// decode instead of deleting it. Useful for validation runs that
     /// want to compare against another tool on the same input file.
     pub keep_sra: bool,
+    /// Place each accession's outputs (FASTQ + sidecars + temp SRA) inside
+    /// its own subdirectory of `output_dir`, named after the accession.
+    /// When `false`, all files land flat in `output_dir`.
+    pub folder_per_accession: bool,
+}
+
+impl PipelineConfig {
+    /// Directory where outputs for `accession` should be written.
+    /// With `folder_per_accession`, this is `output_dir / accession`.
+    /// Otherwise it's `output_dir`.
+    pub fn accession_output_dir(&self, accession: &str) -> std::path::PathBuf {
+        if self.folder_per_accession {
+            self.output_dir.join(accession)
+        } else {
+            self.output_dir.clone()
+        }
+    }
 }
 
 /// Statistics from a completed pipeline run.
@@ -74,4 +91,47 @@ pub struct PipelineStats {
     /// default; pass `--no-strict` to downgrade any non-zero counter from a
     /// hard failure to a warning and inspect these values instead.
     pub integrity: Arc<IntegrityDiag>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(folder_per_accession: bool) -> PipelineConfig {
+        PipelineConfig {
+            output_dir: PathBuf::from("/tmp/x"),
+            split_mode: crate::fastq::SplitMode::Split3,
+            compression: crate::fastq::CompressionMode::None,
+            threads: 1,
+            connections: 1,
+            skip_technical: true,
+            min_read_len: None,
+            force: false,
+            progress: false,
+            run_info: None,
+            fasta: false,
+            resume: true,
+            stdout: false,
+            cancelled: None,
+            strict: false,
+            http_client: None,
+            keep_sra: false,
+            folder_per_accession,
+        }
+    }
+
+    #[test]
+    fn accession_output_dir_flat() {
+        let cfg = test_config(false);
+        assert_eq!(cfg.accession_output_dir("SRR1"), PathBuf::from("/tmp/x"));
+    }
+
+    #[test]
+    fn accession_output_dir_nested() {
+        let cfg = test_config(true);
+        assert_eq!(
+            cfg.accession_output_dir("SRR1"),
+            PathBuf::from("/tmp/x/SRR1"),
+        );
+    }
 }

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -177,8 +177,9 @@ fn create_output_writer_for_slot(
     compress_pool: &Option<Arc<rayon::ThreadPool>>,
 ) -> (OutputWriter, PathBuf, PathBuf) {
     let filename = output_filename(accession, slot, config.fasta, &config.compression);
-    let final_path = config.output_dir.join(&filename);
-    let tmp_path = config.output_dir.join(format!("{filename}.partial"));
+    let out_dir = config.accession_output_dir(accession);
+    let final_path = out_dir.join(&filename);
+    let tmp_path = out_dir.join(format!("{filename}.partial"));
 
     let file = std::fs::File::create(&tmp_path).expect("failed to create output file");
     let buf = std::io::BufWriter::with_capacity(256 * 1024, file);
@@ -430,7 +431,7 @@ fn decode_and_write(
 
     // Create output directory (not needed for stdout mode).
     if !config.stdout {
-        std::fs::create_dir_all(&config.output_dir)?;
+        std::fs::create_dir_all(config.accession_output_dir(accession))?;
     }
 
     // Lazily create output writers as we encounter different output slots.
@@ -1172,7 +1173,7 @@ fn run_fastq_csra(
     };
 
     if !config.stdout {
-        std::fs::create_dir_all(&config.output_dir)?;
+        std::fs::create_dir_all(config.accession_output_dir(acc))?;
     }
 
     let mut writers: HashMap<OutputSlot, OutputWriter> = HashMap::new();
@@ -1306,8 +1307,9 @@ fn run_fastq_csra(
             return Ok(());
         }
         let filename = output_filename(acc, slot, config.fasta, &config.compression);
-        let final_path = config.output_dir.join(&filename);
-        let tmp_path = config.output_dir.join(format!("{filename}.partial"));
+        let out_dir = config.accession_output_dir(acc);
+        let final_path = out_dir.join(&filename);
+        let tmp_path = out_dir.join(format!("{filename}.partial"));
         output_paths.push((final_path, tmp_path.clone()));
         let file = std::fs::File::create(&tmp_path)?;
         let buf = std::io::BufWriter::with_capacity(256 * 1024, file);
@@ -1432,20 +1434,21 @@ pub async fn download_sra(
 ) -> Result<DownloadedSra> {
     let accession = &resolved.accession;
     let total_sra_size = resolved.sra_file.size;
+    let acc_dir = config.accession_output_dir(accession);
 
     // Delete completion marker when --force is used.
     if config.force {
-        let _ = std::fs::remove_file(marker_path(&config.output_dir, accession));
+        let _ = std::fs::remove_file(marker_path(&acc_dir, accession));
     }
 
     // If outputs already exist (validated via completion marker), skip entirely.
     if !config.force
         && !config.stdout
-        && check_completion_marker(&config.output_dir, accession, config, total_sra_size).is_some()
+        && check_completion_marker(&acc_dir, accession, config, total_sra_size).is_some()
     {
         tracing::info!("{accession}: outputs already exist, skipping download");
         let temp_filename = format!(".sracha-tmp-{accession}.sra");
-        let temp_path = config.output_dir.join(&temp_filename);
+        let temp_path = acc_dir.join(&temp_filename);
         return Ok(DownloadedSra {
             temp_path,
             bytes_transferred: 0,
@@ -1462,9 +1465,9 @@ pub async fn download_sra(
     tracing::debug!("{accession}: starting full download from {url}");
 
     let temp_filename = format!(".sracha-tmp-{accession}.sra");
-    let temp_path = config.output_dir.join(&temp_filename);
+    let temp_path = acc_dir.join(&temp_filename);
 
-    tokio::fs::create_dir_all(&config.output_dir).await?;
+    tokio::fs::create_dir_all(&acc_dir).await?;
 
     let dl_config = DownloadConfig {
         connections: config.connections,
@@ -1540,7 +1543,8 @@ pub async fn download_ena_fastq(
     config: &PipelineConfig,
 ) -> Result<PipelineStats> {
     let accession = &ena.accession;
-    tokio::fs::create_dir_all(&config.output_dir).await?;
+    let acc_dir = config.accession_output_dir(accession);
+    tokio::fs::create_dir_all(&acc_dir).await?;
 
     let dl_config = DownloadConfig {
         connections: config.connections,
@@ -1570,7 +1574,7 @@ pub async fn download_ena_fastq(
         }
 
         let name = output_filename(accession, file.slot, config.fasta, &config.compression);
-        let target = config.output_dir.join(&name);
+        let target = acc_dir.join(&name);
 
         tracing::info!(
             "{accession}: downloading ENA FASTQ {} ({}) → {}",
@@ -1628,11 +1632,12 @@ async fn poll_cancelled(flag: Arc<AtomicBool>) {
 /// This is the decode phase of `run_get`. Call from within
 /// `tokio::task::block_in_place` or a blocking thread.
 pub fn decode_sra(downloaded: &DownloadedSra, config: &PipelineConfig) -> Result<PipelineStats> {
+    let acc_dir = config.accession_output_dir(&downloaded.accession);
     // Check if decode can be skipped (unless --force or stdout mode).
     if let Some(output_files) = (!config.force && !config.stdout)
         .then(|| {
             check_completion_marker(
-                &config.output_dir,
+                &acc_dir,
                 &downloaded.accession,
                 config,
                 downloaded.total_sra_size,
@@ -1671,7 +1676,7 @@ pub fn decode_sra(downloaded: &DownloadedSra, config: &PipelineConfig) -> Result
         Ok(result) => result,
         Err(Error::Cancelled { output_files }) => {
             // Delete completion marker (may not exist yet).
-            let _ = std::fs::remove_file(marker_path(&config.output_dir, &downloaded.accession));
+            let _ = std::fs::remove_file(marker_path(&acc_dir, &downloaded.accession));
             // Delete partial FASTQ output files.
             for path in &output_files {
                 if let Err(e) = std::fs::remove_file(path) {
@@ -1709,9 +1714,7 @@ pub fn decode_sra(downloaded: &DownloadedSra, config: &PipelineConfig) -> Result
 
     // Clean up temp file (or preserve it in the output dir if requested).
     if config.keep_sra && !config.stdout {
-        let kept = config
-            .output_dir
-            .join(format!("{}.sra", downloaded.accession));
+        let kept = acc_dir.join(format!("{}.sra", downloaded.accession));
         if let Err(e) = std::fs::rename(&downloaded.temp_path, &kept) {
             tracing::warn!(
                 "{}: failed to move temp SRA {} -> {}: {e}",
@@ -1734,7 +1737,7 @@ pub fn decode_sra(downloaded: &DownloadedSra, config: &PipelineConfig) -> Result
     // Write completion marker so future runs can skip this accession.
     if !config.stdout
         && let Err(e) = write_completion_marker(
-            &config.output_dir,
+            &acc_dir,
             &downloaded.accession,
             downloaded.sra_md5.as_deref(),
             downloaded.total_sra_size,

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -256,6 +256,7 @@ fn test_config(
         strict: false,
         http_client: None,
         keep_sra: false,
+        folder_per_accession: false,
     }
 }
 

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -269,6 +269,12 @@ pub struct FastqArgs {
     #[arg(short, long, help_heading = "Output")]
     pub force: bool,
 
+    /// Place each accession's outputs (FASTQ + sidecars) inside its own
+    /// subdirectory of the output directory, named after the accession.
+    /// Default: all files flat in the output directory.
+    #[arg(long, help_heading = "Output")]
+    pub folder_per_accession: bool,
+
     /// Disable gzip compression (compressed by default)
     #[arg(
         long,
@@ -357,6 +363,12 @@ pub struct GetArgs {
     /// Overwrite existing files
     #[arg(short, long, help_heading = "Output")]
     pub force: bool,
+
+    /// Place each accession's outputs (FASTQ + sidecars) inside its own
+    /// subdirectory of the output directory, named after the accession.
+    /// Default: all files flat in the output directory.
+    #[arg(long, help_heading = "Output")]
+    pub folder_per_accession: bool,
 
     /// Disable gzip compression (compressed by default)
     #[arg(

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -325,6 +325,7 @@ async fn main() -> Result<()> {
                     http_client: None,
                     strict: !args.no_strict,
                     keep_sra: false,
+                    folder_per_accession: args.folder_per_accession,
                 };
 
                 let stats = sracha_core::pipeline::run_fastq(sra_path, None, &pipeline_config)?;
@@ -521,6 +522,7 @@ async fn main() -> Result<()> {
                     strict: !args.no_strict,
                     http_client: Some(http_client.clone()),
                     keep_sra: args.keep_sra,
+                    folder_per_accession: args.folder_per_accession,
                 }
             };
 


### PR DESCRIPTION
## Summary
- Adds `--folder-per-accession` flag on both `get` and `fastq` commands.
- When set, each accession's outputs land in `<output_dir>/<accession>/`: FASTQ files, the `.sracha-done-{accession}` completion marker, the temp `.sracha-tmp-{accession}.sra`, the `.sracha-progress` sidecar, and any `--keep-sra` artifact.
- The shared `sracha-stats.jsonl` deliberately stays at the top-level `output_dir` so the audit log keeps aggregating across runs.
- New helper `PipelineConfig::accession_output_dir(&accession)` centralizes the path computation; all per-run write sites route through it (VDB decode, cSRA decode, ENA fast-path, completion-marker logic, `--keep-sra` rename).
- Default (flag off) behavior is unchanged: flat layout, no subdirectories.

Closes #40.

## Test plan
- [x] `cargo build`
- [x] `cargo test -p sracha-core --lib` (188 passing, includes 2 new helper tests)
- [x] `cargo test -p sracha`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual smoke: `sracha get SRR1234567 ERR9234567 --folder-per-accession -O /tmp/x` produces `/tmp/x/SRR1234567/*` and `/tmp/x/ERR9234567/*`
- [ ] Manual smoke: confirm `sracha-stats.jsonl` lands in `/tmp/x/` (not inside an accession subdir)
- [ ] Manual smoke: resume after interruption finds the marker inside the accession subdir and skips re-decoding