### PR TITLE
fix(csra): derive MAX_SEQ_LEN from archive; ship x86-64 v2/v3 binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,29 @@ jobs:
     name: Build (${{ matrix.target }})
     strategy:
       matrix:
+        # x86_64 ships two microarchitecture variants: v2 (SSE4.2, every CPU
+        # since ~2009 — the safe default) and v3 (AVX2/BMI, Haswell 2013+ —
+        # best SIMD throughput on the byte-plane decode loops). ARM targets
+        # build a single artifact (no x86 microarch levels apply).
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            cpu: x86-64-v2
+            suffix: -v2
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            cpu: x86-64-v3
+            suffix: -v3
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macos-latest
+            cpu: x86-64-v2
+            suffix: -v2
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            cpu: x86-64-v3
+            suffix: -v3
           - target: aarch64-apple-darwin
             os: macos-latest
     runs-on: ${{ matrix.os }}
@@ -33,7 +49,7 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.target }}
+          key: ${{ matrix.target }}${{ matrix.suffix }}
 
       - name: Install musl tools (x86_64)
         if: matrix.target == 'x86_64-unknown-linux-musl'
@@ -51,6 +67,9 @@ jobs:
 
       - name: Build (native)
         if: matrix.target != 'aarch64-unknown-linux-musl'
+        env:
+          # Empty for ARM (no cpu set); raises the ISA floor for x86 variants.
+          RUSTFLAGS: ${{ matrix.cpu && format('-C target-cpu={0}', matrix.cpu) || '' }}
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package
@@ -58,14 +77,14 @@ jobs:
         run: |
           version="${GITHUB_REF_NAME#v}"
           cd target/${{ matrix.target }}/release
-          tar czf ../../../sracha-${version}-${{ matrix.target }}.tar.gz sracha
+          tar czf ../../../sracha-${version}-${{ matrix.target }}${{ matrix.suffix }}.tar.gz sracha
           cd ../../..
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: sracha-${{ github.ref_name }}-${{ matrix.target }}
-          path: sracha-*-${{ matrix.target }}.tar.gz
+          name: sracha-${{ github.ref_name }}-${{ matrix.target }}${{ matrix.suffix }}
+          path: sracha-*-${{ matrix.target }}${{ matrix.suffix }}.tar.gz
 
   release:
     name: Create Release

