### PR TITLE
feat(pacbio): decode PacBio/ONT CONSENSUS reads with fasterq-dump parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,28 @@
   long-read platforms embed there are substrings of that name rather than
   separate columns. Adds network-gated integration fixtures for a PacBio
   SMRT run (SRR38889541) and an Oxford Nanopore run (SRR38892122).
+- PacBio/Oxford Nanopore **CONSENSUS** (CCS) support. When a database carries
+  a `CONSENSUS` table, sracha now reads its reads from there by default —
+  mirroring fasterq-dump's `insp_db_type()` table selection — so FASTQ output
+  matches fasterq-dump byte-for-byte (verified on DRR032988: 4,004 reads,
+  identical bases/quality/deflines, with empty consensus rows dropped). The
+  default defline now follows fasterq-dump's `dflt_seq_defline` rule: the name
+  field is emitted for tables that carry spot names (the reconstructed name, or
+  the spot number as the synthesized fallback) and **omitted entirely** for
+  tables with no NAME column (CONSENSUS), instead of repeating the spot number.
+
+### Fixes
+
+- Decode older PacBio SMRT archives (e.g. DRR032988) that previously failed
+  with `page_map: data_runs has N entries, expected at least M`. Variable-length
+  array columns (READ_START, READ_TYPE, LABEL_LEN/START, RD_FILTER) pack
+  per-record arrays of differing lengths; the page-map expansion now derives
+  each physical record's width from `lengths`/`leng_runs` instead of assuming a
+  single fixed row length, so records are replicated to rows correctly.
+- Stop mis-decoding raw, uncompressed 2na READ payloads. A header-less READ
+  blob whose bytes happen to parse as a tiny deflate stream (PacBio CONSENSUS
+  READ) is now recognised as raw when its size matches the expected packed base
+  count, rather than being collapsed to a few bytes.
 
 ## 0.3.7 (2026-05-29)
 

--- a/crates/sracha-core/src/fastq/mod.rs
+++ b/crates/sracha-core/src/fastq/mod.rs
@@ -204,9 +204,10 @@ const FALLBACK_QUAL_BYTE: u8 = b'?';
 
 /// Format a single read segment into a [`FastqRecord`].
 ///
-/// Defline format matches fasterq-dump: `@{run}.{spot_num} {description} length={len}`
-/// where `description` is the original read name if available, or the spot number again.
-/// The `+` line repeats the defline content.
+/// Defline format matches fasterq-dump: `@{run}.{spot_num} {name} length={len}`
+/// when an original read name is present, or `@{run}.{spot_num} length={len}`
+/// when it is absent (fasterq-dump omits the name field rather than repeating
+/// the spot number). The `+` line repeats the defline content.
 ///
 /// Bases with Phred quality 0 (ASCII `!`) are replaced with `N` to match
 /// the NCBI convention for no-call bases stored in 2na encoding.
@@ -273,7 +274,7 @@ pub fn append_fastq_record(
     diag: Option<&IntegrityDiag>,
 ) {
     let len = sequence.len();
-    let description = original_name.unwrap_or(spot_number);
+    let description = original_name;
     let quality = repair_quality(quality, len, diag);
 
     let mut itoa_buf = itoa::Buffer::new();
@@ -363,20 +364,27 @@ fn repair_quality<'a>(
     Cow::Borrowed(quality)
 }
 
-/// Shared defline body: `{run}.{spot} {description} length={len}`.
-/// Used by both the `@` line and the `>` line (FASTA).
+/// Shared defline body, used by both the `@` line and the `>` line (FASTA).
+///
+/// Matches fasterq-dump's default templates (`dflt_seq_defline`): when a
+/// spot name is present it emits `{run}.{spot} {name} length={len}`
+/// (`DSD_FASTQ_USE_NAME`); when there is no NAME column it omits the name
+/// field entirely — `{run}.{spot} length={len}` (`DSD_FASTQ_NO_NAME`) — rather
+/// than substituting the spot id.
 fn append_defline_body(
     out: &mut Vec<u8>,
     run_name: &str,
     spot_number: &[u8],
-    description: &[u8],
+    description: Option<&[u8]>,
     len_str: &str,
 ) {
     out.extend_from_slice(run_name.as_bytes());
     out.push(b'.');
     out.extend_from_slice(spot_number);
-    out.push(b' ');
-    out.extend_from_slice(description);
+    if let Some(desc) = description {
+        out.push(b' ');
+        out.extend_from_slice(desc);
+    }
     out.extend_from_slice(b" length=");
     out.extend_from_slice(len_str.as_bytes());
 }
