### PR TITLE
feat(fastq): add --paired-suffix flag for _R1/_R2 output (closes #39)

### DIFF
--- a/crates/sracha-core/benches/decode.rs
+++ b/crates/sracha-core/benches/decode.rs
@@ -53,6 +53,7 @@ fn config(out: &std::path::Path, threads: usize, compression: CompressionMode) -
         strict: false,
         http_client: None,
         keep_sra: false,
+        paired_suffix: sracha_core::fastq::PairedSuffix::Numeric,
     }
 }
 

--- a/crates/sracha-core/src/fastq/mod.rs
+++ b/crates/sracha-core/src/fastq/mod.rs
@@ -131,6 +131,8 @@ pub struct FastqConfig {
     pub min_read_len: Option<u32>,
     /// Output FASTA instead of FASTQ (drops quality line).
     pub fasta: bool,
+    /// Suffix style for paired/split output filenames.
+    pub paired_suffix: PairedSuffix,
 }
 
 impl Default for FastqConfig {
@@ -140,6 +142,7 @@ impl Default for FastqConfig {
             skip_technical: true,
             min_read_len: None,
             fasta: false,
+            paired_suffix: PairedSuffix::Numeric,
         }
     }
 }
@@ -165,6 +168,16 @@ pub enum OutputSlot {
     Unpaired,
     /// `_N.fastq[.gz]` (Nth read in SplitFiles mode, 0-indexed).
     ReadN(u32),
+}
+
+/// Filename suffix style for paired / split FASTQ outputs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PairedSuffix {
+    /// `_1.fastq` / `_2.fastq` (default; matches fasterq-dump and ENA filenames).
+    #[default]
+    Numeric,
+    /// `_R1.fastq` / `_R2.fastq` (matches Illumina BCL output convention).
+    R,
 }
 
 // ---------------------------------------------------------------------------
