### PR TITLE
docs(site): document BioContainers/Bioconda container usage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,36 @@ cargo install --git https://github.com/rnabioco/sracha-rs sracha
 pixi add --channel bioconda sracha
 ```
 
+### With containers
+
+Because sracha is on Bioconda, [BioContainers](https://biocontainers.pro/)
+automatically publishes a Docker/Singularity image for every release — no
+local build required.
+
+```bash
+# Docker / Podman
+docker run --rm quay.io/biocontainers/sracha:0.3.7--h54198d6_0 sracha --help
+
+# Singularity / Apptainer
+singularity run \
+  https://depot.galaxyproject.org/singularity/sracha:0.3.7--h54198d6_0 sracha --help
+```
+
+The tags above are examples — check
+[quay.io](https://quay.io/repository/biocontainers/sracha?tab=tags) for the
+latest `<version>--<build>` tag and substitute it in.
+
+In [Nextflow](https://www.nextflow.io/), point a process at the image directly
+or let the `conda` directive resolve it:
+
+```groovy
+process SRACHA_GET {
+    container 'quay.io/biocontainers/sracha:0.3.7--h54198d6_0'
+    // or: conda 'bioconda::sracha=0.3.7'
+    // ...
+}
+```
+
 ## Acknowledgments
 
 sracha builds on the [Sequence Read Archive](https://www.ncbi.nlm.nih.gov/sra),


### PR DESCRIPTION
Adds a **With containers** subsection to the docs site Installation section (`docs/index.md`), mirroring the README change from #60. Covers Docker/Podman, Singularity/Apptainer, and Nextflow usage.

The website change was dropped from #60's squash-merge (only `README.md` landed), so this re-applies it.