@@ -385,10 +393,11 @@ fn append_defline_body(
 fn defline_body_len(
     run_name: &str,
     spot_number: &[u8],
-    description: &[u8],
+    description: Option<&[u8]>,
     len_str: &str,
 ) -> usize {
-    run_name.len() + 1 + spot_number.len() + 1 + description.len() + 8 + len_str.len()
+    let desc_len = description.map_or(0, |d| 1 + d.len());
+    run_name.len() + 1 + spot_number.len() + desc_len + 8 + len_str.len()
 }
 
 /// Format a single read segment into a FASTA record (no quality line).
@@ -419,7 +428,7 @@ pub fn append_fasta_record(
     sequence: &[u8],
 ) {
     let len = sequence.len();
-    let description = original_name.unwrap_or(spot_number);
+    let description = original_name;
 
     let mut itoa_buf = itoa::Buffer::new();
     let len_str = itoa_buf.format(len);
@@ -739,7 +748,8 @@ mod tests {
         assert_eq!(results.len(), 1);
         let data = &results[0].1.data;
         let text = std::str::from_utf8(data).unwrap();
-        assert!(text.starts_with("@SRR123456.42 42 length=4\n"));
+        // No NAME column → fasterq-dump omits the name field (no spot-id repeat).
+        assert!(text.starts_with("@SRR123456.42 length=4\n"));
     }
 
     #[test]
@@ -751,8 +761,8 @@ mod tests {
         assert_eq!(results.len(), 2);
         let r1 = std::str::from_utf8(&results[0].1.data).unwrap();
         let r2 = std::str::from_utf8(&results[1].1.data).unwrap();
-        assert!(r1.starts_with("@SRR999.99 99 length=4\n"));
-        assert!(r2.starts_with("@SRR999.99 99 length=4\n"));
+        assert!(r1.starts_with("@SRR999.99 length=4\n"));
+        assert!(r2.starts_with("@SRR999.99 length=4\n"));
     }
 
     #[test]
@@ -766,7 +776,7 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         let text = std::str::from_utf8(&results[0].1.data).unwrap();
-        assert_eq!(text, "@SRR1.1 1 length=4\nACGT\n+SRR1.1 1 length=4\nIIII\n");
+        assert_eq!(text, "@SRR1.1 length=4\nACGT\n+SRR1.1 length=4\nIIII\n");
     }
 
     // -----------------------------------------------------------------------
@@ -898,16 +908,10 @@ mod tests {
         let r1 = std::str::from_utf8(&results[0].1.data).unwrap();
         let r2 = std::str::from_utf8(&results[1].1.data).unwrap();
 
-        assert_eq!(
-            r1,
-            "@SRR1.10 10 length=4\nAACC\n+SRR1.10 10 length=4\nIIII\n"
-        );
+        assert_eq!(r1, "@SRR1.10 length=4\nAACC\n+SRR1.10 length=4\nIIII\n");
         // N-masking is now handled in the pipeline layer, not format_read.
         // Bases pass through unchanged regardless of quality.
-        assert_eq!(
-            r2,
-            "@SRR1.10 10 length=4\nGGTT\n+SRR1.10 10 length=4\n!!!!\n"
-        );
+        assert_eq!(r2, "@SRR1.10 length=4\nGGTT\n+SRR1.10 length=4\n!!!!\n");
     }
 
     // -----------------------------------------------------------------------
@@ -1207,7 +1211,7 @@ mod tests {
         let results = format_spot(&spot, "SRR1", &config);
 
         let text = std::str::from_utf8(&results[0].1.data).unwrap();
-        assert!(text.starts_with("@SRR1.spot.123_abc spot.123_abc length=4\n"));
+        assert!(text.starts_with("@SRR1.spot.123_abc length=4\n"));
     }
 
     // -----------------------------------------------------------------------
@@ -1584,9 +1588,9 @@ mod tests {
         let rec = format_read("RUN", b"1", None, b"ACGT", b"IIII");
         let text = std::str::from_utf8(&rec.data).unwrap();
         let lines: Vec<&str> = text.lines().collect();
-        assert_eq!(lines[0], "@RUN.1 1 length=4");
+        assert_eq!(lines[0], "@RUN.1 length=4");
         assert_eq!(lines[1], "ACGT");
-        assert_eq!(lines[2], "+RUN.1 1 length=4");
+        assert_eq!(lines[2], "+RUN.1 length=4");
         assert_eq!(lines[3], "IIII");
     }
 

--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -268,6 +268,13 @@ pub(crate) struct BlobDecodeCtx<'a> {
     pub(crate) diag: &'a IntegrityDiag,
     pub(crate) is_lite: bool,
     pub(crate) read_cs: u8,
+    /// Whether the source table exposes spot names (the SEQUENCE schema's
+    /// NAME/SPOT_NAME column, physical or virtual). Controls the default
+    /// defline: when `true` the name field is emitted (reconstructed name, or
+    /// the spot number as fasterq-dump's synthesized fallback); when `false`
+    /// (PacBio/ONT CONSENSUS, which has no NAME column) it is omitted, matching
+    /// fasterq-dump's `DSD_FASTQ_NO_NAME` template.
+    pub(crate) has_name_column: bool,
 }
 
 /// Decode the ALTREAD blob (when present) and merge its per-base 4na
@@ -517,6 +524,7 @@ pub(crate) fn decode_blob_to_fastq(
         diag,
         is_lite,
         read_cs,
+        has_name_column,
     } = *ctx;
     // ------------------------------------------------------------------
     // Decode READ blob -> 2na -> ASCII bases.
