### PR TITLE
fix(sdl): keep RunInfo and quiet warning when NCBI reports avgLength=0 (#67)

### DIFF
--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -560,6 +560,7 @@ fn decode_and_write(
             .run_info
             .as_ref()
             .map(|ri| ri.avg_read_len.clone())
+            .filter(|v| !v.is_empty())
             .or_else(|| cursor.metadata_read_lengths())
     } else {
         None

--- a/crates/sracha-core/src/sdl/mod.rs
+++ b/crates/sracha-core/src/sdl/mod.rs
@@ -674,19 +674,24 @@ fn parse_run_info_csv_multi(body: &str) -> HashMap<String, RunInfo> {
             }
         };
 
+        // NCBI often reports avgLength=0 (the stat was never populated, common
+        // for ENA-mirrored runs). That only affects the read-length *fallback*,
+        // which the VDB's own READ_LEN column overrides — so keep all the other
+        // metadata and leave avg_read_len empty rather than dropping the run.
         let per_read = avg_length / nreads as u32;
-        if per_read == 0 {
-            tracing::warn!("{accession}: computed per_read_len=0 from avgLength={avg_length}");
-            continue;
-        }
-
-        let mut avg_read_len = vec![per_read; nreads];
-        let used = per_read * nreads as u32;
-        if used < avg_length
-            && let Some(last) = avg_read_len.last_mut()
-        {
-            *last += avg_length - used;
-        }
+        let avg_read_len = if per_read == 0 {
+            tracing::debug!("{accession}: avgLength=0; read lengths from VDB");
+            Vec::new()
+        } else {
+            let mut v = vec![per_read; nreads];
+            let used = per_read * nreads as u32;
+            if used < avg_length
+                && let Some(last) = v.last_mut()
+            {
+                *last += avg_length - used;
+            }
+            v
+        };
 
         let platform = platform_idx
             .and_then(|i| values.get(i).copied())
@@ -1008,6 +1013,23 @@ mod tests {
             "Run,avgLength,LibraryLayout\nSRR222,150,SINGLE\n",
         ));
         assert!(missing_accessions(&requested, &resolved).is_empty());
+    }
+
+    #[test]
+    fn parse_run_info_zero_avg_length_keeps_metadata() {
+        // NCBI reports avgLength=0 for many runs; the run should still be kept
+        // with its other metadata, just with an empty avg_read_len fallback.
+        let csv = "Run,spots,avgLength,LibraryLayout,Platform\n\
+                   ERR13385430,1000,0,PAIRED,ILLUMINA\n";
+        let map = parse_run_info_csv_multi(csv);
+        let ri = map
+            .get("ERR13385430")
+            .expect("run kept despite avgLength=0");
+        assert!(ri.avg_read_len.is_empty());
+        assert_eq!(ri.spot_len, 0);
+        assert_eq!(ri.nreads, 2);
+        assert_eq!(ri.spots, Some(1000));
+        assert_eq!(ri.platform.as_deref(), Some("ILLUMINA"));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #67.

## Problem

`sracha get --accession-list` over large accession sets floods stderr with one warning per run:

```
WARN [sdl] ERR13385430: computed per_read_len=0 from avgLength=0
```

NCBI's EUtils RunInfo reports `avgLength=0` for many runs — the stat was simply never populated (common for ENA-mirrored and bacterial submissions). The old code logged a WARN per accession and then `continue`d, **dropping that run's entire `RunInfo`**.

This is benign: `avgLength` only feeds a read-length *fallback* that is used solely when the VDB's own `READ_LEN` column is absent (`pipeline/mod.rs`). The VDB blob is authoritative, so `avgLength=0` has **no effect on the output FASTQ**. The warning didn't warrant WARN level, let alone one per accession — and dropping the `RunInfo` needlessly discarded the run's other valid metadata (platform, spots, library strategy/source, BioProject, etc.).

## Fix

- `sdl/mod.rs` — when `avgLength=0`, keep the run with an empty `avg_read_len` (preserving all other metadata) instead of dropping it. Demote the per-accession message from `warn!` to `debug!` — no flood at default verbosity.
- `pipeline/mod.rs` — guard the `fallback_read_lengths` chain with `.filter(|v| !v.is_empty())` so an empty `avg_read_len` falls through to `cursor.metadata_read_lengths()` rather than shadowing it.
- Added unit test `parse_run_info_zero_avg_length_keeps_metadata`.

## Verification

- `cargo nextest run -p sracha-core -E 'test(parse_run_info)'` → 10/10 pass (incl. new test)
- `cargo clippy --all-targets --all-features -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean