### PR TITLE
feat(long-read): reconstruct native PacBio/ONT read names from the skey index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,18 @@
   blob whose bytes happen to parse as a tiny deflate stream (PacBio CONSENSUS
   READ) is now recognised as raw when its size matches the expected packed base
   count, rather than being collapsed to a few bytes.
+- Reconstruct native long-read names for PacBio Revio and Oxford Nanopore
+  `GenericFastq` (sharq-loaded) runs, which store the read id
+  (`<movie>/<zmw>/ccs`, or an ONT UUID) entirely in the `skey` text index with
+  no physical NAME column. Two parts: (1) the PBSTree `data_idx` stride now uses
+  raw-byte width thresholds (`≤256→u8, ≤65536→u16`) instead of `trans_off`'s
+  `×4`-scaled thresholds, which silently corrupted any node-data region in the
+  `(256, 1024]`-byte window (e.g. a Revio skey transition with a 1013-byte
+  payload); (2) the dense (one-key-per-row) text-index projection
+  (`KPTrieIndex_v2` variant 0: `[count][ord2node]`) is now decoded to map each
+  spot to its trie node, so deflines carry the native name and match
+  fasterq-dump byte-for-byte (SRR38889541, SRR38892122) instead of falling back
+  to the spot number.
 
 ## 0.3.7 (2026-05-29)
 

--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -275,6 +275,11 @@ pub(crate) struct BlobDecodeCtx<'a> {
     /// (PacBio/ONT CONSENSUS, which has no NAME column) it is omitted, matching
     /// fasterq-dump's `DSD_FASTQ_NO_NAME` template.
     pub(crate) has_name_column: bool,
+    /// Native per-spot read names recovered from the skey text index, in
+    /// global row order, for PacBio/ONT `GenericFastq` runs that have no
+    /// physical NAME column and no X/Y coordinates. `None` for every other
+    /// run. Each blob slices its own spot range out of this.
+    pub(crate) skey_spot_names: Option<&'a [Vec<u8>]>,
 }
 
 /// Decode the ALTREAD blob (when present) and merge its per-base 4na
@@ -525,6 +530,7 @@ pub(crate) fn decode_blob_to_fastq(
         is_lite,
         read_cs,
         has_name_column,
+        skey_spot_names,
     } = *ctx;
     // ------------------------------------------------------------------
     // Decode READ blob -> 2na -> ASCII bases.
@@ -1087,6 +1093,30 @@ pub(crate) fn decode_blob_to_fastq(
         }
     } else {
         spot_names
+    };
+
+    // ------------------------------------------------------------------
+    // Native long-read names from the skey text index (PacBio/ONT
+    // GenericFastq runs with no physical NAME column and no X/Y). The names
+    // are global and row-ordered; slice out this blob's spot range.
+    // ------------------------------------------------------------------
+    let spot_names: Option<FlatBytes> = match (spot_names, skey_spot_names) {
+        (None, Some(global)) => {
+            let num_spots = read_lengths
+                .len()
+                .checked_div(reads_per_spot)
+                .unwrap_or(read_lengths.len());
+            let start = (spots_before as usize).min(global.len());
+            let end = (start + num_spots).min(global.len());
+            let slice = &global[start..end];
+            let total: usize = slice.iter().map(|n| n.len()).sum();
+            let mut names = FlatBytes::with_capacity(slice.len(), total);
+            for n in slice {
+                names.push(n);
+            }
+            Some(names)
+        }
+        (other, _) => other,
     };
 
     // ------------------------------------------------------------------

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -403,6 +403,24 @@ fn decode_and_write(
             (Vec::new(), Vec::new())
         };
 
+    // Native long-read names (PacBio/ONT GenericFastq runs): when there is no
+    // physical NAME column and no Illumina X/Y reconstruction, the read id
+    // (e.g. `m84161_.../208934487/ccs`, or an ONT UUID) lives in the skey text
+    // index. Recover one name per spot so default deflines carry the native id
+    // (matching fasterq-dump) instead of falling back to the spot number.
+    let skey_spot_names: Option<Vec<Vec<u8>>> =
+        if cursor.name_col().is_none() && !cursor.has_illumina_name_parts() {
+            VdbCursor::load_skey_spot_names(&mut archive)
+        } else {
+            None
+        };
+    if let Some(ref names) = skey_spot_names {
+        tracing::info!(
+            "{accession}: reconstructed {} native read names from skey index",
+            names.len()
+        );
+    }
+
     // ------------------------------------------------------------------
     // Batch-parallel blob decode and FASTQ output.
     //