@@ -1200,6 +1208,21 @@ pub(crate) fn decode_blob_to_fastq(
             .as_ref()
             .and_then(|names| names.get(spot_idx_in_blob));
 
+        // Default-defline description, matching fasterq-dump's `dflt_seq_defline`:
+        // when the table exposes spot names the `$sn` field is emitted — the
+        // reconstructed name when available, otherwise the spot number as
+        // fasterq-dump's synthesized fallback (`DSD_FASTQ_SYN_NAME`); when the
+        // table has no NAME column (PacBio/ONT CONSENSUS reads) the field is
+        // omitted entirely (`DSD_FASTQ_NO_NAME`) rather than substituting the
+        // spot id. `has_name_column` is the table-level flag (true for SEQUENCE,
+        // false for CONSENSUS); note a physical NAME column may be absent even
+        // when names exist (Illumina names are reconstructed from ALTREAD+X+Y).
+        let description: Option<&[u8]> = if has_name_column {
+            Some(original_name.unwrap_or(spot_number))
+        } else {
+            None
+        };
+
         // Read types for this spot: borrow from decoded data or default to biological.
         let spot_read_types: &[u8] =
             if !read_type_data.is_empty() && rt_offset + rps <= read_type_data.len() {
@@ -1336,11 +1359,11 @@ pub(crate) fn decode_blob_to_fastq(
             match config.split_mode {
                 SplitMode::Split3 => {
                     if segments.len() == 2 {
-                        emit(OutputSlot::Read1, &segments[0], spot_number, original_name);
-                        emit(OutputSlot::Read2, &segments[1], spot_number, original_name);
+                        emit(OutputSlot::Read1, &segments[0], spot_number, description);
+                        emit(OutputSlot::Read2, &segments[1], spot_number, description);
                     } else {
                         for seg in &segments {
-                            emit(OutputSlot::Unpaired, seg, spot_number, original_name);
+                            emit(OutputSlot::Unpaired, seg, spot_number, description);
                         }
                     }
                 }
@@ -1363,7 +1386,7 @@ pub(crate) fn decode_blob_to_fastq(
                         name_buf.extend_from_slice(spot_number);
                         name_buf.push(b'/');
                         name_buf.extend_from_slice(mate_buf.format(seg.mate_idx).as_bytes());
-                        let desc = original_name.or(Some(spot_number));
+                        let desc = description.or(Some(spot_number));
                         emit(OutputSlot::Single, seg, &name_buf, desc);
                     }
                 }
@@ -1373,7 +1396,7 @@ pub(crate) fn decode_blob_to_fastq(
                             OutputSlot::ReadN(file_idx as u32),
                             seg,
                             spot_number,
-                            original_name,
+                            description,
                         );
                     }
                 }

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -354,7 +354,18 @@ fn decode_and_write(
 ) -> Result<(u64, u64, Vec<PathBuf>)> {
     let file = std::fs::File::open(sra_path)?;
     let mut archive = KarArchive::open(std::io::BufReader::new(file))?;
-    let cursor = VdbCursor::open(&mut archive, sra_path)?;
+    // PacBio/Nanopore databases expose their CCS / consensus reads in a
+    // CONSENSUS table; fasterq-dump reads it by default in preference to
+    // SEQUENCE (`insp_db_type()`). Mirror that so our FASTQ matches.
+    let table = if crate::vdb::cursor::archive_has_consensus_table(&archive) {
+        "CONSENSUS"
+    } else {
+        "SEQUENCE"
+    };
+    if table != "SEQUENCE" {
+        tracing::info!("{accession}: reading reads from {table} table");
+    }
+    let cursor = VdbCursor::open_table(&mut archive, sra_path, table)?;
 
     // Check platform — reject legacy platforms with complex read structures.
     if let Some(platform) = cursor.platform()
@@ -667,12 +678,16 @@ fn decode_and_write(
         });
 
         // Per-call immutable context reused across every blob decode.
+        // The SEQUENCE schema always exposes a (possibly virtual) NAME column,
+        // so its default deflines carry a name field; the CONSENSUS table has
+        // none, so fasterq-dump omits it there.
         let decode_ctx = BlobDecodeCtx {
             run_name: accession,
             config: &fastq_config,
             diag,
             is_lite,
             read_cs,
+            has_name_column: table != "CONSENSUS",
         };
 
         // ---- Decode loop (main thread) ----

--- a/crates/sracha-vdb/src/blob.rs
+++ b/crates/sracha-vdb/src/blob.rs
@@ -637,6 +637,102 @@ impl PageMap {
 
         Ok(expanded)
     }
+
+    /// Expand variable-length physical records into per-logical-row data,
+    /// honouring both `data_runs` (record → row replication) and the per-row
+    /// element counts carried by `lengths` / `leng_runs`.
+    ///
+    /// Each physical record occupies a contiguous run of elements in `data`
+    /// whose length is the element count of the first logical row the record
+    /// covers (all rows sharing a physical record have the same length). The
+    /// record is emitted `data_runs[i]` times.
+    ///
+    /// This generalises [`expand_data_runs_bytes`](Self::expand_data_runs_bytes),
+    /// which assumes every record is the same width. Variable-length array
+    /// columns — e.g. READ_START / READ_TYPE / LABEL_LEN / RD_FILTER on PacBio
+    /// SMRT runs, where each spot stores an NREADS-sized array — pack records
+    /// of differing lengths, so the fixed-width walk reads the wrong record
+    /// boundaries (and trips the length check when the record count and the
+    /// data-run count disagree).
+    ///
+    /// `elem_bytes` is the true element size (1 for byte columns, 4 for u32),
+    /// NOT a per-row stride — record widths come from the page map. Falls back
+    /// to passthrough when there are no `data_runs`.
+    pub fn expand_records_to_rows(&self, data: &[u8], elem_bytes: usize) -> Result<Vec<u8>> {
+        if self.data_runs.is_empty() || elem_bytes == 0 {
+            return Ok(data.to_vec());
+        }
+        // Without a length structure we can't recover per-record widths; defer
+        // to the fixed-width walk (each record is one element wide).
+        if self.lengths.is_empty() || self.leng_runs.is_empty() {
+            return self.expand_data_runs_bytes(data, elem_bytes);
+        }
+
+        let mut expanded = Vec::with_capacity(data.len());
+        let mut byte_off = 0usize; // consumed bytes of `data`
+        let mut li = 0usize; // index into lengths/leng_runs
+        let mut rem = self.leng_runs[0] as u64; // rows left in the current leng run
+
+        // Advance the leng-run cursor to the next run that still has rows.
+        let advance = |li: &mut usize, rem: &mut u64| -> Result<()> {
+            while *rem == 0 {
+                *li += 1;
+                match self.leng_runs.get(*li) {
+                    Some(&r) => *rem = r as u64,
+                    None => {
+                        return Err(Error::Format(
+                            "page_map: leng_runs exhausted before data_runs (inconsistent map)"
+                                .into(),
+                        ));
+                    }
+                }
+            }
+            Ok(())
+        };
+
+        for &run in &self.data_runs {
+            advance(&mut li, &mut rem)?;
+            let rec_len =
+                *self.lengths.get(li).ok_or_else(|| {
+                    Error::Format("page_map: lengths shorter than leng_runs".into())
+                })? as usize;
+            let rec_bytes = rec_len.checked_mul(elem_bytes).ok_or_else(|| {
+                Error::Format("page_map: record length × elem_bytes overflows".into())
+            })?;
+            let end = byte_off
+                .checked_add(rec_bytes)
+                .ok_or_else(|| Error::Format("page_map: record offset overflows".into()))?;
+            if end > data.len() {
+                return Err(Error::Format(format!(
+                    "page_map: variable record wants bytes {byte_off}..{end} but data has {}",
+                    data.len(),
+                )));
+            }
+            let chunk = &data[byte_off..end];
+            for _ in 0..run {
+                expanded.extend_from_slice(chunk);
+            }
+            byte_off = end;
+
+            // Consume `run` logical rows from the leng-run stream.
+            let mut to_consume = run as u64;
+            while to_consume > 0 {
+                advance(&mut li, &mut rem)?;
+                let step = to_consume.min(rem);
+                rem -= step;
+                to_consume -= step;
+            }
+        }
+
+        if byte_off != data.len() {
+            return Err(Error::Format(format!(
+                "page_map: variable records consumed {byte_off} of {} data bytes",
+                data.len(),
+            )));
+        }
+
+        Ok(expanded)
+    }
 }
 
 /// Deserialize a page map from its serialized form.
