### PR TITLE
fix(sdl): chunk SDL requests and POST EFetch to avoid HTTP 414 (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixes
+
+- Large `--accession-list` runs no longer fail with `HTTP 414 URI Too Long`
+  (#64). The SDL locate request is now split into chunks of 100 accessions
+  instead of packing every accession into one URL, and EUtils RunInfo EFetch
+  uses HTTP POST (no URL-length limit) instead of GET.
+
 ## 0.3.8 (2026-06-03)
 
 ### Performance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,6 +1851,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2001,6 +2002,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,6 +2101,18 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rnabioco/sracha-rs"
 license = "MIT"
 
 [workspace.dependencies]
-reqwest = { version = "0.13", features = ["json", "rustls", "stream"] }
+reqwest = { version = "0.13", features = ["form", "json", "rustls", "stream"] }
 # Async
 tokio = { version = "1", features = ["full"] }
 

--- a/crates/sracha-core/src/sdl/mod.rs
+++ b/crates/sracha-core/src/sdl/mod.rs
@@ -15,22 +15,35 @@ const EUTILS_ESEARCH_URL: &str = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/
 /// NCBI EUtils RunInfo endpoint (returns CSV).
 const EUTILS_EFETCH_URL: &str = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
 
-/// Maximum UIDs per EFetch request to stay within URL length limits.
+/// Maximum UIDs per EFetch request. EFetch uses HTTP POST (`id` in the body),
+/// so this is a sanity cap on response size, not a URL-length limit.
 const EFETCH_BATCH_SIZE: usize = 500;
+
+/// Maximum accessions per SDL locate `resolve()` call. The SDL API is GET-only
+/// (`?acc=…` repeated per accession), so the request URL grows ~16 bytes per
+/// accession. 100 keeps each URL well under ~2 KB — far below any server's
+/// limit — which prevents HTTP 414 on large `--accession-list` runs (#64).
+const SDL_BATCH_SIZE: usize = 100;
 
 /// Maximum retry attempts for HTTP 429 / 5xx responses.
 const MAX_API_RETRIES: u32 = 3;
 
-/// HTTP GET with automatic retry on 429 (Too Many Requests) and 5xx errors.
+/// Send an HTTP request with automatic retry on 429 (Too Many Requests) and
+/// 5xx errors.
 ///
+/// Takes a closure that builds a fresh `RequestBuilder` on each attempt (a
+/// builder is consumed by `send()`, so it can't be reused across retries).
 /// Uses exponential backoff (1s, 2s, 4s) with random jitter (0-500ms) to
 /// avoid thundering-herd effects when NCBI rate-limits concurrent requests.
-async fn http_get_with_retry(
-    client: &reqwest::Client,
-    url: &str,
+///
+/// Note: 4xx client errors (including 414 URI Too Long) are *not* retried —
+/// they are deterministic and would just fail identically.
+async fn send_with_retry(
+    label: &str,
+    make_req: impl Fn() -> reqwest::RequestBuilder,
 ) -> std::result::Result<reqwest::Response, reqwest::Error> {
     for attempt in 0..=MAX_API_RETRIES {
-        let resp = client.get(url).send().await?;
+        let resp = make_req().send().await?;
         let status = resp.status();
 
         if (status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error())
@@ -43,7 +56,7 @@ async fn http_get_with_retry(
             // 3-attempt backoff isn't an error the user needs to see — the
             // exhausted-retry case will surface as a real Error to the caller.
             tracing::info!(
-                "HTTP {status} from {url}, retry {}/{MAX_API_RETRIES} in {delay:?}",
+                "HTTP {status} from {label}, retry {}/{MAX_API_RETRIES} in {delay:?}",
                 attempt + 1
             );
             tokio::time::sleep(delay).await;
@@ -53,6 +66,34 @@ async fn http_get_with_retry(
         return Ok(resp);
     }
     unreachable!()
+}
+
+/// HTTP GET with automatic retry on 429 / 5xx (see [`send_with_retry`]).
+async fn http_get_with_retry(
+    client: &reqwest::Client,
+    url: &str,
+) -> std::result::Result<reqwest::Response, reqwest::Error> {
+    send_with_retry(url, || client.get(url)).await
+}
+
+/// EUtils EFetch RunInfo via HTTP POST (`id` in the body, not the URL).
+///
+/// POST is the NCBI-recommended transport for large UID lists and has no
+/// URL-length limit, so it never hits HTTP 414 regardless of batch size (#64).
+async fn efetch_runinfo_post(
+    client: &reqwest::Client,
+    ids: &str,
+) -> std::result::Result<reqwest::Response, reqwest::Error> {
+    let form = [
+        ("db", "sra"),
+        ("id", ids),
+        ("rettype", "runinfo"),
+        ("retmode", "text"),
+    ];
+    send_with_retry("EUtils EFetch (POST)", || {
+        client.post(EUTILS_EFETCH_URL).form(&form)
+    })
+    .await
 }
 
 /// Cheap pseudo-random jitter (0-500ms) without pulling in the `rand` crate.
@@ -193,10 +234,33 @@ impl SdlClient {
 
     /// Resolve one or more accessions to download locations via the SDL API.
     ///
-    /// Uses GET with query parameters: `?acc=SRR000001&acc=SRR000002`
+    /// The SDL API is GET-only (`?acc=SRR000001&acc=SRR000002`), so the request
+    /// is split into chunks of [`SDL_BATCH_SIZE`] to keep each URL short enough
+    /// to avoid HTTP 414 on large accession lists (#64). The per-chunk results
+    /// are merged into a single [`SdlResponse`].
     /// When `format` is `Sralite`, appends `capability=zqa:z` to request
     /// SRA-lite files from the SDL API.
     pub async fn resolve(
+        &self,
+        accessions: &[String],
+        format: FormatPreference,
+    ) -> Result<SdlResponse> {
+        let mut merged: Option<SdlResponse> = None;
+
+        for chunk in accessions.chunks(SDL_BATCH_SIZE) {
+            let resp = self.resolve_chunk(chunk, format).await?;
+            match merged.as_mut() {
+                Some(acc) => acc.results.extend(resp.results),
+                None => merged = Some(resp),
+            }
+        }
+
+        // Empty input → an empty response, preserving prior behavior.
+        Ok(merged.unwrap_or_default())
+    }
+
+    /// Resolve a single chunk of accessions in one SDL GET request.
+    async fn resolve_chunk(
         &self,
         accessions: &[String],
         format: FormatPreference,
@@ -356,11 +420,10 @@ impl SdlClient {
 
         for chunk in accessions.chunks(EFETCH_BATCH_SIZE) {
             let ids = chunk.join(",");
-            let url = format!("{EUTILS_EFETCH_URL}?db=sra&id={ids}&rettype=runinfo&retmode=text");
 
             tracing::debug!("EUtils RunInfo batch request ({} accessions)", chunk.len());
 
-            let resp = match http_get_with_retry(&self.http, &url).await {
+            let resp = match efetch_runinfo_post(&self.http, &ids).await {
                 Ok(r) => r,
                 Err(e) => {
                     tracing::warn!("EUtils RunInfo batch request failed: {e}");
@@ -451,12 +514,10 @@ impl SdlClient {
 
         for chunk in uids.chunks(EFETCH_BATCH_SIZE) {
             let ids = chunk.join(",");
-            let fetch_url =
-                format!("{EUTILS_EFETCH_URL}?db=sra&id={ids}&rettype=runinfo&retmode=text");
 
             tracing::debug!("EFetch RunInfo batch request ({} UIDs)", chunk.len());
 
-            let resp = http_get_with_retry(&self.http, &fetch_url)
+            let resp = efetch_runinfo_post(&self.http, &ids)
                 .await
                 .map_err(|e| Error::Sdl {
                     message: format!("{accession}: EFetch request failed: {e}"),
@@ -970,5 +1031,67 @@ mod tests {
         assert!(ri.library_strategy.is_none());
         assert!(ri.biosample.is_none());
         assert!(ri.tax_id.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // SDL request chunking (regression guard for #64: HTTP 414 URI Too Long)
+    // -----------------------------------------------------------------------
+
+    /// Build the SDL GET URL exactly as `resolve_chunk` does, so the test
+    /// guards the real request the server sees.
+    fn sdl_chunk_url(accessions: &[String], format: FormatPreference) -> String {
+        let mut url = reqwest::Url::parse(SDL_URL).expect("invalid SDL URL");
+        for acc in accessions {
+            url.query_pairs_mut().append_pair("acc", acc);
+        }
+        if format == FormatPreference::Sralite {
+            url.query_pairs_mut().append_pair("capability", "zqa:z");
+        }
+        url.to_string()
+    }
+
+    #[test]
+    fn sdl_full_batch_url_stays_well_under_server_limits() {
+        // A full chunk of long-ish accessions must produce a URL comfortably
+        // below the ~8 KB limit servers reject with 414. We assert < 2 KB.
+        let accessions: Vec<String> = (0..SDL_BATCH_SIZE).map(|i| format!("SRR{i:09}")).collect();
+        let url = sdl_chunk_url(&accessions, FormatPreference::Sralite);
+        assert!(
+            url.len() < 2048,
+            "SDL chunk URL is {} bytes, expected < 2048",
+            url.len()
+        );
+    }
+
+    #[test]
+    fn sdl_chunking_covers_all_accessions_without_loss() {
+        // Mirrors resolve()'s chunk loop: every accession lands in exactly one
+        // chunk, no duplicates, order preserved across chunk boundaries.
+        let accessions: Vec<String> = (0..1650).map(|i| format!("SRR{i:09}")).collect();
+        let chunks: Vec<&[String]> = accessions.chunks(SDL_BATCH_SIZE).collect();
+
+        assert_eq!(chunks.len(), 1650usize.div_ceil(SDL_BATCH_SIZE));
+        let flattened: Vec<&String> = chunks.iter().flat_map(|c| c.iter()).collect();
+        assert_eq!(flattened.len(), accessions.len());
+        assert!(flattened.iter().zip(&accessions).all(|(a, b)| *a == b));
+    }
+
+    #[test]
+    fn sdl_response_merge_preserves_lookups_across_chunks() {
+        // resolve() extends results across chunks; find_result must locate an
+        // accession regardless of which chunk it came from.
+        let chunk_a: SdlResponse = serde_json::from_str(
+            r#"{"version":"2","status":200,"result":[{"query":"SRR000001"}]}"#,
+        )
+        .unwrap();
+        let chunk_b: SdlResponse =
+            serde_json::from_str(r#"{"result":[{"query":"SRR000002"}]}"#).unwrap();
+
+        let mut merged = chunk_a;
+        merged.results.extend(chunk_b.results);
+
+        assert!(merged.find_result("SRR000001").is_some());
+        assert!(merged.find_result("SRR000002").is_some());
+        assert!(merged.find_result("SRR999999").is_none());
     }
 }

--- a/crates/sracha-core/src/sdl/response.rs
+++ b/crates/sracha-core/src/sdl/response.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 /// Top-level response from the NCBI SDL API.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct SdlResponse {
     /// API version string (e.g., "2").
     pub version: Option<String>,


### PR DESCRIPTION
Fixes #64.

## Problem

Running `sracha get --accession-list` with ~1650 accessions failed with `Error: SDL API error: HTTP 414 URI Too Long`, preceded by repeated `WARN [sdl] EUtils RunInfo batch HTTP 414` lines.

A **414 (URI Too Long)** means the server refuses the request because the request *URL* exceeds its length limit. Two request sites concatenated every accession into one GET URL:

1. **Fatal** — `SdlClient::resolve()` built one `?acc=…&acc=…` locate URL for the whole list (~25 KB for 1650 accessions).
2. **Warnings** — `fetch_run_info_batch()` / `resolve_project()` sent comma-joined ids in the EFetch GET query string; even the existing 500-id chunks were too long.

Retry/timeout/throttle don't help here: a 414 is deterministic (retrying the same oversized URL just 414s again), it isn't a timeout, and throttling addresses request *rate* (429), not request *size*. The fix is to bound request size.

## Changes

- **Chunk the SDL locate `resolve()` call** into groups of `SDL_BATCH_SIZE` (100, ~1.6 KB/URL) and merge the per-chunk `SdlResponse` results.
- **Switch EUtils RunInfo EFetch to HTTP POST** (ids in the body — NCBI's recommended transport for large id lists), removing the URL-length limit entirely.
- Generalize the retry helper to `send_with_retry` so POST reuses the existing 429/5xx backoff; 4xx (incl. 414) stay non-retried.
- Add `form` to reqwest features and `Default` to `SdlResponse`.
- Regression tests: a full chunk's URL stays < 2 KB, chunking loses no accessions, merged responses stay lookup-able.

## Verification

- `cargo fmt --check`, `cargo clippy -- -D warnings`, and all 616 unit tests pass.
- Live: a 250-accession list now resolves with no 414 — chunked SDL `resolve()` works and the 250-id POST EFetch returns 200 with full RunInfo populated.

## Note (pre-existing, out of scope)

A batch consisting only of withdrawn/unknown accessions (e.g. `SRR000110`) draws an incidental `400 "ID list is empty"` from EFetch. This is **not** introduced here — the old GET code returns the identical 400 — and it's handled non-fatally (warn + continue).