### PR TITLE
feat(pipeline): byte-bounded decode backpressure (ByteBudget)

### DIFF
--- a/crates/sracha-core/src/pipeline/byte_budget.rs
+++ b/crates/sracha-core/src/pipeline/byte_budget.rs
@@ -1,0 +1,204 @@
+//! [`ByteBudget`] — byte-bounded backpressure for the decode → write pipeline.
+//!
+//! Decode runs blob-by-blob in parallel; each decoded blob holds its formatted
+//! FASTQ output (`Vec<u8>`) in memory until the single writer thread drains it.
+//! The amount queued ahead of the writer is the dominant source of resident
+//! memory on large runs (issue #54: a 1024-blob × capacity-4 *count*-bounded
+//! channel buffered ~19 GiB before the writer saw the first byte).
+//!
+//! Bounding by blob *count* is the wrong unit — formatted bytes per blob vary
+//! by ~1000× across runs (short Illumina vs. long-read PacBio/ONT, full vs.
+//! SRA-lite). [`ByteBudget`] bounds the queue by *bytes* instead, so the
+//! pipeline depth self-tunes: many small blobs queue deeply (max throughput),
+//! few huge blobs queue shallowly (memory safe), under one predictable cap.
+//!
+//! The producer [`acquire`](ByteBudget::acquire)s a batch's byte size before
+//! handing it off and blocks while the queue is over budget; the writer
+//! [`release`](ByteBudget::release)s after draining each batch.
+
+use std::sync::Condvar;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+/// Tracks bytes currently queued from the decode producer to the writer and
+/// applies backpressure when that exceeds `cap`.
+pub(crate) struct ByteBudget {
+    /// Bytes handed to the writer but not yet drained.
+    queued: Mutex<u64>,
+    /// Signalled when the writer releases bytes or the budget is closed.
+    cv: Condvar,
+    /// Soft ceiling on `queued`. A batch larger than `cap` is still admitted
+    /// when the queue is empty, so a single oversized batch never deadlocks.
+    cap: u64,
+    /// Set when the writer exits (normal or error) so a parked producer wakes.
+    closed: AtomicBool,
+}
+
+impl ByteBudget {
+    pub(crate) fn new(cap: u64) -> Self {
+        Self {
+            queued: Mutex::new(0),
+            cv: Condvar::new(),
+            cap: cap.max(1),
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    /// Reserve `n` bytes of queue, blocking while the queue is over `cap`.
+    ///
+    /// Returns `true` once the reservation is made; `false` if the writer has
+    /// [`close`](Self::close)d the budget or `cancelled` fired — in which case
+    /// the producer should stop without sending. Polls with a short timeout so
+    /// it stays responsive to cancellation even if no `release` arrives.
+    ///
+    /// Admits a batch larger than `cap` when the queue is empty (the `*q == 0`
+    /// arm), which is what guarantees forward progress on a single blob whose
+    /// output exceeds the whole budget.
+    pub(crate) fn acquire(&self, n: u64, cancelled: Option<&AtomicBool>) -> bool {
+        let mut q = self.queued.lock().unwrap();
+        loop {
+            if self.closed.load(Ordering::Relaxed) {
+                return false;
+            }
+            if cancelled.is_some_and(|c| c.load(Ordering::Relaxed)) {
+                return false;
+            }
+            if *q == 0 || *q + n <= self.cap {
+                *q += n;
+                return true;
+            }
+            (q, _) = self.cv.wait_timeout(q, Duration::from_millis(100)).unwrap();
+        }
+    }
+
+    /// Return `n` bytes to the budget after the writer has drained them and
+    /// wake any producer parked in [`acquire`](Self::acquire).
+    pub(crate) fn release(&self, n: u64) {
+        let mut q = self.queued.lock().unwrap();
+        *q = q.saturating_sub(n);
+        drop(q);
+        self.cv.notify_all();
+    }
+
+    /// Mark the budget closed (writer is gone) and wake every parked producer.
+    pub(crate) fn close(&self) {
+        self.closed.store(true, Ordering::Relaxed);
+        self.cv.notify_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU64;
+
+    #[test]
+    fn acquire_under_cap_succeeds_immediately() {
+        let b = ByteBudget::new(1000);
+        assert!(b.acquire(400, None));
+        assert!(b.acquire(400, None));
+        assert_eq!(*b.queued.lock().unwrap(), 800);
+    }
+
+    #[test]
+    fn oversized_batch_admitted_when_empty() {
+        // A single batch larger than the whole cap must pass when the queue is
+        // empty, or decode of a giant blob would deadlock forever.
+        let b = ByteBudget::new(100);
+        assert!(b.acquire(10_000, None));
+        assert_eq!(*b.queued.lock().unwrap(), 10_000);
+    }
+
+    #[test]
+    fn release_lets_a_blocked_producer_proceed() {
+        let b = Arc::new(ByteBudget::new(1000));
+        assert!(b.acquire(800, None)); // queue now 800
+
+        let b2 = Arc::clone(&b);
+        let done = Arc::new(AtomicBool::new(false));
+        let done2 = Arc::clone(&done);
+        // 800 + 400 > 1000 and queue is non-empty, so this blocks.
+        let h = std::thread::spawn(move || {
+            assert!(b2.acquire(400, None));
+            done2.store(true, Ordering::SeqCst);
+        });
+
+        // Give the producer a moment to park, then confirm it's still blocked.
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(!done.load(Ordering::SeqCst), "should still be blocked");
+
+        b.release(800); // drops queue to 0; the 400 now fits
+        h.join().unwrap();
+        assert!(done.load(Ordering::SeqCst));
+        assert_eq!(*b.queued.lock().unwrap(), 400);
+    }
+
+    #[test]
+    fn close_unblocks_producer_with_false() {
+        let b = Arc::new(ByteBudget::new(1000));
+        assert!(b.acquire(900, None));
+
+        let b2 = Arc::clone(&b);
+        let h = std::thread::spawn(move || b2.acquire(900, None));
+        std::thread::sleep(Duration::from_millis(50));
+        b.close();
+        assert!(!h.join().unwrap(), "acquire must return false after close");
+    }
+
+    #[test]
+    fn cancel_flag_unblocks_producer_with_false() {
+        let b = Arc::new(ByteBudget::new(1000));
+        assert!(b.acquire(900, None));
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        let b2 = Arc::clone(&b);
+        let cancel2 = Arc::clone(&cancel);
+        let h = std::thread::spawn(move || b2.acquire(900, Some(&cancel2)));
+        std::thread::sleep(Duration::from_millis(50));
+        cancel.store(true, Ordering::SeqCst);
+        assert!(!h.join().unwrap(), "acquire must return false after cancel");
+    }
+
+    #[test]
+    fn release_saturates_at_zero() {
+        // Defensive: a release larger than queued must not underflow.
+        let b = ByteBudget::new(1000);
+        assert!(b.acquire(100, None));
+        b.release(999_999);
+        assert_eq!(*b.queued.lock().unwrap(), 0);
+    }
+
+    #[test]
+    fn concurrent_producers_never_exceed_cap_beyond_one_batch() {
+        // With cap C and uniform batch size S (S <= C), queued should never
+        // exceed C while batches are outstanding (each producer acquires
+        // before "sending"). One consumer drains in a loop.
+        let cap = 1000u64;
+        let b = Arc::new(ByteBudget::new(cap));
+        let peak = Arc::new(AtomicU64::new(0));
+        let batch = 200u64;
+
+        let mut producers = Vec::new();
+        for _ in 0..4 {
+            let b = Arc::clone(&b);
+            let peak = Arc::clone(&peak);
+            producers.push(std::thread::spawn(move || {
+                for _ in 0..50 {
+                    assert!(b.acquire(batch, None));
+                    let cur = *b.queued.lock().unwrap();
+                    peak.fetch_max(cur, Ordering::Relaxed);
+                    // Simulate immediate hand-off + drain.
+                    b.release(batch);
+                }
+            }));
+        }
+        for p in producers {
+            p.join().unwrap();
+        }
+        // Each acquire admits only when *q == 0 or *q + batch <= cap, so the
+        // observed queue never exceeds cap (batch divides cap here).
+        assert!(peak.load(Ordering::Relaxed) <= cap);
+    }
+}

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -44,11 +44,13 @@ pub use config::{PipelineConfig, PipelineStats};
 // ---------------------------------------------------------------------------
 
 mod blob_decode;
+mod byte_budget;
 mod marker;
 mod validate;
 use blob_decode::{
     BlobDecodeCtx, RawBlobData, decode_blob_to_fastq, decode_raw, decode_zip_encoding,
 };
+use byte_budget::ByteBudget;
 use marker::{
     StatsEntry, check_completion_marker, marker_path, write_completion_marker, write_stats_file,
 };
@@ -564,22 +566,45 @@ fn decode_and_write(
         None
     };
 
-    /// Number of blobs per batch for parallel decode.
-    const BATCH_SIZE: usize = 1024;
+    // Number of blobs decoded in parallel per wave. This is the *materialized*
+    // working set the `par_iter().collect()` below holds at once, so it is kept
+    // small — a few blobs per thread for work-stealing slack, capped so the
+    // pre-handoff wave stays modest. Memory queued *ahead of the writer* is
+    // bounded separately, by bytes, via `ByteBudget` (see below).
+    let batch_size = (num_threads * 4).clamp(16, 64);
 
     // ------------------------------------------------------------------
-    // Pipelined decode → write.
+    // Pipelined decode → write, with byte-bounded backpressure.
     //
-    // A crossbeam channel decouples the decode loop (producer) from the
-    // write loop (consumer).  While the writer drains batch N, the
-    // decode pool is already working on batch N+1.
-    // ------------------------------------------------------------------
+    // A channel decouples the decode loop (producer) from the writer
+    // (consumer): while the writer drains batch N, the decode pool works on
+    // batch N+1. The channel is *unbounded* — backpressure is applied by
+    // bytes instead of by message count via `ByteBudget`, so the producer can
+    // never get more than ~one batch ahead of the budget regardless of how
+    // many (or how few) messages that represents.
+    //
+    // Why bytes, not blob count: formatted FASTQ per blob varies ~1000× across
+    // runs (short Illumina vs. long-read, full vs. SRA-lite). A fixed
+    // count-based bound buffered ~19 GiB on SRR36401016 (issue #54). A byte
+    // budget self-tunes pipeline depth — deep for small blobs (throughput),
+    // shallow for huge blobs (memory) — under one predictable cap.
     type FormattedBlob = (Vec<BlobSlotOutput>, u64);
-    // Bounded channel gives the decode pool slack when writer batch time
-    // varies. Capacity 4 costs at most 4×BATCH_SIZE formatted blobs of
-    // memory — bounded, and measurably better than 2 on variable-sized
-    // writer work (e.g. gzip vs plain).
-    let (batch_tx, batch_rx) = crossbeam_channel::bounded::<Vec<Result<FormattedBlob>>>(4);
+    // Each message is `(queued_bytes, batch)` so the writer can refund the
+    // exact amount the producer reserved. The producer blocks in
+    // `budget.acquire` before sending, so at most one batch beyond the cap is
+    // ever resident; the unbounded channel therefore never actually piles up.
+    let (batch_tx, batch_rx) = crossbeam_channel::unbounded::<(u64, Vec<Result<FormattedBlob>>)>();
+
+    /// Default cap on formatted FASTQ queued ahead of the writer (256 MiB).
+    /// Peak decode RSS is roughly this plus the in-flight wave
+    /// (`batch_size × per-blob output`), independent of total run size.
+    const DECODE_BUFFER_BYTES: u64 = 256 * 1024 * 1024;
+    let budget = ByteBudget::new(DECODE_BUFFER_BYTES);
+    let budget = &budget;
+    tracing::debug!(
+        "{accession}: decode batch_size={batch_size}, queue budget={} MiB",
+        DECODE_BUFFER_BYTES / (1024 * 1024),
+    );
 
     // Rebind the shared state the writer thread touches as explicit
     // `&mut` / `&` references BEFORE the scope, then the writer's `move`
@@ -600,52 +625,70 @@ fn decode_and_write(
     let write_result: Result<()> = std::thread::scope(|scope| {
         // ---- Writer thread ----
         let writer_handle = scope.spawn(move || -> Result<()> {
-            let mut blob_counter: usize = 0;
-            while let Ok(formatted_batches) = batch_rx.recv() {
-                for result in formatted_batches {
-                    let (slot_outputs, num_spots) = result?;
+            // Wrap the drain loop so the budget is closed on *every* exit path
+            // (normal end, decode error, write error) — otherwise a producer
+            // parked in `budget.acquire` would never wake. `close()` makes that
+            // `acquire` return `false`, unwinding the decode loop cleanly.
+            let mut drain = || -> Result<()> {
+                let mut blob_counter: usize = 0;
+                while let Ok((queued_bytes, formatted_batches)) = batch_rx.recv() {
+                    for result in formatted_batches {
+                        let (slot_outputs, num_spots) = result?;
 
-                    // One write_all per (slot, blob) instead of per record —
-                    // orders of magnitude fewer write calls, and the Vec<u8>
-                    // allocation happens at most 4× per blob, not per record.
-                    for slot_out in &slot_outputs {
-                        let writer = if let Some(sw) = stdout_writer_ref {
-                            sw
-                        } else {
-                            writers_ref.entry(slot_out.slot).or_insert_with(|| {
-                                let (writer, final_path, tmp_path) = create_output_writer_for_slot(
-                                    accession,
-                                    slot_out.slot,
-                                    config,
-                                    &compress_pool,
-                                );
-                                output_paths_ref.push((final_path, tmp_path));
-                                writer
-                            })
-                        };
+                        // One write_all per (slot, blob) instead of per record —
+                        // orders of magnitude fewer write calls, and the Vec<u8>
+                        // allocation happens at most 4× per blob, not per record.
+                        for slot_out in &slot_outputs {
+                            let writer = if let Some(sw) = stdout_writer_ref {
+                                sw
+                            } else {
+                                writers_ref.entry(slot_out.slot).or_insert_with(|| {
+                                    let (writer, final_path, tmp_path) =
+                                        create_output_writer_for_slot(
+                                            accession,
+                                            slot_out.slot,
+                                            config,
+                                            &compress_pool,
+                                        );
+                                    output_paths_ref.push((final_path, tmp_path));
+                                    writer
+                                })
+                            };
 
-                        writer.write_all(&slot_out.bytes).map_err(Error::Io)?;
-                        *reads_written_ref += slot_out.records;
-                        *per_slot_counts_ref.entry(slot_out.slot).or_insert(0) += slot_out.records;
+                            writer.write_all(&slot_out.bytes).map_err(Error::Io)?;
+                            *reads_written_ref += slot_out.records;
+                            *per_slot_counts_ref.entry(slot_out.slot).or_insert(0) +=
+                                slot_out.records;
+                        }
+
+                        spots_read_ref.fetch_add(num_spots, std::sync::atomic::Ordering::Relaxed);
+                        blob_counter += 1;
+
+                        if let Some(pb) = decode_pb_ref.as_ref() {
+                            pb.inc(1);
+                        }
+
+                        if blob_counter.is_multiple_of(50) || blob_counter == num_blobs {
+                            tracing::debug!(
+                                "{accession}: decoded {blob_counter}/{num_blobs} blobs, \
+                                 {} spots so far",
+                                spots_read_ref.load(std::sync::atomic::Ordering::Relaxed),
+                            );
+                        }
                     }
 
-                    spots_read_ref.fetch_add(num_spots, std::sync::atomic::Ordering::Relaxed);
-                    blob_counter += 1;
-
-                    if let Some(pb) = decode_pb_ref.as_ref() {
-                        pb.inc(1);
-                    }
-
-                    if blob_counter.is_multiple_of(50) || blob_counter == num_blobs {
-                        tracing::debug!(
-                            "{accession}: decoded {blob_counter}/{num_blobs} blobs, \
-                             {} spots so far",
-                            spots_read_ref.load(std::sync::atomic::Ordering::Relaxed),
-                        );
-                    }
+                    // Whole batch drained — refund exactly what the producer
+                    // reserved so it can queue more (or unblock if parked).
+                    budget.release(queued_bytes);
                 }
-            }
-            Ok(())
+                Ok(())
+            };
+
+            let result = drain();
+            // Always wake any producer parked in `budget.acquire`, even on the
+            // error path where `release` for the failed batch never ran.
+            budget.close();
+            result
         });
 
         // Per-call immutable context reused across every blob decode.
@@ -662,9 +705,9 @@ fn decode_and_write(
         // `cumulative_spots` tracks the total number of spots in blobs 0..blob_idx
         // so each batch can compute `spots_before_per_blob` deterministically
         // from blob metadata alone. Reading `spots_read` here would race with
-        // the writer thread on archives with more than `BATCH_SIZE` (1024)
-        // blobs — the bounded channel of capacity 4 lets the decoder queue
-        // four batches ahead of the writer, and the writer's fetch_add on
+        // the writer thread on archives with more than `batch_size` blobs —
+        // the byte budget lets the decoder queue batches ahead of the writer,
+        // and the writer's fetch_add on
         // `spots_read` doesn't happen until it has processed a batch.
         // DRR045255 (3658 blobs) used to emit `spots_before=0` for batch 2
         // onwards, resetting the FASTQ defline spot number to 1.
@@ -677,7 +720,7 @@ fn decode_and_write(
                 break;
             }
 
-            let batch_end = (blob_idx + BATCH_SIZE).min(num_blobs);
+            let batch_end = (blob_idx + batch_size).min(num_blobs);
 
             let blob_id_ranges: Vec<u32> = (blob_idx..batch_end)
                 .map(|bi| cursor.read_col().blobs()[bi].id_range)
@@ -865,10 +908,27 @@ fn decode_and_write(
                     .collect()
             });
 
-            // Send to writer thread (blocks if writer is behind by 2 batches).
-            if batch_tx.send(formatted_batches).is_err() {
-                break; // Writer thread exited (error) — rx is dropped
-                // because the writer closure captured it by value (move).
+            // Sum the formatted bytes this batch will queue (errored blobs
+            // contribute nothing — the writer surfaces the error and exits).
+            let queued_bytes: u64 = formatted_batches
+                .iter()
+                .filter_map(|r| r.as_ref().ok())
+                .flat_map(|(slots, _)| slots.iter())
+                .map(|s| s.bytes.len() as u64)
+                .sum();
+
+            // Backpressure by bytes: block until this batch fits under the
+            // budget (an oversized lone batch passes when the queue is empty).
+            // `false` means the writer is gone (error/cancel) — stop sending.
+            if !budget.acquire(queued_bytes, config.cancelled.as_deref()) {
+                break;
+            }
+
+            // Unbounded channel, so this never blocks; the budget above is the
+            // sole backpressure. An error means the writer thread exited (it
+            // dropped `batch_rx` on the way out).
+            if batch_tx.send((queued_bytes, formatted_batches)).is_err() {
+                break;
             }
 
             blob_idx = batch_end;
@@ -1114,7 +1174,7 @@ mod batch_spots_tests {
 
     #[test]
     fn second_batch_continues_from_cumulative() {
-        // Regression for the BATCH_SIZE=1024 race: batch 2's per-blob
+        // Regression for the multi-batch decode race: batch 2's per-blob
         // offsets must pick up from the running total at the end of
         // batch 1, not from a stale `spots_read` atomic that the writer
         // thread hadn't yet updated via `fetch_add`.


### PR DESCRIPTION
Refs #54. **Alternative** to #55 — kept on its own branch so the two can be benchmarked head-to-head. Not intended to merge alongside #55; pick one.

## Problem

Decoded blobs hold their formatted FASTQ output (owned `Vec<u8>`) in memory until the single writer thread drains them. Raw VDB input is zero-copy mmap (`read_raw_blob_slice -> &[u8]`), so this formatted output is the *only* controllable RSS.

The previous bound (1024-blob batches × capacity-4 channel) is **count-based**, but formatted bytes per blob vary ~1000× across runs (short Illumina vs long-read PacBio/ONT, full vs SRA-lite). Count is the wrong unit, so the same constants buffered ~19 GiB on `SRR36401016` (#54) while being fine elsewhere.

#55 mitigates by shrinking the count bound (thread-scaled batch + capacity 1). This PR fixes the unit: **bound by bytes**, which decouples peak RSS from both run size *and* thread count, and self-tunes pipeline depth.

## Design

- **New `ByteBudget` primitive** (`pipeline/byte_budget.rs`): `Mutex<u64>` + `Condvar` tracking queued bytes against a cap.
  - `acquire(n, cancelled)` blocks the producer while over budget; admits an oversized lone batch when the queue is empty (deadlock guard); returns `false` on `close()` (writer gone) or a cancel flag; polls with a 100 ms timeout for cancel responsiveness.
  - `release(n)` refunds after the writer drains a batch; `close()` wakes parked producers.
- **`decode_and_write` rewiring**: channel is now **unbounded**, carrying `(queued_bytes, batch)`. The byte budget is the sole backpressure — the producer `acquire`s before sending, so at most one batch beyond the cap is ever resident.
- **`batch_size = (threads*4).clamp(16,64)`** — only the in-flight parallel-decode wave; queue depth self-tunes via the budget (deep for small blobs = throughput, shallow for huge blobs = memory).
- Writer **closes the budget on every exit path** (normal / decode error / write error) so a parked producer always wakes.

Default cap `DECODE_BUFFER_BYTES = 256 MiB`. Peak decode RSS ≈ `cap + batch_size × per-blob output`, independent of total run size.

## Why this is the structural fix, not just smaller constants

The original capacity-4 buffer existed to give the writer slack when batch times vary (gzip vs plain). A byte budget gives that slack *adaptively* — hundreds of small blobs queue deeply for throughput, a few huge blobs queue shallowly for safety — under one predictable cap. That directly addresses the gzip-variance regression risk called out in #55, without the memory blowup.

## Verification

- 7 unit tests for `ByteBudget`: cap enforcement, oversized-batch admission, blocked-producer wakeup, close/cancel unblock, saturating release, concurrent producers stay under cap. (230 unit tests total, all pass.)
- Integration parity: `drr045255_cross_batch_spot_numbering` (now ~57 batches at batch_size 64) + `run_fastq_gzip` / `run_fastq_zstd` / `run_fastq_split_files` / `run_fastq_interleaved` / `run_fasta_split3` / `run_fastq_deterministic` all pass. The deterministic test confirms output ordering is preserved under the new concurrency.
- `cargo fmt --check`, `clippy -D warnings` clean.

## Deliberately scoped out

- **No CLI knob.** The 256 MiB cap is an internal `const` rather than a `--decode-buffer` flag threaded through `PipelineConfig` and its construction sites — keeps the diff contained to the decode path for clean benchmarking. Trivial follow-up if this approach wins.
- **The decode floor remains.** The budget caps the *queue*, not the parallel-decode wave (`num_threads × max_blob`). On long-read runs at high thread counts that floor can itself be a few GiB; the only lever there is fewer threads.

## Decision criterion vs #55

Benchmark a many-core `--compress gzip` run across `main` / #55 / this branch, comparing wall time *and* peak RSS. If #55's count bound shows no gzip-path regression and long-read runs aren't a concern, the simpler #55 may be enough. If either bites, this is the robust answer.