@@ -2988,6 +3084,96 @@ mod tests {
         let data = vec![1, 2, 3, 4, 5, 6, 7, 8];
         let expanded = pm.expand_data_runs_bytes(&data, 4).unwrap();
         assert_eq!(expanded, data);
+    }
+
+    #[test]
+    fn page_map_expand_records_to_rows_uniform_matches_fixed() {
+        // For uniform-length records, expand_records_to_rows must reproduce the
+        // fixed-width expand_data_runs_bytes result exactly.
+        let pm = PageMap {
+            data_recs: 2,
+            lengths: vec![1], // one u32 per row, constant
+            leng_runs: vec![5],
+            data_runs: vec![3, 2],
+        };
+        let mut data = Vec::new();
+        data.extend_from_slice(&42u32.to_le_bytes());
+        data.extend_from_slice(&99u32.to_le_bytes());
+
+        let variable = pm.expand_records_to_rows(&data, 4).unwrap();
+        let fixed = pm.expand_data_runs_bytes(&data, 4).unwrap();
+        assert_eq!(variable, fixed);
+
+        let vals: Vec<u32> = variable
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        assert_eq!(vals, vec![42, 42, 42, 99, 99]);
+    }
+
+    #[test]
+    fn page_map_expand_records_to_rows_variable_lengths() {
+        // Variable-length array column (e.g. READ_START on PacBio SMRT): records
+        // have differing element counts, given by the lengths/leng_runs runs,
+        // and each record is replicated data_runs[i] times. The fixed-width walk
+        // mis-reads record boundaries and rejects this shape — the variable walk
+        // must reconstruct it. Mirrors the real DRR032988 first-blob layout where
+        // data runs align with leng runs.
+        //
+        //   3 records: lengths 1, 3, 1 (sum = 5 u32s of source data)
+        //   record 0 (len 1) -> repeated 2 rows
+        //   record 1 (len 3) -> repeated 1 row
+        //   record 2 (len 1) -> repeated 2 rows                (total 5 rows)
+        let pm = PageMap {
+            data_recs: 3,
+            lengths: vec![1, 3, 1],
+            leng_runs: vec![2, 1, 2],
+            data_runs: vec![2, 1, 2],
+        };
+        // Source u32 stream: rec0=[10], rec1=[20,21,22], rec2=[30]  (5 u32s)
+        let src: Vec<u32> = vec![10, 20, 21, 22, 30];
+        let mut data = Vec::new();
+        for v in &src {
+            data.extend_from_slice(&v.to_le_bytes());
+        }
+
+        // The fixed-width walk can't handle this (would want >= 5 data_runs).
+        assert!(pm.expand_data_runs_bytes(&data, 4).is_err());
+
+        let expanded = pm.expand_records_to_rows(&data, 4).unwrap();
+        let vals: Vec<u32> = expanded
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        // row0=[10] row1=[10] row2=[20,21,22] row3=[30] row4=[30]
+        assert_eq!(vals, vec![10, 10, 20, 21, 22, 30, 30]);
+    }
+
+    #[test]
+    fn page_map_expand_records_to_rows_byte_column() {
+        // Same shape, 1-byte elements (e.g. READ_TYPE).
+        let pm = PageMap {
+            data_recs: 3,
+            lengths: vec![1, 3, 1],
+            leng_runs: vec![2, 1, 2],
+            data_runs: vec![2, 1, 2],
+        };
+        let data = vec![1u8, 0, 1, 0, 1]; // rec0=[1] rec1=[0,1,0] rec2=[1]
+        let expanded = pm.expand_records_to_rows(&data, 1).unwrap();
+        assert_eq!(expanded, vec![1, 1, 0, 1, 0, 1, 1]);
+    }
+
+    #[test]
+    fn page_map_expand_records_to_rows_rejects_truncated() {
+        // Source shorter than the records demand -> error, not silent garbage.
+        let pm = PageMap {
+            data_recs: 2,
+            lengths: vec![1, 3],
+            leng_runs: vec![1, 1],
+            data_runs: vec![1, 1],
+        };
+        let data = vec![0u8; 4]; // only 1 u32, needs 1 + 3 = 4 u32s
+        assert!(pm.expand_records_to_rows(&data, 4).is_err());
     }
 
     #[test]