@@ -688,6 +706,7 @@ fn decode_and_write(
             is_lite,
             read_cs,
             has_name_column: table != "CONSENSUS",
+            skey_spot_names: skey_spot_names.as_deref(),
         };
 
         // ---- Decode loop (main thread) ----

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -1551,6 +1551,17 @@ fn pacbio_long_read_decodes_single_end() {
 
     let data = std::fs::read(&stats.output_files[0]).unwrap();
     assert_valid_fastq(&data);
+
+    // The native PacBio CCS read name (`<movie>/<zmw>/ccs`) is stored only in
+    // the skey text index (no physical NAME column on sharq-loaded
+    // GenericFastq runs). It must be reconstructed so the defline matches
+    // fasterq-dump instead of falling back to the bare spot number.
+    let first_line = std::str::from_utf8(&data).unwrap().lines().next().unwrap();
+    assert!(
+        first_line.contains("m84161_260513_202306_s2/208934487/ccs"),
+        "PacBio defline should carry the native CCS read name from the skey \
+         index, got: {first_line}",
+    );
 }
 
 #[ignore]
@@ -1601,6 +1612,16 @@ fn nanopore_platform_detected_and_decodes_single_end() {
     assert!(
         max_seq_len > 1000,
         "Nanopore reads should be long (>1 kb), got max {max_seq_len}",
+    );
+
+    // The native ONT read UUID lives only in the skey text index; it must be
+    // reconstructed into the defline (matching fasterq-dump) rather than
+    // falling back to the spot number.
+    let first_line = std::str::from_utf8(&data).unwrap().lines().next().unwrap();
+    assert!(
+        first_line.contains("ec840866-cfb3-4b95-9efb-f59d64d96de1"),
+        "Nanopore defline should carry the native read UUID from the skey \
+         index, got: {first_line}",
     );
 }
 

--- a/crates/sracha-vdb/src/cursor.rs
+++ b/crates/sracha-vdb/src/cursor.rs
@@ -334,6 +334,79 @@ impl VdbCursor {
     // (helpers `parse_skey_offset_table` / `parse_skey_byte_scan` defined
     // at module scope below.)
 
+    /// Reconstruct the native per-spot read name from the skey text index for
+    /// runs that have **no physical NAME column** — PacBio/ONT `GenericFastq`
+    /// runs (sharq-loaded) store the read id (e.g. `m84161_.../208934487/ccs`,
+    /// or an ONT UUID) entirely in the `skey` index rather than in
+    /// `NAME`/`SPOT_NAME`.
+    ///
+    /// Returns one name per spot in row order (`names[spot_id - first]`), or
+    /// `None` when the index isn't a decodable dense text projection.
+    ///
+    /// On-disk layout (NCBI `KPTrieIndex_v2`, dense / "variant 0"):
+    ///   `[ P_Trie image ][ count: u32 ][ ord2node: u32 × count ]`
+    /// The trie maps `node_id → name` (recovered by
+    /// [`crate::ptrie::parse_ptrie_templates`]); the dense projection stores,
+    /// for each id in `[first, last]`, the trie node holding that row's name
+    /// (`ord = id - first + 1`, `node = ord2node[ord - 1]`). The id→ord step is
+    /// the identity here because every row has its own key, so no packed
+    /// `id2ord` table follows. See ncbi-vdb `libs/kdb/rtrieidx-v2.c`.
+    pub fn load_skey_spot_names<R: Read + Seek>(
+        archive: &mut KarArchive<R>,
+    ) -> Option<Vec<Vec<u8>>> {
+        let skey = archive
+            .read_file("tbl/SEQUENCE/idx/skey")
+            .or_else(|_| archive.read_file("idx/skey"))
+            .ok()?;
+        if skey.len() < 40 {
+            return None;
+        }
+        // v3/v4 header: first @16, last @24 (i64 LE).
+        let version = u32::from_le_bytes(skey[4..8].try_into().ok()?);
+        if !(version == 3 || version == 4) {
+            return None;
+        }
+        let first = i64::from_le_bytes(skey[16..24].try_into().ok()?);
+        let last = i64::from_le_bytes(skey[24..32].try_into().ok()?);
+        if last < first {
+            return None;
+        }
+        let count = (last - first + 1) as usize;
+
+        // node_id → name (the PTrie walker places each at `templates[node-1]`).
+        let templates = crate::ptrie::parse_ptrie_templates(&skey)?;
+        let proj_start = crate::ptrie::ptrie_image_end(&skey)?;
+
+        // Dense projection: a leading `count` u32 then `count` u32 ord2node
+        // entries, with no trailing packed id2ord table.
+        if proj_start + 4 + count * 4 > skey.len() {
+            return None;
+        }
+        let lead = u32::from_le_bytes(skey[proj_start..proj_start + 4].try_into().ok()?) as usize;
+        if lead != count {
+            // Not the dense one-key-per-row layout (a sparse projection with
+            // shared templates is the Illumina X/Y path in load_name_templates).
+            return None;
+        }
+        let array_start = proj_start + 4;
+
+        let mut names = Vec::with_capacity(count);
+        let mut any = false;
+        for i in 0..count {
+            let off = array_start + i * 4;
+            let node = u32::from_le_bytes(skey[off..off + 4].try_into().ok()?) as usize;
+            let name = match node.checked_sub(1).and_then(|n| templates.get(n)) {
+                Some(t) if !t.is_empty() => {
+                    any = true;
+                    t.clone()
+                }
+                _ => Vec::new(),
+            };
+            names.push(name);
+        }
+        if any { Some(names) } else { None }
+    }
+
     /// Load NAME_FMT templates from the skey index.
     ///
     /// The skey file at `tbl/SEQUENCE/idx/skey` (database layout) or

--- a/crates/sracha-vdb/src/ptrie.rs
+++ b/crates/sracha-vdb/src/ptrie.rs
@@ -43,12 +43,30 @@ impl Stride {
     }
 }
 
