### PR TITLE
feat(long-read): improve PacBio/ONT platform detection and read structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Improvements
+
+- Better long-read (PacBio / Oxford Nanopore) support. Platform detection
+  now reads the authoritative `col/PLATFORM/row` numeric id
+  (`INSDC:SRA:platform_id`) before sniffing the schema table name, so runs
+  submitted as plain FASTQ and loaded under the generic
+  `NCBI:SRA:GenericFastq` schema — common for PacBio/ONT — report their real
+  platform (e.g. `PACBIO_SMRT`) instead of `unknown`. The same id feeds the
+  read-structure fallback, so generic-loaded long-read runs resolve to one
+  biological read per spot even without read columns. Schema-based
+  read-structure inference also resolves PacBio and Nanopore *schema-tagged*
+  runs to one biological read per spot instead of erroring out to an untyped
+  fallback, so single-end long-read spots decode with a known read type. The
+  single-end advisory printed for `--split split-3` now also fires for
+  `--split interleaved` and points at `--split split-spot` as the explicit
+  single-file layout. `--seq-defline`'s `$sn` is documented as the
+  platform-native read identifier for PacBio/ONT (e.g. `m64012_.../ccs`,
+  ONT `<uuid> ch=.. start_time=..`); the channel/start-time/ZMW values
+  long-read platforms embed there are substrings of that name rather than
+  separate columns. Adds network-gated integration fixtures for a PacBio
+  SMRT run (SRR38889541) and an Oxford Nanopore run (SRR38892122).
+
 ## 0.3.7 (2026-05-29)
 
 ### Features

--- a/crates/sracha-core/src/fastq/defline.rs
+++ b/crates/sracha-core/src/fastq/defline.rs
@@ -16,6 +16,16 @@
 //! | `$sn` | spot name    |
 //! | `$rl` | read length  |
 //!
+//! `$sn` resolves to the run's `NAME`/`SPOT_NAME` column. For Illumina that is
+//! the reconstructed instrument name (`M05881:542:...`); for long-read
+//! platforms (PacBio, Oxford Nanopore) it is the platform-native read
+//! identifier as submitted — e.g. PacBio `m64012_.../ccs` or an ONT
+//! `<uuid> runid=.. read=.. ch=.. start_time=..` string. The channel /
+//! start-time / ZMW fields ONT and PacBio embed there are substrings of that
+//! one name, not separate VDB columns, so they are exposed only as part of
+//! `$sn` (which is also the default header's description field) rather than as
+//! standalone variables.
+//!
 //! `$$` emits a literal `$`. A leading `@`/`>` is accepted (so `fasterq-dump`
 //! templates like `@$ac.$si.$ri` paste in unchanged) but stripped — the record
 //! prefix is added by the formatter (`@` for FASTQ, `>` for FASTA). `$sg`
