### PR TITLE
ci: migrate test suite to cargo-nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,33 @@
+# cargo-nextest configuration
+# https://nexte.st/docs/configuration/
+
+[profile.default]
+# Show output for failing tests after the run completes
+failure-output = "immediate-final"
+# Hide stdout/stderr for passing tests
+success-output = "never"
+# Retry flaky tests once (most tests are deterministic; network tests benefit)
+retries = 0
+# Fail fast on first test failure during local development
+fail-fast = true
+
+[profile.ci]
+# CI: never fail-fast — surface every failure in one run
+fail-fast = false
+# Retry transient network failures in integration tests
+retries = { backoff = "exponential", count = 2, delay = "5s", jitter = true, max-delay = "30s" }
+# Verbose failure output for CI logs
+failure-output = "immediate-final"
+final-status-level = "slow"
+
+[profile.ci.junit]
+path = "junit.xml"
+
+# Integration tests download SRA files from NCBI — give them more time
+[[profile.default.overrides]]
+filter = "test(integration_) or test(test_download_) or test(test_pipeline_)"
+slow-timeout = { period = "60s", terminate-after = 4 }
+
+[[profile.ci.overrides]]
+filter = "test(integration_) or test(test_download_) or test(test_pipeline_)"
+slow-timeout = { period = "60s", terminate-after = 4 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
       - name: Run tests
-        run: cargo test --all-features
+        run: cargo nextest run --all-features --profile ci
 
   integration:
     name: Integration Test
@@ -49,13 +50,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
       - name: Cache SRA fixture
         uses: actions/cache@v4
         with:
           path: crates/sracha-core/tests/fixtures
           key: sra-fixture-SRR28588231-v1
       - name: Run integration tests
-        run: cargo test -p sracha-core --all-features -- --ignored
+        run: cargo nextest run -p sracha-core --all-features --profile ci --run-ignored=ignored-only
 
   msrv:
     name: MSRV (1.92)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,14 @@ sracha-rs is a pure Rust SRA downloader and FASTQ converter — a fast replaceme
 ```bash
 cargo build                                          # dev build
 cargo build --profile release                        # optimized release build (LTO)
-cargo test                                           # unit tests only
-cargo test -p sracha-core -- --ignored               # integration tests (downloads SRA fixtures from NCBI)
-cargo test -p sracha-core -- test_name               # run a single test
+cargo nextest run                                    # unit tests only (cargo-nextest required)
+cargo nextest run -p sracha-core --run-ignored=ignored-only  # integration tests (downloads SRA fixtures from NCBI)
+cargo nextest run -p sracha-core -E 'test(test_name)'        # run a single test
 cargo clippy --all-targets --all-features -- -D warnings
 cargo fmt --all -- --check
 ```
+
+Tests run via [cargo-nextest](https://nexte.st). Install with `cargo install cargo-nextest --locked` or use the bundled `pixi` env (`cargo-nextest` is a pixi dep). Config lives at `.config/nextest.toml`; the `ci` profile retries flaky network tests and writes JUnit XML.
 
 Fast local dev builds via mold (pixi env: `dev`). `mold -run` intercepts the
 linker exec via `LD_PRELOAD` and works with the compute nodes' system gcc

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,6 +13,7 @@ vhs = ">=0.11.0,<0.12"
 bwa = ">=0.7.18"
 samtools = ">=1.21"
 sracha = ">=0.3.0,<0.4"
+cargo-nextest = ">=0.9"
 
 [pypi-dependencies]
 zensical = "*"
@@ -21,7 +22,8 @@ zensical = "*"
 build = "cargo build"
 release = "cargo build --profile release"
 release-debug = "cargo build --profile release-with-debug"
-test = "cargo test"
+test = "cargo nextest run"
+test-integration = "cargo nextest run -p sracha-core --run-ignored=ignored-only"
 check = "cargo check"
 clippy = "cargo clippy --all-targets --all-features -- -D warnings"
 fmt = "cargo fmt --all"
@@ -41,12 +43,13 @@ install-sratools = { cmd = "bash validation/install-sratools.sh", description = 
 mold = ">=2.4"
 
 [feature.dev.tasks]
-build         = "mold -run cargo build"
-release       = "mold -run cargo build --profile release"
-release-debug = "mold -run cargo build --profile release-with-debug"
-test          = "mold -run cargo test"
-check         = "mold -run cargo check"
-clippy        = "mold -run cargo clippy --all-targets --all-features -- -D warnings"
+build            = "mold -run cargo build"
+release          = "mold -run cargo build --profile release"
+release-debug    = "mold -run cargo build --profile release-with-debug"
+test             = "mold -run cargo nextest run"
+test-integration = "mold -run cargo nextest run -p sracha-core --run-ignored=ignored-only"
+check            = "mold -run cargo check"
+clippy           = "mold -run cargo clippy --all-targets --all-features -- -D warnings"
 
 [environments]
 dev = { features = ["dev"], solve-group = "default" }


### PR DESCRIPTION
## Summary
- Swap `cargo test` for `cargo nextest run` across pixi tasks and CI workflows
- Add `.config/nextest.toml` with `default` and `ci` profiles (CI: no fail-fast, exponential-backoff retries for network-flaky tests, 60s × 4 slow-timeout for integration/download/pipeline tests, JUnit XML output)
- Install nextest in CI via `taiki-e/install-action@nextest`; integration job uses `--run-ignored=ignored-only` to mirror prior `cargo test -- --ignored` behavior
- Add `cargo-nextest` to pixi `[dependencies]`; new `test-integration` task

Doctests in this repo are all non-executable `text` fences, so nextest's lack of doctest support is a non-issue here.

## Test plan
- [x] `cargo nextest run` passes locally — 585 tests, 36 skipped, ~0.9s
- [x] `cargo nextest list --profile ci` parses the new config cleanly
- [ ] CI green on this PR (both `test` matrix jobs and `integration`)
- [ ] Verify `pixi run test` works after `pixi update` picks up `cargo-nextest`