### PR TITLE
perf(decode): pre-size per-slot FASTQ output buffers

### DIFF
--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -1153,6 +1153,24 @@ pub(crate) fn decode_blob_to_fastq(
     const SLOT_LUT_SIZE: usize = 16;
     let mut slot_lut: [Option<BlobSlotOutput>; SLOT_LUT_SIZE] = std::array::from_fn(|_| None);
     let mut slot_overflow: Vec<BlobSlotOutput> = Vec::new();
+
+    // Pre-size each slot's output buffer. Starting from `Vec::new()` made the
+    // thousands of `append_fastq_record` calls per blob re-grow the buffer by
+    // repeated doubling — `RawVec::finish_grow` was ~10% of decode self-time in
+    // a flamegraph of `run_fastq`. The decoded blob tells us the output size up
+    // front: ~1 byte/base for FASTA, ~2 (seq+qual) for FASTQ, plus a defline
+    // allowance per record. Split across the slots a given mode actually emits,
+    // so the reserve matches usage rather than ballooning RSS (decode keeps
+    // many blobs' buffers live at once — see QUEUED_BATCHES).
+    const DEFLINE_OVERHEAD: usize = 40;
+    let expected_slots = match config.split_mode {
+        SplitMode::SplitSpot | SplitMode::Interleaved => 1,
+        SplitMode::Split3 => 2,
+        SplitMode::SplitFiles => rps,
+    };
+    let bytes_per_base = if config.fasta { 1 } else { 2 };
+    let est_output = read_data.len() * bytes_per_base + read_lengths.len() * DEFLINE_OVERHEAD;
+    let per_slot_reserve = est_output / expected_slots.max(1);
     let mut seq_offset: usize = 0;
     let mut qual_offset: usize = 0;
     let mut rt_offset: usize = 0;
@@ -1329,7 +1347,7 @@ pub(crate) fn decode_blob_to_fastq(
                     let buf = if let Some(i) = lut_idx {
                         slot_lut[i].get_or_insert_with(|| BlobSlotOutput {
                             slot,
-                            bytes: Vec::new(),
+                            bytes: Vec::with_capacity(per_slot_reserve),
                             records: 0,
                         })
                     } else {
@@ -1342,7 +1360,7 @@ pub(crate) fn decode_blob_to_fastq(
                             None => {
                                 slot_overflow.push(BlobSlotOutput {
                                     slot,
-                                    bytes: Vec::new(),
+                                    bytes: Vec::with_capacity(per_slot_reserve),
                                     records: 0,
                                 });
                                 slot_overflow.last_mut().unwrap()


### PR DESCRIPTION
## What

Pre-size each blob's per-slot FASTQ/FASTA output buffer instead of starting from `Vec::new()`.

## Why

A symbolicated flamegraph of `run_fastq` (plain decode of SRR28588231, 8 threads, macOS `sample`) put **`RawVec::finish_grow` at ~10% of decode self-time** — the single largest cost after FASTQ formatting and deflate decompression. Cause: `BlobSlotOutput.bytes` started empty and re-grew by repeated doubling across thousands of `append_fastq_record` appends per blob.

For context, the same profile showed the DNA-unpack loops (`unpack_2na`/`unpack_4na` — the obvious "add SSE" candidates) at **zero** samples, and deflate already vectorized inside libdeflate's C. So allocation churn, not SIMD, was the real hot-path opportunity.

## How

The decoded blob tells us the output size up front:

```
est_output = read_data.len() * bytes_per_base   // 1 (FASTA) or 2 (FASTQ: seq+qual)
           + read_lengths.len() * DEFLINE_OVERHEAD
per_slot_reserve = est_output / expected_slots   // 1 spot/interleaved, 2 split-3, rps split-files
```

Dividing by the slots a mode actually emits keeps the reserve matched to usage rather than ballooning RSS (decode holds many blobs' buffers live at once — see `QUEUED_BATCHES`).

## Verification

- **Byte-identical output**: sha of decompressed `_1`/`_2.fastq.gz` for SRR28588231 matches before/after (pure capacity hint, no behavior change).
- **234 `sracha-core` unit tests pass**; clippy `-D warnings` + fmt clean.
- **Profile re-run**: allocation-growth stacks roughly halved (2079 → 918 `finish_grow` frames over a 20 s sample).
- **Wall-clock**: the gain is small (alloc was ~10% of self-time, now ~halved → low-single-digit % of decode) and below the noise floor of the 23 MiB fixture on a contended laptop (`[92 ms, 113 ms, 143 ms]`). Best confirmed on a large run (e.g. SRR2584863, 288 MiB) in the CI bench environment (`cargo bench -p sracha-core --bench decode`), where decode is sustained and allocation churn isn't masked by parallel scheduling.

Independent of #71 (MAX_SEQ_LEN fix + v2/v3 release binaries).