### PR TITLE
fix(get): preserve partial download on Ctrl-C and report accurate resume state

### DIFF
--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -1528,10 +1528,19 @@ pub async fn download_sra(
         tokio::select! {
             result = dl_future => result?,
             _ = poll_cancelled(flag) => {
-                tracing::info!("{accession}: download cancelled");
-                let _ = tokio::fs::remove_file(&temp_path).await;
-                let sidecar = crate::download::progress_path(&temp_path);
-                let _ = tokio::fs::remove_file(&sidecar).await;
+                // Non-stdout: preserve the partial file + `.sracha-progress`
+                // sidecar so the next run resumes the download instead of
+                // starting over (see the resume contract in `download_file`).
+                // stdout streams should leave no artifacts, matching the
+                // decode-phase cleanup below, so wipe both there.
+                if config.stdout {
+                    let _ = tokio::fs::remove_file(&temp_path).await;
+                    let sidecar = crate::download::progress_path(&temp_path);
+                    let _ = tokio::fs::remove_file(&sidecar).await;
+                    tracing::info!("{accession}: download cancelled (partial discarded)");
+                } else {
+                    tracing::info!("{accession}: download cancelled (partial kept for resume)");
+                }
                 return Err(Error::Cancelled { output_files: vec![] });
             }
         }

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -1457,7 +1457,10 @@ fn download_cancel_stdout_discards_partial_and_sidecar() {
         matches!(result, Err(sracha_core::error::Error::Cancelled { .. })),
         "pre-cancelled stdout download must return Error::Cancelled",
     );
-    assert!(!temp_path.exists(), "stdout cancel must discard the partial .sra");
+    assert!(
+        !temp_path.exists(),
+        "stdout cancel must discard the partial .sra"
+    );
     assert!(!sidecar.exists(), "stdout cancel must discard the sidecar");
 }
 

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -1358,6 +1358,109 @@ fn ctrl_c_before_decode_aborts_with_cancelled_error() {
     assert!(cancelled.load(Ordering::Relaxed));
 }
 
+/// Build a `ResolvedAccession` pointing at an unreachable mirror. Used by the
+/// download-cancel tests below, where a pre-flipped cancel flag wins the
+/// `tokio::select!` before any network I/O is attempted, so the URL is never
+/// actually fetched.
+fn resolved_for_cancel(acc: &str) -> sracha_core::sdl::ResolvedAccession {
+    use sracha_core::sdl::{ResolvedAccession, ResolvedFile, ResolvedMirror};
+    ResolvedAccession {
+        accession: acc.to_string(),
+        sra_file: ResolvedFile {
+            mirrors: vec![ResolvedMirror {
+                url: "http://127.0.0.1:1/file".to_string(),
+                service: "ncbi".to_string(),
+            }],
+            size: 1024,
+            md5: None,
+            is_lite: false,
+        },
+        vdbcache_file: None,
+        run_info: None,
+    }
+}
+
+/// Regression guard for the resume contract: a graceful Ctrl-C *during the
+/// download phase* (non-stdout) must NOT delete the partial `.sra` or its
+/// `.sracha-progress` sidecar — the next run resumes from them. Commit
+/// 83de2c9 once added a `remove_file` pair here that silently defeated resume
+/// and made the "next run will skip download" message a lie. This test fails
+/// if those deletions ever come back.
+#[test]
+fn download_cancel_keeps_partial_and_sidecar_for_resume() {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+
+    let out = tempfile::tempdir().unwrap();
+    let acc = "SRR000001";
+
+    // Stand in for a prior interrupted download: a partial .sra plus the
+    // sidecar that `download_file` writes alongside it. The sidecar name
+    // mirrors `download::progress_path` (`.{filename}.sracha-progress`), which
+    // is crate-private, so it's spelled out here.
+    let temp_path = out.path().join(format!(".sracha-tmp-{acc}.sra"));
+    let sidecar = out
+        .path()
+        .join(format!("..sracha-tmp-{acc}.sra.sracha-progress"));
+    std::fs::write(&temp_path, b"partial bytes").unwrap();
+    std::fs::write(&sidecar, b"{}").unwrap();
+
+    let resolved = resolved_for_cancel(acc);
+    let mut config = test_config(out.path(), SplitMode::Split3, CompressionMode::None);
+    config.force = false; // don't wipe the (nonexistent) completion marker
+    config.cancelled = Some(Arc::new(AtomicBool::new(true)));
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let result = rt.block_on(sracha_core::pipeline::download_sra(&resolved, &config));
+
+    assert!(
+        matches!(result, Err(sracha_core::error::Error::Cancelled { .. })),
+        "pre-cancelled download must return Error::Cancelled",
+    );
+    assert!(temp_path.exists(), "partial .sra must be kept for resume");
+    assert!(sidecar.exists(), "progress sidecar must be kept for resume");
+}
+
+/// Counterpart to the resume test: `--stdout` streams with no on-disk artifact,
+/// so a download-phase cancel there *must* wipe the partial + sidecar, matching
+/// the stdout decode-phase cleanup.
+#[test]
+fn download_cancel_stdout_discards_partial_and_sidecar() {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+
+    let out = tempfile::tempdir().unwrap();
+    let acc = "SRR000001";
+    let temp_path = out.path().join(format!(".sracha-tmp-{acc}.sra"));
+    let sidecar = out
+        .path()
+        .join(format!("..sracha-tmp-{acc}.sra.sracha-progress"));
+    std::fs::write(&temp_path, b"partial bytes").unwrap();
+    std::fs::write(&sidecar, b"{}").unwrap();
+
+    let resolved = resolved_for_cancel(acc);
+    let mut config = test_config(out.path(), SplitMode::Split3, CompressionMode::None);
+    config.force = false;
+    config.stdout = true;
+    config.cancelled = Some(Arc::new(AtomicBool::new(true)));
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let result = rt.block_on(sracha_core::pipeline::download_sra(&resolved, &config));
+
+    assert!(
+        matches!(result, Err(sracha_core::error::Error::Cancelled { .. })),
+        "pre-cancelled stdout download must return Error::Cancelled",
+    );
+    assert!(!temp_path.exists(), "stdout cancel must discard the partial .sra");
+    assert!(!sidecar.exists(), "stdout cancel must discard the sidecar");
+}
+
 #[ignore]
 #[test]
 fn ls454_platform_is_rejected_end_to_end() {

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -510,8 +510,20 @@ async fn main() -> Result<()> {
                 });
             }
 