@@ -571,6 +584,7 @@ pub fn output_filename(
     slot: OutputSlot,
     fasta: bool,
     compression: &CompressionMode,
+    suffix: PairedSuffix,
 ) -> String {
     let base = if fasta { ".fasta" } else { ".fastq" };
     let ext = match compression {
@@ -578,16 +592,20 @@ pub fn output_filename(
         CompressionMode::Gzip { .. } => format!("{base}.gz"),
         CompressionMode::Zstd { .. } => format!("{base}.zst"),
     };
+    let sep = match suffix {
+        PairedSuffix::Numeric => "_",
+        PairedSuffix::R => "_R",
+    };
     match slot {
         OutputSlot::Single => format!("{accession}{ext}"),
-        OutputSlot::Read1 => format!("{accession}_1{ext}"),
-        OutputSlot::Read2 => format!("{accession}_2{ext}"),
+        OutputSlot::Read1 => format!("{accession}{sep}1{ext}"),
+        OutputSlot::Read2 => format!("{accession}{sep}2{ext}"),
         // Matches fasterq-dump: split-3 orphans and single-end runs both
         // land in `{accession}.fastq` (no `_0` suffix).
         OutputSlot::Unpaired => format!("{accession}{ext}"),
         // ReadN is 0-indexed internally but 1-indexed in the filename to match
         // the convention used by SRA tools (read number, not array index).
-        OutputSlot::ReadN(n) => format!("{accession}_{}{ext}", n + 1),
+        OutputSlot::ReadN(n) => format!("{accession}{sep}{}{ext}", n + 1),
     }
 }
 
@@ -1167,7 +1185,13 @@ mod tests {
     fn output_filename_single_gzip() {
         let gz = CompressionMode::Gzip { level: 6 };
         assert_eq!(
-            output_filename("SRR123456", OutputSlot::Single, false, &gz),
+            output_filename(
+                "SRR123456",
+                OutputSlot::Single,
+                false,
+                &gz,
+                PairedSuffix::Numeric
+            ),
             "SRR123456.fastq.gz"
         );
     }
@@ -1179,7 +1203,8 @@ mod tests {
                 "SRR123456",
                 OutputSlot::Single,
                 false,
-                &CompressionMode::None
+                &CompressionMode::None,
+                PairedSuffix::Numeric,
             ),
             "SRR123456.fastq"
         );
@@ -1189,7 +1214,13 @@ mod tests {
     fn output_filename_read1() {
         let gz = CompressionMode::Gzip { level: 6 };
         assert_eq!(
-            output_filename("SRR123456", OutputSlot::Read1, false, &gz),
+            output_filename(
+                "SRR123456",
+                OutputSlot::Read1,
+                false,
+                &gz,
+                PairedSuffix::Numeric
+            ),
             "SRR123456_1.fastq.gz"
         );
     }
@@ -1198,7 +1229,13 @@ mod tests {
     fn output_filename_read2() {
         let gz = CompressionMode::Gzip { level: 6 };
         assert_eq!(
-            output_filename("SRR123456", OutputSlot::Read2, false, &gz),
+            output_filename(
+                "SRR123456",
+                OutputSlot::Read2,
+                false,
+                &gz,
+                PairedSuffix::Numeric
+            ),
             "SRR123456_2.fastq.gz"
         );
     }
@@ -1210,7 +1247,13 @@ mod tests {
         // causes FAIL_MISSING in validation comparisons.
         let gz = CompressionMode::Gzip { level: 6 };
         assert_eq!(
-            output_filename("SRR123456", OutputSlot::Unpaired, false, &gz),
+            output_filename(
+                "SRR123456",
+                OutputSlot::Unpaired,
+                false,
+                &gz,
+                PairedSuffix::Numeric
+            ),
             "SRR123456.fastq.gz"
         );
     }
@@ -1220,7 +1263,13 @@ mod tests {
         let gz = CompressionMode::Gzip { level: 6 };
         // ReadN(0) -> _1 in the filename (1-indexed).
         assert_eq!(
-            output_filename("SRR123456", OutputSlot::ReadN(0), false, &gz),
+            output_filename(
+                "SRR123456",
+                OutputSlot::ReadN(0),
+                false,
+                &gz,
+                PairedSuffix::Numeric
+            ),
             "SRR123456_1.fastq.gz"
         );
     }
@@ -1232,7 +1281,8 @@ mod tests {
                 "SRR123456",
                 OutputSlot::ReadN(2),
                 false,
-                &CompressionMode::None
+                &CompressionMode::None,
+                PairedSuffix::Numeric,
             ),
             "SRR123456_3.fastq"
         );
@@ -1245,7 +1295,8 @@ mod tests {
                 "SRR999",
                 OutputSlot::Unpaired,
                 false,
-                &CompressionMode::None
+                &CompressionMode::None,
+                PairedSuffix::Numeric,
             ),
             "SRR999.fastq"
         );
@@ -1254,7 +1305,13 @@ mod tests {
     #[test]
     fn output_filename_read1_no_gzip() {
         assert_eq!(
-            output_filename("SRR999", OutputSlot::Read1, false, &CompressionMode::None),
+            output_filename(
+                "SRR999",
+                OutputSlot::Read1,
+                false,
+                &CompressionMode::None,
+                PairedSuffix::Numeric
+            ),
             "SRR999_1.fastq"
         );
     }
@@ -1262,7 +1319,13 @@ mod tests {
     #[test]
     fn output_filename_read2_no_gzip() {
         assert_eq!(
-            output_filename("SRR999", OutputSlot::Read2, false, &CompressionMode::None),
+            output_filename(
+                "SRR999",
+                OutputSlot::Read2,
+                false,
+                &CompressionMode::None,
+                PairedSuffix::Numeric
+            ),
             "SRR999_2.fastq"
         );
     }
@@ -1271,7 +1334,13 @@ mod tests {
     fn output_filename_fasta_gzip() {
         let gz = CompressionMode::Gzip { level: 6 };
         assert_eq!(
-            output_filename("SRR123456", OutputSlot::Single, true, &gz),
+            output_filename(
+                "SRR123456",
+                OutputSlot::Single,
+                true,
+                &gz,
+                PairedSuffix::Numeric
+            ),
             "SRR123456.fasta.gz"
         );
     }
@@ -1279,7 +1348,13 @@ mod tests {
     #[test]
     fn output_filename_fasta_no_compression() {
         assert_eq!(
-            output_filename("SRR123456", OutputSlot::Read1, true, &CompressionMode::None),
+            output_filename(
+                "SRR123456",
+                OutputSlot::Read1,
+                true,
+                &CompressionMode::None,
+                PairedSuffix::Numeric
+            ),
             "SRR123456_1.fasta"
         );
     }
@@ -1291,7 +1366,13 @@ mod tests {
             threads: 4,
         };
         assert_eq!(
-            output_filename("SRR123456", OutputSlot::Single, false, &zst),
+            output_filename(
+                "SRR123456",
+                OutputSlot::Single,
+                false,
+                &zst,
+                PairedSuffix::Numeric
+            ),
             "SRR123456.fastq.zst"
         );
     }
@@ -1303,8 +1384,106 @@ mod tests {
             threads: 4,
         };
         assert_eq!(
-            output_filename("SRR123456", OutputSlot::Read2, true, &zst),
+            output_filename(
+                "SRR123456",
+                OutputSlot::Read2,
+                true,
+                &zst,
+                PairedSuffix::Numeric
+            ),
             "SRR123456_2.fasta.zst"
+        );
+    }
+
+    // PairedSuffix::R variants ------------------------------------------------
+
+    #[test]
+    fn output_filename_read1_r_suffix() {
+        let gz = CompressionMode::Gzip { level: 6 };
+        assert_eq!(
+            output_filename("SRR123456", OutputSlot::Read1, false, &gz, PairedSuffix::R),
+            "SRR123456_R1.fastq.gz"
+        );
+    }
+
+    #[test]
+    fn output_filename_read2_r_suffix() {
+        let gz = CompressionMode::Gzip { level: 6 };
+        assert_eq!(
+            output_filename("SRR123456", OutputSlot::Read2, false, &gz, PairedSuffix::R),
+            "SRR123456_R2.fastq.gz"
+        );
+    }
+
+    #[test]
+    fn output_filename_read_n_zero_indexed_r_suffix() {
+        let gz = CompressionMode::Gzip { level: 6 };
+        // ReadN(0) -> _R1 with PairedSuffix::R.
+        assert_eq!(
+            output_filename(
+                "SRR123456",
+                OutputSlot::ReadN(0),
+                false,
+                &gz,
+                PairedSuffix::R
+            ),
+            "SRR123456_R1.fastq.gz"
+        );
+    }
+
+    #[test]
+    fn output_filename_read_n_higher_r_suffix() {
+        let gz = CompressionMode::Gzip { level: 6 };
+        // ReadN(2) -> _R3 with PairedSuffix::R.
+        assert_eq!(
+            output_filename(
+                "SRR123456",
+                OutputSlot::ReadN(2),
+                false,
+                &gz,
+                PairedSuffix::R
+            ),
+            "SRR123456_R3.fastq.gz"
+        );
+    }
+
+    #[test]
+    fn output_filename_single_unaffected_by_r_suffix() {
+        // Single-file outputs never get a paired suffix; --paired-suffix r
+        // must leave them alone.
+        let gz = CompressionMode::Gzip { level: 6 };
+        assert_eq!(
+            output_filename("SRR123456", OutputSlot::Single, false, &gz, PairedSuffix::R),
+            "SRR123456.fastq.gz"
+        );
+    }
+
+    #[test]
+    fn output_filename_unpaired_unaffected_by_r_suffix() {
+        // Split-3 orphan files (Unpaired slot) follow fasterq-dump naming and
+        // are not renamed by --paired-suffix r.
+        let gz = CompressionMode::Gzip { level: 6 };
+        assert_eq!(
+            output_filename(
+                "SRR123456",
+                OutputSlot::Unpaired,
+                false,
+                &gz,
+                PairedSuffix::R
+            ),
+            "SRR123456.fastq.gz"
+        );
+    }
+
+    #[test]
+    fn output_filename_fasta_zstd_r_suffix() {
+        let zst = CompressionMode::Zstd {
+            level: 3,
+            threads: 4,
+        };
+        assert_eq!(
+            output_filename("SRR123456", OutputSlot::Read1, true, &zst, PairedSuffix::R),
+            "SRR123456_R1.fasta.zst"
         );
     }
 

--- a/crates/sracha-core/src/pipeline/config.rs
+++ b/crates/sracha-core/src/pipeline/config.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-use crate::fastq::{CompressionMode, IntegrityDiag, SplitMode};
+use crate::fastq::{CompressionMode, IntegrityDiag, PairedSuffix, SplitMode};
 
 /// Configuration for the get pipeline.
 #[derive(Clone)]
@@ -54,6 +54,8 @@ pub struct PipelineConfig {
     /// decode instead of deleting it. Useful for validation runs that
     /// want to compare against another tool on the same input file.
     pub keep_sra: bool,
+    /// Suffix style for paired/split FASTQ outputs (`_1`/`_2` vs `_R1`/`_R2`).
+    pub paired_suffix: PairedSuffix,
 }
 
 /// Statistics from a completed pipeline run.

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -176,7 +176,13 @@ fn create_output_writer_for_slot(
     config: &PipelineConfig,
     compress_pool: &Option<Arc<rayon::ThreadPool>>,
 ) -> (OutputWriter, PathBuf, PathBuf) {
-    let filename = output_filename(accession, slot, config.fasta, &config.compression);
+    let filename = output_filename(
+        accession,
+        slot,
+        config.fasta,
+        &config.compression,
+        config.paired_suffix,
+    );
     let final_path = config.output_dir.join(&filename);
     let tmp_path = config.output_dir.join(format!("{filename}.partial"));
 
@@ -426,6 +432,7 @@ fn decode_and_write(
         skip_technical: config.skip_technical,
         min_read_len: config.min_read_len,
         fasta: config.fasta,
+        paired_suffix: config.paired_suffix,
     };
 
     // Create output directory (not needed for stdout mode).
@@ -1169,6 +1176,7 @@ fn run_fastq_csra(
         skip_technical: config.skip_technical,
         min_read_len: config.min_read_len,
         fasta: config.fasta,
+        paired_suffix: config.paired_suffix,
     };
 
     if !config.stdout {
@@ -1305,7 +1313,13 @@ fn run_fastq_csra(
         if writers.contains_key(&slot) {
             return Ok(());
         }
-        let filename = output_filename(acc, slot, config.fasta, &config.compression);
+        let filename = output_filename(
+            acc,
+            slot,
+            config.fasta,
+            &config.compression,
+            config.paired_suffix,
+        );
         let final_path = config.output_dir.join(&filename);
         let tmp_path = config.output_dir.join(format!("{filename}.partial"));
         output_paths.push((final_path, tmp_path.clone()));
@@ -1569,7 +1583,13 @@ pub async fn download_ena_fastq(
             });
         }
 
-        let name = output_filename(accession, file.slot, config.fasta, &config.compression);
+        let name = output_filename(
+            accession,
+            file.slot,
+            config.fasta,
+            &config.compression,
+            config.paired_suffix,
+        );
         let target = config.output_dir.join(&name);
 
         tracing::info!(

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -256,6 +256,7 @@ fn test_config(
         strict: false,
         http_client: None,
         keep_sra: false,
+        paired_suffix: sracha_core::fastq::PairedSuffix::Numeric,
     }
 }
 

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -261,6 +261,12 @@ pub struct FastqArgs {
     #[arg(long, default_value = "split-3", help_heading = "Output")]
     pub split: SplitMode,
 
+    /// Suffix style for paired/split FASTQ outputs.
+    /// `numeric` -> `_1.fastq`/`_2.fastq` (default, matches fasterq-dump and ENA).
+    /// `r` -> `_R1.fastq`/`_R2.fastq` (matches Illumina BCL output convention).
+    #[arg(long, value_enum, default_value = "numeric", help_heading = "Output")]
+    pub paired_suffix: PairedSuffix,
+
     /// Output FASTA instead of FASTQ (drops quality scores)
     #[arg(long, help_heading = "Output")]
     pub fasta: bool,
@@ -349,6 +355,12 @@ pub struct GetArgs {
     /// Split mode
     #[arg(long, default_value = "split-3", help_heading = "Output")]
     pub split: SplitMode,
+
+    /// Suffix style for paired/split FASTQ outputs.
+    /// `numeric` -> `_1.fastq`/`_2.fastq` (default, matches fasterq-dump and ENA).
+    /// `r` -> `_R1.fastq`/`_R2.fastq` (matches Illumina BCL output convention).
+    #[arg(long, value_enum, default_value = "numeric", help_heading = "Output")]
+    pub paired_suffix: PairedSuffix,
 
     /// Output FASTA instead of FASTQ (drops quality scores)
     #[arg(long, help_heading = "Output")]
@@ -584,6 +596,24 @@ impl From<SplitMode> for fastq::SplitMode {
             SplitMode::SplitFiles => fastq::SplitMode::SplitFiles,
             SplitMode::SplitSpot => fastq::SplitMode::SplitSpot,
             SplitMode::Interleaved => fastq::SplitMode::Interleaved,
+        }
+    }
+}
+
+#[derive(Clone, Copy, ValueEnum, Default)]
+pub enum PairedSuffix {
+    /// `_1.fastq` / `_2.fastq` (default, matches fasterq-dump and ENA)
+    #[default]
+    Numeric,
+    /// `_R1.fastq` / `_R2.fastq` (matches Illumina BCL output convention)
+    R,
+}
+
+impl From<PairedSuffix> for fastq::PairedSuffix {
+    fn from(s: PairedSuffix) -> Self {
+        match s {
+            PairedSuffix::Numeric => fastq::PairedSuffix::Numeric,
+            PairedSuffix::R => fastq::PairedSuffix::R,
         }
     }
 }

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -325,6 +325,7 @@ async fn main() -> Result<()> {
                     http_client: None,
                     strict: !args.no_strict,
                     keep_sra: false,
+                    paired_suffix: args.paired_suffix.into(),
                 };
 
                 let stats = sracha_core::pipeline::run_fastq(sra_path, None, &pipeline_config)?;
@@ -521,6 +522,7 @@ async fn main() -> Result<()> {
                     strict: !args.no_strict,
                     http_client: Some(http_client.clone()),
                     keep_sra: args.keep_sra,
+                    paired_suffix: args.paired_suffix.into(),
                 }
             };
 


### PR DESCRIPTION
## Summary
- Adds `--paired-suffix {numeric,r}` flag on both `get` and `fastq` commands.
- Default `numeric` preserves existing `_1`/`_2` filenames (matches fasterq-dump and ENA).
- `r` emits `_R1`/`_R2` to match the Illumina BCL convention many pipelines expect.
- Single change in `output_filename()` covers all paths: VDB decode, cSRA decode, split-files, and the ENA fast-path.
- `Single`/`Unpaired` slots are deliberately unaffected (single-end and split-3 orphans stay as `{accession}.fastq` regardless of the flag).

Closes #39.

## Test plan
- [x] `cargo build`
- [x] `cargo test -p sracha-core --lib` (193 passing, includes 7 new `PairedSuffix::R` tests)
- [x] `cargo test -p sracha` (23 tests across 2 suites)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual smoke: `sracha get SRR1234567 --paired-suffix r -O /tmp/x` produces `SRR1234567_R1.fastq.gz` / `SRR1234567_R2.fastq.gz`
- [ ] Manual smoke: `sracha get SRR1234567 -O /tmp/x` (no flag) still produces `_1`/`_2`