--- a/crates/sracha-vdb/src/blob_codecs.rs
+++ b/crates/sracha-vdb/src/blob_codecs.rs
@@ -121,10 +121,12 @@ pub fn expand_via_page_map(
         }
         Ok(expanded)
     } else if !pm.data_runs.is_empty() {
-        // data_runs is per-row; each row is `entry_bytes` (row_length × elem_bytes).
-        // Passing elem_bytes here would trip the length check on any column with
-        // row_length > 1, crashing with a 2:1 (or N:1) "expected at least" ratio.
-        Ok(pm.expand_data_runs_bytes(&decoded_ints, entry_bytes)?)
+        // data_runs replicates physical records across rows. Records may be
+        // variable-length (array columns like READ_START on PacBio SMRT pack
+        // one NREADS-sized array per spot), so widths come from the page map's
+        // lengths/leng_runs rather than a single row_length. For uniform-length
+        // columns this reduces to the old fixed-width walk.
+        Ok(pm.expand_records_to_rows(&decoded_ints, elem_bytes)?)
     } else {
         Ok(decoded_ints)
     }

--- a/crates/sracha-vdb/src/cursor.rs
+++ b/crates/sracha-vdb/src/cursor.rs
@@ -84,12 +84,24 @@ impl VdbCursor {
         archive: &mut KarArchive<R>,
         sra_path: &std::path::Path,
     ) -> Result<Self> {
-        let seq_col_base = find_sequence_col_base(archive)?;
+        Self::open_table(archive, sra_path, "SEQUENCE")
+    }
+
+    /// Open a specific table (e.g. `SEQUENCE`, or `CONSENSUS` for PacBio/ONT
+    /// CCS runs). Mirrors fasterq-dump's `insp_db_type()`: PacBio/Nanopore
+    /// databases that carry a CONSENSUS table expose their CCS reads there
+    /// rather than in SEQUENCE.
+    pub fn open_table<R: Read + Seek>(
+        archive: &mut KarArchive<R>,
+        sra_path: &std::path::Path,
+        table: &str,
+    ) -> Result<Self> {
+        let seq_col_base = find_table_col_base(archive, table)?;
         reject_if_csra(archive, &seq_col_base)?;
 
         // Parse table metadata (md/cur) to extract reads_per_spot and
         // platform for SRA-lite files that lack physical READ_LEN/NREADS columns.
-        let (metadata_read_descs, platform) = Self::detect_metadata(archive);
+        let (metadata_read_descs, platform) = Self::detect_metadata(archive, table);
         let is_sra_lite = Self::detect_sra_lite(archive);
 
         // READ is required.
@@ -582,6 +594,7 @@ impl VdbCursor {
     /// whichever tree produced a schema attribute.
     fn detect_metadata<R: Read + Seek>(
         archive: &mut KarArchive<R>,
+        table: &str,
     ) -> (Option<Vec<ReadDescriptor>>, Option<String>) {
         fn try_tree<R: Read + Seek>(
             archive: &mut KarArchive<R>,
@@ -603,7 +616,8 @@ impl VdbCursor {
             Some((rps, platform))
         }
 
-        let (rps_tbl, plat_tbl) = try_tree(archive, "tbl/SEQUENCE/md/cur").unwrap_or((None, None));
+        let (rps_tbl, plat_tbl) =
+            try_tree(archive, &format!("tbl/{table}/md/cur")).unwrap_or((None, None));
         let (rps_db, plat_db) = try_tree(archive, "md/cur").unwrap_or((None, None));
 
         let rps = rps_tbl.or(rps_db);
@@ -786,19 +800,24 @@ fn parse_skey_byte_scan(skey_data: &[u8]) -> Vec<Vec<u8>> {
 ///
 /// This function detects which layout is present and returns the path to the
 /// `col/` directory containing the column subdirectories.
-fn find_sequence_col_base<R: Read + Seek>(archive: &KarArchive<R>) -> Result<String> {
+fn find_table_col_base<R: Read + Seek>(archive: &KarArchive<R>, table: &str) -> Result<String> {
     tracing::debug!(
-        "KAR archive has {} entries; looking for SEQUENCE column base",
+        "KAR archive has {} entries; looking for {table} column base",
         archive.entries().len()
     );
     for (path, entry) in archive.entries().iter() {
         tracing::trace!("  KAR entry: {path} ({entry:?})");
     }
 
-    // Strategy 1: look for database-style `tbl/SEQUENCE/col` directory.
-    // May be at root (`tbl/SEQUENCE/col`) or under a prefix (`SRR.../tbl/SEQUENCE/col`).
+    let tbl_col = format!("tbl/{table}/col");
+    let tbl_col_slash = format!("/tbl/{table}/col");
+    let tbl_col_prefix = format!("tbl/{table}/col/");
+    let tbl_col_mid = format!("/tbl/{table}/col/");
+
+    // Strategy 1: look for database-style `tbl/{table}/col` directory.
+    // May be at root (`tbl/{table}/col`) or under a prefix (`SRR.../tbl/{table}/col`).
     for path in archive.entries().keys() {
-        if (path == "tbl/SEQUENCE/col" || path.ends_with("/tbl/SEQUENCE/col"))
+        if (path == &tbl_col || path.ends_with(&tbl_col_slash))
             && matches!(
                 archive.entries().get(path.as_str()),
                 Some(crate::kar::KarEntry::Directory)
@@ -808,32 +827,45 @@ fn find_sequence_col_base<R: Read + Seek>(archive: &KarArchive<R>) -> Result<Str
         }
     }
 
-    // Strategy 2: look for `tbl/SEQUENCE/col/` prefix in any entry.
+    // Strategy 2: look for `tbl/{table}/col/` prefix in any entry.
     for path in archive.entries().keys() {
-        if path.starts_with("tbl/SEQUENCE/col/") {
-            return Ok("tbl/SEQUENCE/col".to_string());
+        if path.starts_with(&tbl_col_prefix) {
+            return Ok(tbl_col.clone());
         }
-        if let Some(idx) = path.find("/tbl/SEQUENCE/col/") {
-            let base = &path[..idx + "/tbl/SEQUENCE/col".len()];
+        if let Some(idx) = path.find(&tbl_col_mid) {
+            let base = &path[..idx + tbl_col_slash.len()];
             return Ok(base.to_string());
         }
     }
 
     // Strategy 3: flat-table layout — columns directly under `col/`.
-    // Look for `col/READ` (the required column) as a directory.
-    if archive.entries().contains_key("col/READ") {
-        return Ok("col".to_string());
-    }
-    // Or with the common col/READ/data pattern.
-    for path in archive.entries().keys() {
-        if path.starts_with("col/READ/") {
+    // Only valid for the primary SEQUENCE table (a flat archive has no
+    // `tbl/` wrapper and thus a single, unnamed table).
+    if table == "SEQUENCE" {
+        // Look for `col/READ` (the required column) as a directory.
+        if archive.entries().contains_key("col/READ") {
             return Ok("col".to_string());
+        }
+        // Or with the common col/READ/data pattern.
+        for path in archive.entries().keys() {
+            if path.starts_with("col/READ/") {
+                return Ok("col".to_string());
+            }
         }
     }
 
-    Err(Error::Format(
-        "SEQUENCE table not found in KAR archive (tried database and flat-table layouts)".into(),
-    ))
+    Err(Error::Format(format!(
+        "{table} table not found in KAR archive (tried database and flat-table layouts)"
+    )))
+}
+
+/// Whether the archive contains a `tbl/CONSENSUS/col` table.
+///
+/// PacBio/Nanopore databases expose their CCS / consensus reads in a
+/// `CONSENSUS` table; fasterq-dump reads it by default in preference to
+/// SEQUENCE (`insp_db_type()`). Used by the pipeline to pick the table.
+pub fn archive_has_consensus_table<R: Read + Seek>(archive: &KarArchive<R>) -> bool {
+    find_table_col_base(archive, "CONSENSUS").is_ok()
 }
 
 /// Reject archives that need ncbi-vdb's schema-aware virtual cursor.
@@ -1014,6 +1046,76 @@ mod tests {
         let root_dir = build_dir_node("SRR000001", &[&tbl_dir]);
 
         build_kar_archive(&[&root_dir], &data_section)
+    }
+
+    /// Like [`build_minimal_sra_archive`] but places the single READ column in
+    /// a database table named `table` (e.g. `SEQUENCE` or `CONSENSUS`).
+    fn build_minimal_db_archive(table: &str) -> Vec<u8> {
+        let col_data = b"ACGTN";
+        let idx1 = build_idx1_v1(col_data.len() as u64, 1, 0);
+        let idx0 = build_kdb_blob_loc(0, 5, 1, 1);
+
+        let mut data_section = Vec::new();
+        let idx1_off = 0u64;
+        data_section.extend_from_slice(&idx1);
+        let idx0_off = data_section.len() as u64;
+        data_section.extend_from_slice(&idx0);
+        let data_off = data_section.len() as u64;
+        data_section.extend_from_slice(col_data);
+
+        let idx1_node = build_file_node("idx1", idx1_off, idx1.len() as u64);
+        let idx0_node = build_file_node("idx0", idx0_off, idx0.len() as u64);
+        let data_node = build_file_node("data", data_off, col_data.len() as u64);
+
+        let read_dir = build_dir_node("READ", &[&data_node, &idx0_node, &idx1_node]);
+        let col_dir = build_dir_node("col", &[&read_dir]);
+        let tbl_inner = build_dir_node(table, &[&col_dir]);
+        let tbl_dir = build_dir_node("tbl", &[&tbl_inner]);
+        let root_dir = build_dir_node("DRR000000", &[&tbl_dir]);
+
+        build_kar_archive(&[&root_dir], &data_section)
+    }
+
+    #[test]
+    fn detects_consensus_table_presence() {
+        let cons = build_minimal_db_archive("CONSENSUS");
+        let archive = KarArchive::open(Cursor::new(cons)).unwrap();
+        assert!(archive_has_consensus_table(&archive));
+
+        let seq = build_minimal_db_archive("SEQUENCE");
+        let archive = KarArchive::open(Cursor::new(seq)).unwrap();
+        assert!(!archive_has_consensus_table(&archive));
+    }
+
+    #[test]
+    fn open_table_reads_named_table() {
+        let archive_bytes = build_minimal_db_archive("CONSENSUS");
+        let sra_path = write_temp_sra(&archive_bytes);
+        let mut archive = KarArchive::open(Cursor::new(archive_bytes)).unwrap();
+
+        // The default open() looks for SEQUENCE and must fail here.
+        {
+            let mut a2 =
+                KarArchive::open(Cursor::new(build_minimal_db_archive("CONSENSUS"))).unwrap();
+            assert!(VdbCursor::open(&mut a2, &sra_path).is_err());
+        }
+
+        // open_table("CONSENSUS") locates the CONSENSUS column base.
+        let cursor = VdbCursor::open_table(&mut archive, &sra_path, "CONSENSUS").unwrap();
+        assert_eq!(cursor.spot_count(), 1);
+        assert_eq!(cursor.read_col().read_blob_for_row(1).unwrap(), b"ACGTN");
+        let _ = std::fs::remove_file(&sra_path);
+    }
+
+    #[test]
+    fn flat_layout_only_resolves_sequence() {
+        // A flat (non-database) archive's columns live directly under `col/`
+        // with no `tbl/<name>` wrapper, so it represents the single SEQUENCE
+        // table — never CONSENSUS.
+        let flat = build_minimal_sra_archive(); // database SEQUENCE layout
+        let archive = KarArchive::open(Cursor::new(flat)).unwrap();
+        assert!(find_table_col_base(&archive, "CONSENSUS").is_err());
+        assert!(find_table_col_base(&archive, "SEQUENCE").is_ok());
     }
 
     /// Write archive bytes to a temporary file and return the path.

--- a/crates/sracha-vdb/src/dump.rs
+++ b/crates/sracha-vdb/src/dump.rs
@@ -348,10 +348,31 @@ fn materialize_blob(
 }
 
 fn materialize_dna2na(decoded: &DecodedBlob<'_>, row_count: u64) -> Result<(Vec<u8>, Vec<usize>)> {
-    let packed = decode_zip_encoding(decoded)?;
+    let offsets = split_offsets(decoded, row_count, 1)?;
+    let expected_bases = offsets.last().copied().unwrap_or(0);
+    let packed = decode_2na_payload(decoded, expected_bases)?;
     let actual_bases = elem_count(decoded, &packed, 2);
     let bases = unpack_2na(&packed, actual_bases);
     split_by_rows(decoded, bases, row_count, 1)
+}
+
+/// Obtain the packed 2na bytes for a READ blob.
+///
+/// READ blobs with no compression header carry raw, uncompressed 2na. The
+/// generic [`decode_zip_encoding`] probe tries deflate/zlib first and can
+/// *spuriously* succeed on raw 2na — high-entropy base-packed bytes
+/// occasionally parse as a tiny valid deflate stream (e.g. the PacBio
+/// CONSENSUS READ column, which decoded to 4 bytes instead of 435 KB). When
+/// the raw payload already matches the expected packed size for `expected_bases`
+/// (2na = 4 bases/byte), trust it and skip decompression. Compressed blobs
+/// (smaller-than-expected payload, or a real compression header) still route
+/// through `decode_zip_encoding`.
+fn decode_2na_payload(decoded: &DecodedBlob<'_>, expected_bases: usize) -> Result<Vec<u8>> {
+    let expected_packed = expected_bases.div_ceil(4);
+    if decoded.headers.is_empty() && expected_packed > 0 && decoded.data.len() == expected_packed {
+        return Ok(decoded.data.to_vec());
+    }
+    decode_zip_encoding(decoded)
 }
 
 fn materialize_dna4na_bin(
@@ -527,8 +548,9 @@ fn expand_leng_runs(pm: &PageMap) -> Vec<u32> {
     out
 }
 
-/// For fixed-size element columns (u32, u8), run `expand_data_runs_bytes` if
-/// the page_map carries data_runs — otherwise return as-is.
+/// For fixed-size element columns (u32, u8), replicate physical records to
+/// per-row data via the page map's data_runs (honouring variable per-record
+/// lengths) — otherwise return as-is.
 fn expand_runs_if_any(
     decoded: &DecodedBlob<'_>,
     data: Vec<u8>,
@@ -537,7 +559,7 @@ fn expand_runs_if_any(
     if let Some(pm) = decoded.page_map.as_ref()
         && !pm.data_runs.is_empty()
     {
-        return pm.expand_data_runs_bytes(&data, elem_bytes);
+        return pm.expand_records_to_rows(&data, elem_bytes);
     }
     Ok(data)
 }
@@ -856,6 +878,57 @@ pub fn dump_to_vec<R: Read + Seek>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decode_2na_payload_trusts_raw_when_size_matches() {
+        // Raw, uncompressed 2na: 4 bytes = 16 bases. With no compression header
+        // and a payload that already equals the expected packed size, the bytes
+        // must be returned verbatim — never run through the deflate/zlib probe,
+        // which can spuriously "succeed" on raw 2na and collapse a whole blob to
+        // a few bytes (the PacBio CONSENSUS READ bug: 435 KB → 4 bytes).
+        let data = vec![0x1b, 0xe4, 0x4b, 0x80];
+        let blob = DecodedBlob {
+            data: std::borrow::Cow::Borrowed(&data),
+            adjust: 0,
+            big_endian: false,
+            headers: vec![],
+            page_map: None,
+            row_length: None,
+        };
+        let out = decode_2na_payload(&blob, 16).unwrap();
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn materialize_dna2na_consensus_like_mostly_empty() {
+        // CONSENSUS READ shape: many zero-length rows plus one real read,
+        // stored as raw 2na sized to the per-row length sum. This previously
+        // errored ("decoded N bytes but split plan needs M") because the raw
+        // 2na was wrongly deflate-decoded down to a stub.
+        //
+        // lengths/leng_runs expand to per-row [0, 0, 8, 0, 0]; 8 bases total
+        // = 2 packed 2na bytes.
+        let pm = PageMap {
+            data_recs: 5,
+            lengths: vec![0, 8, 0],
+            leng_runs: vec![2, 1, 2],
+            data_runs: vec![],
+        };
+        let data = vec![0x1b, 0xe4];
+        let blob = DecodedBlob {
+            data: std::borrow::Cow::Borrowed(&data),
+            adjust: 0,
+            big_endian: false,
+            headers: vec![],
+            page_map: Some(pm),
+            row_length: None,
+        };
+        let (bases, offsets) = materialize_dna2na(&blob, 5).unwrap();
+        // Only the third row carries the 8 bases; the rest are empty.
+        assert_eq!(offsets, vec![0, 0, 0, 8, 8, 8]);
+        // Bases come straight from the raw 2na payload (no deflate misfire).
+        assert_eq!(bases, unpack_2na(&data, 8));
+    }
 
     #[test]
     fn infer_kind_table_matches_spec() {


### PR DESCRIPTION
## Summary

Makes sracha decode PacBio/ONT runs that previously failed or were read from the wrong table, and produce FASTQ that is **byte-identical to fasterq-dump**.

Two problems are fixed, both surfaced by the old PacBio SMRT run **DRR032988** (which the long-read benchmark had to drop as "undecodable"):

1. **Undecodable page map.** Older PacBio archives errored with `page_map: data_runs has N entries, expected at least M`. Variable-length array columns (`READ_START`, `READ_TYPE`, `LABEL_LEN/START`, `RD_FILTER`) pack one NREADS-sized array per spot, so physical records have *different* widths. The expansion assumed a single fixed row length; it now derives each record's width from `lengths`/`leng_runs`.

2. **Wrong table + 2na decode.** PacBio/ONT databases store their CCS reads in a `CONSENSUS` table. fasterq-dump (`insp_db_type()`) defaults to it; sracha read `SEQUENCE` (raw subreads) instead. Routing to `CONSENSUS` also exposed a 2na bug: raw, uncompressed READ bytes that happen to parse as a tiny deflate stream were collapsed to a stub (435 KB → 4 bytes). Raw 2na is now recognised by size.

The default defline was also corrected to match fasterq-dump's `dflt_seq_defline`: emit the name field for tables that have spot names (reconstructed name, or spot number as the synthesized fallback), and **omit it entirely** for tables without a NAME column (CONSENSUS) instead of repeating the spot id.

## Changes

- `sracha-vdb`: `PageMap::expand_records_to_rows` (variable-length record → row replication); reroute `expand_via_page_map` and the dump path to it.
- `sracha-vdb`: `decode_2na_payload` — trust raw 2na when the payload matches the expected packed size.
- `sracha-vdb`: parameterise `VdbCursor` by table (`open_table`); add `archive_has_consensus_table` / `find_table_col_base`.
- `sracha-core` pipeline: default to the `CONSENSUS` table when present.
- `sracha-core` fastq: table-level `has_name_column` gating for the default defline.

## Verification

- **DRR032988** (PacBio CONSENSUS, 5.3 GB): `sracha fastq --split split-3` is **byte-identical** (md5) to `fasterq-dump` — 4,004 CCS reads, empty consensus rows dropped, matching bases/quality/deflines. Per-column `vdb dump` matches `vdb-dump` across all 326,964 rows.
- **No regressions**: `DRR045255` and `SRR28588231` remain byte-identical to fasterq-dump.
- New unit tests: variable page-map expansion, 2na raw detection, table routing. `cargo nextest` (589 tests), `cargo fmt`, `cargo clippy -D warnings` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)