+            // Which phase a Ctrl-C landed in determines what was left on disk,
+            // and therefore what we tell the user the next run will do.
+            enum InterruptPhase {
+                // Partial .sra + sidecar preserved; next run resumes download.
+                Download,
+                // Full .sra preserved; next run skips download, re-decodes.
+                Decode,
+                // ENA fast path: partial FASTQ removed, no .sra involved.
+                Ena,
+            }
+
             let mut completed_accessions: Vec<String> = Vec::new();
             let mut interrupted_accession: Option<String> = None;
+            let mut interrupt_phase: Option<InterruptPhase> = None;
 
             // Process accessions with an N-deep download prefetch queue:
             // while decoding accession i, keep the next `prefetch_depth`
@@ -614,6 +626,7 @@ async fn main() -> Result<()> {
                         Ok(s) => s,
                         Err(sracha_core::error::Error::Cancelled { .. }) => {
                             interrupted_accession = Some(resolved.accession.clone());
+                            interrupt_phase = Some(InterruptPhase::Ena);
                             break;
                         }
                         Err(e) => return Err(e.into()),
@@ -658,12 +671,14 @@ async fn main() -> Result<()> {
                     Ok(Ok(d)) => d,
                     Ok(Err(sracha_core::error::Error::Cancelled { .. })) => {
                         interrupted_accession = Some(resolved.accession.clone());
+                        interrupt_phase = Some(InterruptPhase::Download);
                         break;
                     }
                     Ok(Err(e)) => return Err(e.into()),
                     Err(join_err) => {
                         if cancelled.load(Ordering::Relaxed) {
                             interrupted_accession = Some(resolved.accession.clone());
+                            interrupt_phase = Some(InterruptPhase::Download);
                             break;
                         }
                         return Err(anyhow::anyhow!("download task panicked: {join_err}"));
@@ -735,6 +750,7 @@ async fn main() -> Result<()> {
                     }
                     Err(sracha_core::error::Error::Cancelled { .. }) => {
                         interrupted_accession = Some(resolved.accession.clone());
+                        interrupt_phase = Some(InterruptPhase::Decode);
                         break;
                     }
                     Err(e) => return Err(e.into()),
@@ -761,9 +777,19 @@ async fn main() -> Result<()> {
                         style::header(interrupted),
                     );
                 } else {
+                    let detail = match interrupt_phase {
+                        Some(InterruptPhase::Download) => {
+                            "partial download kept, next run will resume"
+                        }
+                        Some(InterruptPhase::Decode) => {
+                            "temp SRA kept, next run will skip download"
+                        }
+                        // ENA fast path leaves no .sra; only the partial FASTQ
+                        // was removed.
+                        Some(InterruptPhase::Ena) | None => "cleaned up partial output",
+                    };
                     eprintln!(
-                        "Interrupted -- cleaned up partial output for {} \
-                         (temp SRA kept, next run will skip download).{suffix}",
+                        "Interrupted {} -- {detail}.{suffix}",
                         style::header(interrupted),
                     );
                 }


### PR DESCRIPTION
## What

Interrupting `sracha get` mid-download printed `cleaned up partial output … (temp SRA kept, next run will skip download)`, but no partial was actually on disk — the message was a lie.

## Root cause

Two issues, one underlying:

1. **Resume regression.** The graceful download-phase Ctrl-C handler deleted the partial `.sra` *and* its `.sracha-progress` sidecar. That defeats the resume contract documented in `download_file` ("partial files and progress sidecars are preserved for the next attempt") and in `CLAUDE.md`. The original Ctrl-C commit (`378203f`) preserved the partial; the deletion was slipped in by `83de2c9`, an unrelated `--format sra` change.

2. **One message for three phases.** `sracha get` can be interrupted during ENA fast-path download, NCBI download, or decode — each leaves something different on disk, but all three printed the decode-phase text.

## Fix

- **pipeline:** non-stdout download cancel now keeps the partial + sidecar so the next run resumes. `--stdout` still wipes both, matching the decode-phase "streaming leaves no artifacts" rule.
- **cli:** track which phase the interrupt landed in and print an accurate message:
  - download → `partial download kept, next run will resume`
  - decode → `temp SRA kept, next run will skip download`
  - ENA → `cleaned up partial output`
- **tests:** two hermetic regression tests (pre-flipped cancel flag, no network, ~18ms) asserting the partial is kept on non-stdout cancel and discarded on stdout cancel. Verified the resume test fails if the buggy deletion is reintroduced.

## Not covered

The `main.rs` message wording itself isn't unit-tested — it lives deep in the `Command::Get` orchestration loop and isn't cheaply reachable without a refactor. It's now a pure function of the tracked phase, so the risk is low.

## Test plan

- [x] `cargo nextest run -p sracha-core -E 'test(download_cancel)'` — 2 passed
- [x] Verified both tests fail/pass correctly against buggy vs fixed code
- [x] `cargo clippy -p sracha-core -p sracha --all-targets` clean
- [x] `cargo build` clean