@@ -215,6 +225,22 @@ mod tests {
     fn substitutes_all_variables() {
         let t = DeflineTemplate::parse("$ac/$si/$ri/$sn/$rl").unwrap();
         assert_eq!(body(&t, Some(b"NAME")), "SRR000001/42/1/NAME/4");
+    }
+
+    #[test]
+    fn spot_name_carries_long_read_native_id() {
+        // For PacBio/ONT the NAME column holds the platform-native read id;
+        // $sn must pass it through verbatim (spaces, slashes, key=value all).
+        let t = DeflineTemplate::parse("@$ac.$si $sn").unwrap();
+        assert_eq!(
+            body(&t, Some(b"m64012_200723_165033/ccs")),
+            "SRR000001.42 m64012_200723_165033/ccs"
+        );
+        let ont = DeflineTemplate::parse("$sn").unwrap();
+        assert_eq!(
+            body(&ont, Some(b"abc-uuid runid=r1 read=123 ch=42")),
+            "abc-uuid runid=r1 read=123 ch=42"
+        );
     }
 
     #[test]

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -1021,18 +1021,28 @@ pub fn run_fastq(
         decode_and_write(sra_path, &acc, config, is_lite, &diag)
             .map_err(|e| wrap_blob_integrity(&acc, e))?;
 
-    // Warn (but don't fail) when split-3 was requested on an effectively
-    // single-end run: every spot produced exactly one read, so output
-    // lands in `{accession}.fastq` with no `_1`/`_2` files. Users asking
-    // for --split split-3 on single-end data usually didn't realize the
-    // layout; surfacing this beats a silently-different filename.
-    if matches!(config.split_mode, SplitMode::Split3)
-        && spots_read > 0
+    // Warn (but don't fail) when a paired layout was requested on an
+    // effectively single-end run: every spot produced exactly one read, so
+    // split-3 collapses to `{accession}.fastq` (no `_1`/`_2`) and interleaved
+    // has nothing to interleave. This is the common shape for long-read
+    // platforms (PacBio/ONT, one biological read per spot) and single-end
+    // Illumina; users usually didn't realize the layout. `--split split-spot`
+    // expresses the single-file result explicitly, so point them at it.
+    if spots_read > 0
         && reads_written == spots_read
+        && matches!(
+            config.split_mode,
+            SplitMode::Split3 | SplitMode::Interleaved
+        )
     {
+        let requested = match config.split_mode {
+            SplitMode::Interleaved => "interleaved",
+            _ => "split-3",
+        };
         eprintln!(
-            "warning: {acc}: --split split-3 requested but run is single-end \
-             ({spots_read} spots, 1 read each); output is {acc}.fastq"
+            "warning: {acc}: --split {requested} requested but run is single-end \
+             ({spots_read} spots, 1 read each); output is a single file — \
+             use --split split-spot to make this explicit"
         );
     }
 

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -232,6 +232,84 @@ fn ensure_vdb_3418() -> PathBuf {
     path
 }
 
+/// Ensure the SRR38889541 fixture (PacBio SMRT amplicon, ~11 MiB).
+///
+/// A genuine long-read run: 25,000 spots, one biological read per spot,
+/// variable read length (~1.5 kb). Exercises the long-read decode path —
+/// single-read spots through the variable-length READ_LEN column — and the
+/// `--split split-3` single-end advisory (every spot yields exactly one read).
+fn ensure_srr38889541() -> PathBuf {
+    static DOWNLOAD: Once = Once::new();
+    let path = fixtures_dir().join("SRR38889541.sra");
+
+    DOWNLOAD.call_once(|| {
+        if path.exists() {
+            return;
+        }
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let url = "https://sra-pub-run-odp.s3.amazonaws.com/sra/SRR38889541/SRR38889541";
+        eprintln!("downloading SRR38889541 fixture from {url} ...");
+
+        let resp = reqwest::blocking::get(url)
+            .unwrap_or_else(|e| panic!("failed to download SRR38889541: {e}"));
+        assert!(
+            resp.status().is_success(),
+            "HTTP {} downloading fixture",
+            resp.status()
+        );
+        let bytes = resp.bytes().unwrap();
+        std::fs::write(&path, &bytes).unwrap();
+        eprintln!(
+            "fixture saved to {} ({} bytes)",
+            path.display(),
+            bytes.len()
+        );
+    });
+
+    assert!(path.exists(), "fixture not found at {}", path.display());
+    path
+}
+
+/// Ensure the SRR38892122 fixture (Oxford Nanopore WGS, ~7 MiB).
+///
+/// A genuine long-read run: 1,828 spots, one biological read per spot, with
+/// multi-kilobase reads (the first read is ~9.2 kb). The VDB schema is tagged
+/// `NCBI:SRA:Nanopore`, so `cursor.platform()` reports `OXFORD_NANOPORE` —
+/// covers long-read platform detection plus the single-end decode shape.
+fn ensure_srr38892122() -> PathBuf {
+    static DOWNLOAD: Once = Once::new();
+    let path = fixtures_dir().join("SRR38892122.sra");
+
+    DOWNLOAD.call_once(|| {
+        if path.exists() {
+            return;
+        }
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let url = "https://sra-pub-run-odp.s3.amazonaws.com/sra/SRR38892122/SRR38892122";
+        eprintln!("downloading SRR38892122 fixture from {url} ...");
+
+        let resp = reqwest::blocking::get(url)
+            .unwrap_or_else(|e| panic!("failed to download SRR38892122: {e}"));
+        assert!(
+            resp.status().is_success(),
+            "HTTP {} downloading fixture",
+            resp.status()
+        );
+        let bytes = resp.bytes().unwrap();
+        std::fs::write(&path, &bytes).unwrap();
+        eprintln!(
+            "fixture saved to {} ({} bytes)",
+            path.display(),
+            bytes.len()
+        );
+    });
+
+    assert!(path.exists(), "fixture not found at {}", path.display());
+    path
+}
+
 /// Build a `PipelineConfig` suitable for testing.
 fn test_config(
     output_dir: &std::path::Path,
@@ -1322,6 +1400,101 @@ fn ls454_platform_is_rejected_end_to_end() {
         files.is_empty(),
         "no FASTQ output should be written for rejected platform, found: {:?}",
         files.iter().map(|e| e.file_name()).collect::<Vec<_>>(),
+    );
+}
+
+#[ignore]
+#[test]
+fn pacbio_long_read_decodes_single_end() {
+    // PacBio SMRT amplicon run: every spot is one biological read, so the
+    // long-read decode path (single read per spot, variable READ_LEN) must
+    // produce exactly `spots_read` reads with split-spot's single output file.
+    use sracha_core::vdb::{KarArchive, VdbCursor};
+
+    let sra_path = ensure_srr38889541();
+
+    // This run was loaded under the generic `NCBI:SRA:GenericFastq` schema
+    // (no platform tag in the schema name), so platform detection must come
+    // from the authoritative `col/PLATFORM/row` numeric id, not schema sniffing.
+    let file = std::fs::File::open(&sra_path).unwrap();
+    let mut archive = KarArchive::open(std::io::BufReader::new(file)).unwrap();
+    let cursor = VdbCursor::open(&mut archive, &sra_path).unwrap();
+    assert_eq!(
+        cursor.platform(),
+        Some("PACBIO_SMRT"),
+        "PacBio PLATFORM column should resolve even under a generic schema",
+    );
+    drop(cursor);
+    drop(archive);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let config = test_config(tmp.path(), SplitMode::SplitSpot, CompressionMode::None);
+
+    let stats = sracha_core::pipeline::run_fastq(&sra_path, Some("SRR38889541"), &config).unwrap();
+
+    assert!(stats.spots_read > 0, "should read at least one spot");
+    assert_eq!(
+        stats.reads_written, stats.spots_read,
+        "long-read run is single-end: one read per spot",
+    );
+    assert_eq!(
+        stats.output_files.len(),
+        1,
+        "split-spot should produce exactly one file",
+    );
+
+    let data = std::fs::read(&stats.output_files[0]).unwrap();
+    assert_valid_fastq(&data);
+}
+
+#[ignore]
+#[test]
+fn nanopore_platform_detected_and_decodes_single_end() {
+    // Oxford Nanopore WGS run. Two things to lock in: (1) the VDB schema is
+    // tagged `NCBI:SRA:Nanopore`, so the cursor must report OXFORD_NANOPORE;
+    // (2) the run is single-end with multi-kilobase reads.
+    use sracha_core::vdb::{KarArchive, VdbCursor};
+
+    let sra_path = ensure_srr38892122();
+
+    // (1) Platform detection straight from the archive metadata.
+    let file = std::fs::File::open(&sra_path).unwrap();
+    let mut archive = KarArchive::open(std::io::BufReader::new(file)).unwrap();
+    let cursor = VdbCursor::open(&mut archive, &sra_path).unwrap();
+    assert_eq!(
+        cursor.platform(),
+        Some("OXFORD_NANOPORE"),
+        "Nanopore schema should be detected as OXFORD_NANOPORE",
+    );
+    drop(cursor);
+    drop(archive);
+
+    // (2) Decode: single-end, valid FASTQ, long reads present.
+    let tmp = tempfile::tempdir().unwrap();
+    let config = test_config(tmp.path(), SplitMode::SplitSpot, CompressionMode::None);
+    let stats = sracha_core::pipeline::run_fastq(&sra_path, Some("SRR38892122"), &config).unwrap();
+
+    assert!(stats.spots_read > 0);
+    assert_eq!(
+        stats.reads_written, stats.spots_read,
+        "long-read run is single-end: one read per spot",
+    );
+    assert_eq!(stats.output_files.len(), 1, "split-spot is one file");
+
+    let data = std::fs::read(&stats.output_files[0]).unwrap();
+    assert_valid_fastq(&data);
+    // Long reads: at least one sequence well past short-read length.
+    let max_seq_len = std::str::from_utf8(&data)
+        .unwrap()
+        .lines()
+        .skip(1)
+        .step_by(4)
+        .map(str::len)
+        .max()
+        .unwrap_or(0);
+    assert!(
+        max_seq_len > 1000,
+        "Nanopore reads should be long (>1 kb), got max {max_seq_len}",
     );
 }
 

--- a/crates/sracha-vdb/src/metadata.rs
+++ b/crates/sracha-vdb/src/metadata.rs
@@ -54,9 +54,22 @@ pub fn parse_read_structure(tree_data: &[u8]) -> Result<Vec<ReadDescriptor>, Str
         return Ok(descs);
     }
 
-    // Strategy 3: detect platform from embedded schema text.
-    // The "schema" node contains the full VDB schema which starts with
-    // the table type name (e.g. "NCBI:SRA:Illumina:tbl:phred:v2#1.0.4").
+    // Strategy 3: infer reads-per-spot from the run's platform, as a last
+    // resort when no physical/static read columns exist (e.g. SRA-lite).
+    //
+    // 3a: the authoritative `col/PLATFORM/row` numeric id. This is set even
+    // when the schema table name carries no platform tag — the common case
+    // for PacBio/ONT runs loaded under the generic `NCBI:SRA:GenericFastq`
+    // schema, where 3b below would find nothing.
+    if let Some(nreads) = read_platform_id_column(&nodes)
+        .and_then(platform_id_to_name)
+        .and_then(infer_nreads_from_platform)
+    {
+        return Ok(biological_descs(nreads));
+    }
+
+    // 3b: platform tag embedded in the schema table name (e.g.
+    // "NCBI:SRA:Illumina:tbl:phred:v2#1.0.4").
     for node in &nodes {
         if node.name == "schema" {
             // The table type name is typically stored as an attribute of
@@ -64,25 +77,13 @@ pub fn parse_read_structure(tree_data: &[u8]) -> Result<Vec<ReadDescriptor>, Str
             for (_, attr_val) in &node.attrs {
                 let attr_text = String::from_utf8_lossy(attr_val);
                 if let Some(nreads) = infer_nreads_from_schema(&attr_text) {
-                    let descs = (0..nreads)
-                        .map(|_| ReadDescriptor {
-                            read_type: b'B',
-                            read_len: 0,
-                        })
-                        .collect();
-                    return Ok(descs);
+                    return Ok(biological_descs(nreads));
                 }
             }
             // Also check the value text.
             let schema_text = String::from_utf8_lossy(&node.value);
             if let Some(nreads) = infer_nreads_from_schema(&schema_text) {
-                let descs = (0..nreads)
-                    .map(|_| ReadDescriptor {
-                        read_type: b'B',
-                        read_len: 0,
-                    })
-                    .collect();
-                return Ok(descs);
+                return Ok(biological_descs(nreads));
             }
         }
     }
@@ -231,13 +232,52 @@ pub fn detect_platform_from_schema(schema_text: &str) -> Option<String> {
     None
 }
 
-/// Infer reads-per-spot from the schema table name.
-fn infer_nreads_from_schema(schema_text: &str) -> Option<usize> {
-    if schema_text.contains("Illumina") {
-        tracing::debug!("metadata: schema indicates Illumina platform, assuming nreads=2");
-        return Some(2);
+/// Build `n` biological read descriptors of unknown length. Used by the
+/// Strategy-3 platform fallbacks, where only the read *count* is known and
+/// per-read lengths come from `spot_len / nreads` downstream.
+fn biological_descs(n: usize) -> Vec<ReadDescriptor> {
+    (0..n)
+        .map(|_| ReadDescriptor {
+            read_type: b'B',
+            read_len: 0,
+        })
+        .collect()
+}
+
+/// Default reads-per-spot implied by a known platform.
+///
+/// Used only as a last-resort fallback (Strategy 3) when neither physical
+/// `READ_LEN` nor static `col/READ_TYPE` columns are present. The mapping is
+/// deliberately conservative — it asserts a read count only for platforms
+/// whose spot structure is fixed by the technology:
+///
+/// - **Illumina** → 2. Paired-end is the overwhelming default and SRA-lite
+///   Illumina runs routinely drop the physical columns this would otherwise
+///   read; assuming 2 matches fasterq-dump's behaviour on those runs.
+/// - **PacBio / Oxford Nanopore** → 1. Long-read platforms emit a single
+///   biological read per spot (one ZMW/CCS read, one nanopore strand). Without
+///   this, such runs hit the "no read structure found" error and fall through
+///   to `meta_rps = 1` anyway — but only after losing the read *type*, so the
+///   spot would be treated as untyped rather than a known single biological
+///   read. Asserting it here keeps `metadata_read_types()` meaningful and lets
+///   the split-mode advisor (see `pipeline`) recognise the run as single-read.
+fn infer_nreads_from_platform(name: &str) -> Option<usize> {
+    match name {
+        "ILLUMINA" => Some(2),
+        "PACBIO_SMRT" | "OXFORD_NANOPORE" => Some(1),
+        _ => None,
     }
-    None
+}
+
+/// Infer reads-per-spot from the schema table name, by mapping it to a
+/// platform first. Thin wrapper over [`infer_nreads_from_platform`] so the
+/// schema-string and `PLATFORM`-column fallbacks stay in lock-step.
+fn infer_nreads_from_schema(schema_text: &str) -> Option<usize> {
+    let nreads = detect_platform_from_schema(schema_text)
+        .as_deref()
+        .and_then(infer_nreads_from_platform)?;
+    tracing::debug!("metadata: schema implies platform nreads={nreads}");
+    Some(nreads)
 }
 
 /// Detect whether a run is an SRA-Lite (quality-stripped, synthesized-on-read)
@@ -266,12 +306,58 @@ pub fn detect_sra_lite(tree_data: &[u8]) -> bool {
     false
 }
 
+/// Map an `INSDC:SRA:platform_id` enum value to sracha's canonical platform
+/// name. The enum is defined by NCBI in `interfaces/insdc/sra.vschema` and has
+/// been stable for years; we mirror the well-established values and reuse the
+/// exact strings sracha matches on elsewhere (e.g. `UNSUPPORTED_PLATFORMS`).
+///
+/// `0` (UNDEFINED) and any unmapped/newer id return `None` so the caller falls
+/// back to schema-name sniffing rather than asserting a wrong platform.
+fn platform_id_to_name(id: u8) -> Option<&'static str> {
+    Some(match id {
+        1 => "LS454",
+        2 => "ILLUMINA",
+        3 => "ABI_SOLID",
+        4 => "COMPLETE_GENOMICS",
+        5 => "HELICOS",
+        6 => "PACBIO_SMRT",
+        7 => "ION_TORRENT",
+        8 => "CAPILLARY",
+        9 => "OXFORD_NANOPORE",
+        10 => "DNBSEQ",
+        11 => "ELEMENT",
+        _ => return None,
+    })
+}
+
+/// Read the run's platform id from the static `col/PLATFORM/row` column.
+///
+/// VDB stores the sequencing platform as a single `INSDC:SRA:platform_id` (U8)
+/// in this static column — the authoritative source `vdb`/`fasterq-dump` read.
+/// It is present even when the table's *schema name* carries no platform tag,
+/// which is the common case for PacBio/ONT runs submitted as plain FASTQ and
+/// loaded under the generic `NCBI:SRA:GenericFastq` schema. Returns the first
+/// byte (platform is constant per run); `None` when the column is absent/empty.
+fn read_platform_id_column(nodes: &[MetaNode]) -> Option<u8> {
+    let col = nodes.iter().find(|n| n.name == "col")?;
+    let platform = find_meta_node(&col.children, "PLATFORM/row")?;
+    platform.value.first().copied()
+}
+
 /// Detect the sequencing platform from VDB metadata.
 ///
-/// Examines the schema node for platform-identifying strings.
-/// Returns `None` if the platform cannot be determined.
+/// Prefers the authoritative `col/PLATFORM/row` numeric id (set even on
+/// generic-FASTQ-loaded runs), then falls back to sniffing the schema table
+/// name for a platform tag. Returns `None` if neither yields a known platform.
 pub fn detect_platform(tree_data: &[u8]) -> Option<String> {
     let nodes = parse_meta_nodes(tree_data).ok()?;
+
+    // Authoritative: the numeric platform id column.
+    if let Some(name) = read_platform_id_column(&nodes).and_then(platform_id_to_name) {
+        return Some(name.to_string());
+    }
+
+    // Fallback: platform tag embedded in the schema table name.
     for node in &nodes {
         if node.name == "schema" {
             for (_, attr_val) in &node.attrs {
@@ -716,6 +802,68 @@ pub(crate) mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // PLATFORM column detection (INSDC:SRA:platform_id)
+    // -----------------------------------------------------------------------
+
+    /// Build a metadata tree with a `col/PLATFORM/row` byte, optionally
+    /// alongside a `schema` node carrying `schema_name`.
+    fn platform_col_tree(platform_id: u8, schema_name: Option<&[u8]>) -> Vec<u8> {
+        let row = build_meta_node("row", &[platform_id], None);
+        let platform = build_meta_node_with_children("PLATFORM", b"", &[&row], None);
+        let col = build_meta_node_with_children("col", b"", &[&platform], None);
+        match schema_name {
+            Some(name) => {
+                let attrs = build_attrs_pbstree(&[("name", name)]);
+                let schema = build_meta_node("schema", b"", Some(&attrs));
+                build_pbstree(&[&col, &schema])
+            }
+            None => build_pbstree(&[&col]),
+        }
+    }
+
+    #[test]
+    fn platform_id_to_name_mapping() {
+        assert_eq!(platform_id_to_name(2), Some("ILLUMINA"));
+        assert_eq!(platform_id_to_name(6), Some("PACBIO_SMRT"));
+        assert_eq!(platform_id_to_name(9), Some("OXFORD_NANOPORE"));
+        // UNDEFINED and unmapped/newer ids fall through to schema sniffing.
+        assert_eq!(platform_id_to_name(0), None);
+        assert_eq!(platform_id_to_name(200), None);
+    }
+
+    #[test]
+    fn detect_platform_from_platform_column() {
+        // PacBio run loaded under a generic schema: the schema name has no
+        // platform tag, but the PLATFORM column (id 6) is authoritative.
+        let tree = platform_col_tree(6, Some(b"NCBI:SRA:GenericFastq:sequence#2"));
+        assert_eq!(detect_platform(&tree), Some("PACBIO_SMRT".into()));
+    }
+
+    #[test]
+    fn detect_platform_column_beats_schema() {
+        // If they ever disagree, the numeric column wins.
+        let tree = platform_col_tree(9, Some(b"NCBI:SRA:Illumina:tbl:phred:v2"));
+        assert_eq!(detect_platform(&tree), Some("OXFORD_NANOPORE".into()));
+    }
+
+    #[test]
+    fn detect_platform_falls_back_to_schema_when_id_unmapped() {
+        // PLATFORM id 0 (UNDEFINED) → ignore column, use schema tag.
+        let tree = platform_col_tree(0, Some(b"NCBI:SRA:Illumina:tbl:phred:v2"));
+        assert_eq!(detect_platform(&tree), Some("ILLUMINA".into()));
+    }
+
+    #[test]
+    fn read_structure_from_platform_column() {
+        // Generic-loaded PacBio with no read columns: Strategy 3a reads the
+        // PLATFORM column and infers one biological read per spot.
+        let tree = platform_col_tree(6, Some(b"NCBI:SRA:GenericFastq:sequence#2"));
+        let descs = parse_read_structure(&tree).unwrap();
+        assert_eq!(descs.len(), 1);
+        assert_eq!(descs[0].read_type, b'B');
+    }
+
+    // -----------------------------------------------------------------------
     // is_aligned_database_schema
     // -----------------------------------------------------------------------
 
@@ -761,8 +909,19 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn infer_nreads_non_illumina() {
-        assert_eq!(infer_nreads_from_schema("NCBI:SRA:PacBio:tbl:v2"), None);
+    fn infer_nreads_long_read() {
+        // Long-read platforms emit one biological read per spot.
+        assert_eq!(infer_nreads_from_schema("NCBI:SRA:PacBio:tbl:v2"), Some(1));
+        assert_eq!(
+            infer_nreads_from_schema("NCBI:SRA:Nanopore:tbl:v2"),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn infer_nreads_unknown_platform() {
+        // Platforms with no fixed spot structure stay unasserted.
+        assert_eq!(infer_nreads_from_schema("NCBI:SRA:IonTorrent:tbl:v2"), None);
     }
 
     #[test]

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -272,9 +272,11 @@ pub struct FastqArgs {
     pub fasta: bool,
 
     /// Custom defline template (fasterq-dump `--seq-defline` syntax).
-    /// Variables: $ac (accession) $si (spot id) $ri (read id) $sn (spot name)
-    /// $rl (read length); $$ is a literal '$'. Example: '@$ac.$si.$ri'.
-    /// The '+' line mirrors this. ($sg/spot-group is not supported.)
+    /// Variables: $ac (accession) $si (spot id) $ri (read id) $sn (spot/read
+    /// name) $rl (read length); $$ is a literal '$'. Example: '@$ac.$si.$ri'.
+    /// For PacBio/ONT, $sn is the native read name (e.g. PacBio
+    /// 'm64012_.../ccs', ONT '<uuid> ch=.. start_time=..'); it is also the
+    /// default header. The '+' line mirrors this. ($sg/spot-group unsupported.)
     #[arg(
         long,
         value_name = "TEMPLATE",
@@ -385,9 +387,11 @@ pub struct GetArgs {
     pub fasta: bool,
 
     /// Custom defline template (fasterq-dump `--seq-defline` syntax).
-    /// Variables: $ac (accession) $si (spot id) $ri (read id) $sn (spot name)
-    /// $rl (read length); $$ is a literal '$'. Example: '@$ac.$si.$ri'.
-    /// The '+' line mirrors this. ($sg/spot-group is not supported.)
+    /// Variables: $ac (accession) $si (spot id) $ri (read id) $sn (spot/read
+    /// name) $rl (read length); $$ is a literal '$'. Example: '@$ac.$si.$ri'.
+    /// For PacBio/ONT, $sn is the native read name (e.g. PacBio
+    /// 'm64012_.../ccs', ONT '<uuid> ch=.. start_time=..'); it is also the
+    /// default header. The '+' line mirrors this. ($sg/spot-group unsupported.)
     #[arg(
         long,
         value_name = "TEMPLATE",


### PR DESCRIPTION
## Summary

Improves support for long-read platforms (PacBio SMRT, Oxford Nanopore). The motivating bug: a PacBio run loaded from FASTQ reported `Platform: unknown` because its VDB schema table is the generic `NCBI:SRA:GenericFastq:sequence#2` (no platform tag) and detection only sniffed the schema string.

## Changes

- **Authoritative platform detection** (`sracha-vdb/metadata.rs`): `detect_platform` now reads the `col/PLATFORM/row` numeric id (`INSDC:SRA:platform_id`, ids 1–11) before falling back to schema-string sniffing. This is the same source `vdb`/`fasterq-dump` use, and it's set even on generic-FASTQ-loaded runs. The PacBio fixture flips from `unknown` → `PACBIO_SMRT`. Generalizes to any generic-loaded run (ONT, BGISEQ, Element, …).
- **Read structure for long reads**: PacBio/Nanopore runs resolve to one biological read per spot — from the PLATFORM id (Strategy 3a) or a platform-tagged schema (3b) — instead of erroring to an untyped fallback. Keeps `metadata_read_types()` meaningful for single-end long reads.
- **Split advisory**: the single-end warning printed for `--split split-3` now also fires for `--split interleaved` and points users at `--split split-spot`.
- **Docs**: `--seq-defline`'s `$sn` is documented as the platform-native read identifier for PacBio/ONT (e.g. `m64012_.../ccs`, ONT `<uuid> ch=.. start_time=..`). Those channel/start-time/ZMW values are substrings of the read name, not separate VDB columns, so they're exposed via `$sn` (and the default header) rather than standalone variables.

## Tests

- New network-gated integration fixtures: PacBio SMRT `SRR38889541` (~11 MiB) and Oxford Nanopore `SRR38892122` (~7 MiB), both downloaded + decoded to confirm single-end output; PacBio asserts PLATFORM-column detection, ONT asserts schema-tag detection.
- New metadata unit tests: id→name mapping, column-beats-schema, undefined-id-falls-back-to-schema, read-structure-from-PLATFORM-column, long-read nreads inference.
- `601` unit tests pass; both ignored long-read integration tests pass; `cargo fmt` and `cargo clippy -D warnings` clean.

## Notes

- Fixture `.sra` files are gitignored (download-on-first-run + cached, matching existing fixtures).
- Not in scope (not an easy/correct win): PacBio sub-read structure (CLR subreads vs HiFi/CCS) and ZMW/movie sub-fields aren't separate VDB columns — they live inside the read name, already surfaced via `$sn` — so splitting them out would require fragile name parsing.