--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ or install from source:
 cargo install --git https://github.com/rnabioco/sracha-rs sracha
 ```
 
+On x86_64 the release page carries two variants per platform: pick **`-v2`**
+(the safe default — runs on any CPU since ~2009), or **`-v3`** for extra SIMD
+throughput on Haswell-or-newer (2013+) hardware. A `-v3` binary aborts with an
+illegal-instruction fault at startup on older CPUs, so prefer `-v2` unless you
+know the host has AVX2. ARM builds (`aarch64`) ship a single binary.
+
+To build from source tuned for the current machine, set
+`RUSTFLAGS="-C target-cpu=native"` before `cargo install`/`cargo build --release`.
+
 ### Containers
 
 Because sracha is on Bioconda, [BioContainers](https://biocontainers.pro/)

--- a/crates/sracha-vdb/src/reference.rs
+++ b/crates/sracha-vdb/src/reference.rs
@@ -20,10 +20,16 @@ use crate::kdb::ColumnReader;
 
 /// BAM-load's standard chunk size. REFERENCE rows each hold up to this many
 /// bases (last chunk of a reference may be shorter, recorded in SEQ_LEN).
-/// MAX_SEQ_LEN is declared as a static column in the align schema; we
-/// hardcode 5000 for v1 and will read it from metadata once we have a
-/// fixture that uses a different value.
+/// MAX_SEQ_LEN is declared as a static column in the align schema. We resolve
+/// the real value from the archive at open time (see [`resolve_max_seq_len`])
+/// and only fall back to this historical default when neither the column nor
+/// the SEQ_LEN-derived estimate is available — a wrong value silently corrupts
+/// cSRA reads via [`plan_span_start`].
 const DEFAULT_MAX_SEQ_LEN: u32 = 5000;
+
+/// Upper bound on REFERENCE rows sampled when deriving MAX_SEQ_LEN from
+/// SEQ_LEN, keeping `open()` cheap on references with millions of chunks.
+const MAX_SEQ_LEN_SAMPLE_ROWS: u64 = 256;
 
 /// Handle to the REFERENCE table's CMP_READ + SEQ_LEN columns.
 pub struct ReferenceCursor {
@@ -48,10 +54,36 @@ impl ReferenceCursor {
         let first_row = cmp_read.first_row_id().unwrap_or(1);
         let row_count = cmp_read.row_count();
 
+        let cmp_read = CachedColumn::new(cmp_read, ColumnKind::TwoNa);
+        let seq_len = CachedColumn::new(seq_len, ColumnKind::Irzip { elem_bits: 32 });
+
+        // Resolve the real chunk size instead of assuming 5000. Prefer the
+        // static MAX_SEQ_LEN column; if it is absent/unreadable, derive it from
+        // the widest SEQ_LEN we observe (every non-terminal chunk equals
+        // MAX_SEQ_LEN). Both can fail on degenerate archives, hence the default.
+        let col_value =
+            match ColumnReader::open(archive, &format!("{col_base}/MAX_SEQ_LEN"), sra_path) {
+                Ok(col) => {
+                    let fr = col.first_row_id().unwrap_or(1);
+                    CachedColumn::new(col, ColumnKind::Irzip { elem_bits: 32 })
+                        .read_scalar_u32(fr)
+                        .ok()
+                        .filter(|&v| v > 0)
+                }
+                Err(_) => None,
+            };
+        let derived = if col_value.is_none() {
+            derive_max_seq_len_from_seq_len(&seq_len, first_row, row_count)
+        } else {
+            None
+        };
+        let (max_seq_len, source) = resolve_max_seq_len(col_value, derived);
+        tracing::debug!("REFERENCE MAX_SEQ_LEN = {max_seq_len} (source: {source})");
+
         Ok(Self {
-            cmp_read: CachedColumn::new(cmp_read, ColumnKind::TwoNa),
-            seq_len: CachedColumn::new(seq_len, ColumnKind::Irzip { elem_bits: 32 }),
-            max_seq_len: DEFAULT_MAX_SEQ_LEN,
+            cmp_read,
+            seq_len,
+            max_seq_len,
             first_row,
             row_count,
         })
@@ -107,6 +139,43 @@ impl ReferenceCursor {
     }
 }
 
+/// Estimate MAX_SEQ_LEN from SEQ_LEN when the static column is unavailable.
+///
+/// Every non-terminal chunk of a reference is exactly MAX_SEQ_LEN bases, so the
+/// widest SEQ_LEN over a bounded prefix of the table recovers the value as long
+/// as any reference in that prefix spans more than one chunk. Returns `None`
+/// when nothing decodes (caller falls back to [`DEFAULT_MAX_SEQ_LEN`]).
+fn derive_max_seq_len_from_seq_len(
+    seq_len: &CachedColumn,
+    first_row: i64,
+    row_count: u64,
+) -> Option<u32> {
+    if row_count == 0 {
+        return None;
+    }
+    let sampled = row_count.min(MAX_SEQ_LEN_SAMPLE_ROWS);
+    let end = first_row + sampled as i64;
+    let mut max = 0u32;
+    for row in first_row..end {
+        if let Ok(v) = seq_len.read_scalar_u32(row) {
+            max = max.max(v);
+        }
+    }
+    (max > 0).then_some(max)
+}
+
+/// Pick the MAX_SEQ_LEN value and a label for diagnostics, in priority order:
+/// the static column, then the SEQ_LEN-derived estimate, then the default.
+fn resolve_max_seq_len(col_value: Option<u32>, derived: Option<u32>) -> (u32, &'static str) {
+    if let Some(v) = col_value {
+        (v, "MAX_SEQ_LEN column")
+    } else if let Some(v) = derived {
+        (v, "derived from SEQ_LEN")
+    } else {
+        (DEFAULT_MAX_SEQ_LEN, "default")
+    }
+}
+
 /// Translate a global reference position to `(chunk_row, offset_in_chunk)`.
 ///
 /// REFERENCE rows are 1-based and each holds up to `max_seq_len` bases, laid
@@ -159,5 +228,29 @@ mod tests {
         assert_eq!(plan_span_start(100, 100), (2, 0));
         assert_eq!(plan_span_start(199, 100), (2, 99));
         assert_eq!(plan_span_start(200, 100), (3, 0));
+    }
+
+    #[test]
+    fn resolve_max_seq_len_prefers_column() {
+        assert_eq!(
+            resolve_max_seq_len(Some(10_000), Some(5000)),
+            (10_000, "MAX_SEQ_LEN column")
+        );
+    }
+
+    #[test]
+    fn resolve_max_seq_len_falls_back_to_derived() {
+        assert_eq!(
+            resolve_max_seq_len(None, Some(4096)),
+            (4096, "derived from SEQ_LEN")
+        );
+    }
+
+    #[test]
+    fn resolve_max_seq_len_falls_back_to_default() {
+        assert_eq!(
+            resolve_max_seq_len(None, None),
+            (DEFAULT_MAX_SEQ_LEN, "default")
+        );
     }
 }


### PR DESCRIPTION
Two independent wins from a perf/correctness audit of the VDB decode path. The plain-SRA hot loops were already well-tuned (LUT unpacking, vectorizable quality scan, FASTA skips quality decode, fully pipelined parallel decode/compress), so this PR targets a latent correctness bug and a free config-level speedup.

## 1. Correctness — derive `MAX_SEQ_LEN` instead of hardcoding 5000

`crates/sracha-vdb/src/reference.rs` hardcoded the REFERENCE chunk size to `5000`. That value drives `plan_span_start`'s `(chunk_row, offset)` math, so a cSRA archive built with a different `MAX_SEQ_LEN` would silently return the **wrong reference bases** → corrupt FASTQ. The code itself flagged this as provisional.

`ReferenceCursor::open` now resolves the real value in priority order:
1. the static `MAX_SEQ_LEN` column, else
2. the widest `SEQ_LEN` over a bounded 256-row sample (every non-terminal chunk is exactly `MAX_SEQ_LEN`), else
3. the historical `5000` default (with a `tracing::debug!` recording which source won).

## 2. Speed — ship x86-64 v2 + v3 release binaries

Release binaries compiled to generic `x86-64` (SSE2 only), leaving the format's byte-plane decode loops un-vectorized despite being written to auto-vectorize. `.github/workflows/release.yml` now builds two x86_64 variants per platform via per-entry `RUSTFLAGS=-C target-cpu=…`:

- **`-v2`** (SSE4.2/POPCNT, every CPU since ~2009) — the safe default
- **`-v3`** (AVX2/BMI, Haswell 2013+) — best SIMD throughput

ARM stays single-artifact. The variant is encoded in tarball + artifact names and the rust-cache key so the two caches don't collide. ISA selection lives entirely in CI — no committed `.cargo/config.toml` that would taint reproducible musl builds. `README.md` documents the choice (default to `-v2`; `-v3` SIGILLs on pre-AVX2 CPUs).

## Verification

- `crates/sracha-vdb`: 8 `reference` unit tests (incl. 3 new `resolve_max_seq_len` precedence cases) pass; clippy + fmt clean.
- cSRA integration suite passes, including `csra_reference_fetch_span` (vdb-dump cross-check) and `csra_full_archive_matches_fasterq_dump` (full-output diff vs sra-tools) — confirms VDB-3418 resolves to 5000 and output is byte-identical.
- `release.yml` YAML validated → 6 matrix entries as intended.

## Deferred (follow-up)

- Batch the serial cSRA per-bit loops (`cache.rs` `read_2na_row` / `read_bool_row`).
- Narrow the irzip plane-merge buffer from `Vec<i64>` to the element width (largely subsumed by `target-cpu`).