-/// Stride rule shared by `trans_off`, PBSTree `data_idx`, and the
-/// dad/child arrays — all keyed off the size of the addressed region.
+/// Stride rule for `trans_off`, keyed off the size of the addressed region.
+/// `trans_off` entries are stored in units of 4 bytes (the persisted offsets
+/// are `byte_offset / 4`), so a u8 entry addresses up to `256 * 4` bytes.
 fn stride_for_data_size(data_size: u64) -> Stride {
     if data_size <= 256 * 4 {
         Stride::U8
     } else if data_size <= 65536 * 4 {
+        Stride::U16
+    } else {
+        Stride::U32
+    }
+}
+
+/// Stride rule for a PBSTree's `data_idx` array. Unlike `trans_off`, these
+/// entries are RAW byte offsets into the node-data region (no `/4` scaling),
+/// so a u8 entry only addresses up to 256 bytes. Matches ncbi-vdb's
+/// `PBSTreeImplGetVTable` (`data_size <= 256 → 8-bit, <= 65536 → 16-bit,
+/// else 32-bit`). Using the `trans_off` thresholds here silently mis-strides
+/// any node-data region in `(256, 1024]` bytes (e.g. a PacBio Revio skey
+/// transition with a 1013-byte payload), corrupting every offset.
+fn stride_for_pbstree_data(data_size: u64) -> Stride {
+    if data_size <= 256 {
+        Stride::U8
+    } else if data_size <= 65536 {
         Stride::U16
     } else {
         Stride::U32
@@ -448,7 +466,7 @@ fn parse_pbstree(buf: &[u8]) -> Option<Vec<Vec<u8>>> {
     if num_nodes == 0 {
         return Some(Vec::new());
     }
-    let stride = stride_for_data_size(data_size);
+    let stride = stride_for_pbstree_data(data_size);
     let idx_start = 8;
     let idx_bytes = (num_nodes as usize) * stride.bytes();
     if idx_start + idx_bytes + data_size as usize > buf.len() {
@@ -544,6 +562,13 @@ fn dfs(
 /// Walk the P_Trie at offset 0x28 of `skey_data` and reconstruct a
 /// dense `Vec<Vec<u8>>` indexed by `node_id - 1`. Returns `None` when
 /// the layout doesn't validate (caller falls back to byte-scan).
+/// Byte offset just past the P_Trie image (where the id→node projection
+/// arrays begin). `None` when the skey wrapper / header can't be parsed.
+pub(crate) fn ptrie_image_end(skey_data: &[u8]) -> Option<usize> {
+    let header = parse_header(skey_data)?;
+    Some(header.data_base + header.data_size as usize)
+}
+
 pub(crate) fn parse_ptrie_templates(skey_data: &[u8]) -> Option<Vec<Vec<u8>>> {
     let header = parse_header(skey_data)?;
     if header.num_trans <= 1 {
@@ -633,18 +658,13 @@ pub(crate) fn parse_ptrie_templates(skey_data: &[u8]) -> Option<Vec<Vec<u8>>> {
         templates[i] = t;
     }
 
-    // Validation: at least 50% of populated entries must contain `$X`.
-    // Mirrors the offset-table parser's guard so we fall through to
-    // byte-scan rather than emit garbage on a misparse.
-    let populated: Vec<&Vec<u8>> = templates.iter().filter(|t| !t.is_empty()).collect();
-    if populated.is_empty() {
-        return None;
-    }
-    let with_placeholder = populated
-        .iter()
-        .filter(|t| t.windows(2).any(|w| w == b"$X"))
-        .count();
-    if with_placeholder * 2 < populated.len() {
+    // Reject an all-empty walk (misparse) so the caller can fall back to the
+    // byte-scan heuristic. Unlike the older guard here, we do NOT require a
+    // `$X` placeholder: Illumina name templates carry one, but PacBio/ONT
+    // GenericFastq runs store full per-read names (no placeholder) in the same
+    // PTrie, and the walker — once the PBSTree stride is correct — reconstructs
+    // both faithfully.
+    if templates.iter().all(|t| t.is_empty()) {
         return None;
     }
 
@@ -668,6 +688,24 @@ mod tests {
         assert_eq!(stride_for_num_trans(257), Stride::U16);
         assert_eq!(stride_for_num_trans(65536), Stride::U16);
         assert_eq!(stride_for_num_trans(65537), Stride::U32);
+    }
+
+    #[test]
+    fn pbstree_stride_uses_raw_byte_thresholds() {
+        // PBSTree data_idx entries are RAW byte offsets, so the u8/u16/u32
+        // boundary is 256 / 65536 — NOT the `* 4`-scaled boundary that
+        // `trans_off` (offset-in-4-byte-units) uses. The (256, 1024] window is
+        // exactly where the two disagree: a 1013-byte node-data region (real
+        // PacBio Revio skey) needs u16 offsets, and using u8 there silently
+        // corrupts every offset.
+        assert_eq!(stride_for_pbstree_data(256), Stride::U8);
+        assert_eq!(stride_for_pbstree_data(257), Stride::U16);
+        assert_eq!(stride_for_pbstree_data(1013), Stride::U16);
+        assert_eq!(stride_for_pbstree_data(1024), Stride::U16);
+        assert_eq!(stride_for_pbstree_data(65536), Stride::U16);
+        assert_eq!(stride_for_pbstree_data(65537), Stride::U32);
+        // Contrast with the trans_off rule, which stays u8 through 1024.
+        assert_eq!(stride_for_data_size(1013), Stride::U8);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PacBio Revio and Oxford Nanopore runs loaded under the `GenericFastq` schema (sharq) have **no physical NAME column** — the native read id (`<movie>/<zmw>/ccs`, or an ONT UUID) is stored entirely in the `skey` text index. sracha was emitting the spot number instead, diverging from fasterq-dump deflines. This reconstructs the names so output is **byte-identical to fasterq-dump**.

This is the follow-up to #57 (which deliberately left this name-reconstruction gap out of scope).

## Root cause & fixes

The names are in the `skey` PTrie text index, but two things blocked recovery:

1. **PBSTree stride bug.** A transition's `data_idx` array uses RAW byte offsets, so the u8/u16/u32 width boundary is `256 / 65536`. sracha reused `trans_off`'s thresholds (`256*4 / 65536*4`, correct there because those offsets are `/4`-scaled). For any node-data region in the `(256, 1024]` window — e.g. a Revio skey transition with a 1013-byte payload — this picked u8, and a u8 can't address past byte 255, corrupting every offset and aborting the whole walk. Now matches ncbi-vdb `PBSTreeImplGetVTable`.
2. **`$X` gate.** The walker rejected any result where <50% of entries had an Illumina `$X` placeholder — throwing away full per-read names. Removed (the walker is reliable once the stride is fixed).
3. **Projection not decoded.** The row→name mapping is a *dense* text-index projection (`KPTrieIndex_v2` variant 0: `[count][ord2node]`, `node = ord2node[id - first]`), which sracha didn't handle. Added `load_skey_spot_names` to decode it.
4. **Pipeline wiring.** When a run has no NAME column and no Illumina X/Y, spot names are now populated from the skey projection.

## Verification

- **SRR38889541** (PacBio Revio CCS) and **SRR38892122** (ONT): `sracha fastq` is **byte-identical** to `fasterq-dump`, including deflines with the native `<movie>/<zmw>/ccs` / UUID names.
- **No regressions**: SRR28588231 (Illumina names *reconstructed* via the same PTrie walker) and DRR045255 remain byte-identical — the stride fix doesn't disturb the existing path.
- Tests: PBSTree stride thresholds (unit); integration assertions that the long-read deflines carry the native name. `cargo nextest` (590), `fmt`, `clippy -D warnings` all clean.

Source-confirmed against ncbi-vdb `libs/kdb/rtrieidx-v2.c` and `libs/klib/pbstree-impl.c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)