### PR TITLE
fix(dry_run): default new RunInfo fields in test fixture

### DIFF
--- a/crates/sracha-core/src/dry_run.rs
+++ b/crates/sracha-core/src/dry_run.rs
@@ -97,6 +97,7 @@ mod tests {
                 spot_len: 200,
                 platform: Some("ILLUMINA".into()),
                 spots: Some(42),
+                ..Default::default()
             }),
         }
     }


### PR DESCRIPTION
## Summary
- Unbreaks the build on main.
- The dry-run test fixture in #41 hand-constructed `RunInfo` with explicit fields. #42 added 17 new optional fields and a `Default` derive, but didn't update the fixture — so once both merged, the lib-test build failed with E0063 on the now-incomplete struct initializer.
- Adds `..Default::default()` to the fixture.

This is a build-fix only — no behavior change.

## Test plan
- [x] `cargo test -p sracha-core --lib` — 194 passing
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean