### PR TITLE
feat(csra): suggest ENA FASTQ mirror when cSRA can't be decoded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,11 +109,11 @@ jobs:
           fail_ci_if_error: false
 
   msrv:
-    name: MSRV (1.92)
+    name: MSRV (1.95)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.92.0
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
       - name: Check MSRV
         run: cargo check --all-targets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ pixi run -e dev check          # cargo check
 pixi run -e dev clippy         # cargo clippy --all-targets --all-features -- -D warnings
 ```
 
-The project uses `pixi` for environment management (Rust 1.92+, Python 3.14+, sra-tools for validation reference). All the above are also available as `pixi run build`, `pixi run test`, etc. Swap `pixi run` for `pixi run -e dev` on any linking task to pick up mold.
+The project uses `pixi` for environment management (Rust 1.95+, Python 3.14+, sra-tools for validation reference). All the above are also available as `pixi run build`, `pixi run test`, etc. Swap `pixi run` for `pixi run -e dev` on any linking task to pick up mold.
 
 ## Workspace layout
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,6 +2203,7 @@ dependencies = [
  "libc",
  "owo-colors",
  "predicates",
+ "reqwest",
  "serde_json",
  "sracha-core",
  "tabled",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,9 +249,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -261,9 +261,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1306,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -1613,7 +1613,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1708,9 +1708,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -1801,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1813,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2408,9 +2408,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -2437,9 +2437,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3072,18 +3072,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/sracha", "crates/sracha-core", "crates/sracha-vdb"]
 [workspace.package]
 version = "0.3.10"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.95"
 repository = "https://github.com/rnabioco/sracha-rs"
 license = "MIT"
 

--- a/crates/sracha-core/src/error.rs
+++ b/crates/sracha-core/src/error.rs
@@ -58,6 +58,13 @@ pub enum Error {
 
     #[error("integrity check failed for {accession}: {summary}")]
     IntegrityFailure { accession: String, summary: String },
+
+    /// A reference-compressed cSRA that sracha cannot reconstruct (external
+    /// refseq, static-metadata READ_LEN, …). Carries the accession so the CLI
+    /// can probe ENA for a FASTQ mirror and suggest `--prefer-ena`. `message`
+    /// is the diagnosis from `sracha_vdb::Error::CsraUnsupported`.
+    #[error("{accession}: {message}")]
+    CsraUnsupported { accession: String, message: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -1519,7 +1519,7 @@ mod tests {
         // Bytes in [33, 126] are NOT treated as already-encoded. This
         // regression test pins the boundary: any non-zero numeric input
         // must have +33 applied.
-        let raw = [b'?', b'I']; // 63, 73 — plausibly ASCII, must still +33
+        let raw = *b"?I"; // 63, 73 — plausibly ASCII, must still +33
         let (out, is_empty) = encode_raw_quality_for_fastq(&raw);
         assert!(!is_empty);
         assert_eq!(out, vec![63 + 33, 73 + 33]);

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -1071,8 +1071,23 @@ pub fn run_fastq(
 
     let diag = Arc::new(IntegrityDiag::default());
     let (spots_read, reads_written, output_files) =
-        decode_and_write(sra_path, &acc, config, is_lite, &diag)
-            .map_err(|e| wrap_blob_integrity(&acc, e))?;
+        match decode_and_write(sra_path, &acc, config, is_lite, &diag) {
+            Ok(v) => v,
+            // An unsupported archive shape — most commonly an aligned /
+            // reference-compressed cSRA whose PRIMARY_ALIGNMENT + REFERENCE
+            // tables aren't present locally (they live in an undownloaded
+            // .vdbcache), so `looks_like_decodable_csra` routed it here rather
+            // than to CsraCursor. sracha can't emit correct FASTQ for these.
+            // Surface it as CsraUnsupported so the CLI can offer ENA's FASTQ
+            // mirror instead of a dead-end decode error.
+            Err(Error::Vdb(sracha_vdb::Error::UnsupportedFormat { format, hint })) => {
+                return Err(Error::CsraUnsupported {
+                    accession: acc.clone(),
+                    message: format!("{format} — {hint}"),
+                });
+            }
+            Err(e) => return Err(wrap_blob_integrity(&acc, e)),
+        };
 
     // Warn (but don't fail) when a paired layout was requested on an
     // effectively single-end run: every spot produced exactly one read, so
@@ -1233,7 +1248,19 @@ fn run_fastq_csra(
                 (Some(a), Some(p)) => Some((a, p)),
                 _ => None,
             };
-        CsraCursor::open_any(&mut archive, sra_path, vdbcache_for_open)?
+        match CsraCursor::open_any(&mut archive, sra_path, vdbcache_for_open) {
+            Ok(c) => c,
+            // Known-unsupported cSRA shape (external refseq, static READ_LEN).
+            // Surface a distinct error carrying the accession so the CLI can
+            // check ENA for a FASTQ mirror rather than reporting a decode bug.
+            Err(sracha_vdb::Error::CsraUnsupported(message)) => {
+                return Err(Error::CsraUnsupported {
+                    accession: acc.to_string(),
+                    message,
+                });
+            }
+            Err(e) => return Err(e.into()),
+        }
     };
 
     let fastq_config = FastqConfig {
@@ -1935,6 +1962,18 @@ pub fn decode_sra(downloaded: &DownloadedSra, config: &PipelineConfig) -> Result
             }
             return Err(Error::Cancelled {
                 output_files: vec![],
+            });
+        }
+        // Aligned / reference-compressed cSRA sracha can't reconstruct (its
+        // PRIMARY_ALIGNMENT + REFERENCE tables live in an undownloaded
+        // .vdbcache, or the shape has no validated decoder). Surface as
+        // CsraUnsupported so the CLI can point the user at ENA's FASTQ mirror.
+        // The temp SRA is left in place (only the success path below removes
+        // it), so the suggested `--prefer-ena` re-run doesn't re-download.
+        Err(Error::Vdb(sracha_vdb::Error::UnsupportedFormat { format, hint })) => {
+            return Err(Error::CsraUnsupported {
+                accession: downloaded.accession.clone(),
+                message: format!("{format} — {hint}"),
             });
         }
         Err(e) => return Err(wrap_blob_integrity(&downloaded.accession, e)),

--- a/crates/sracha-vdb/src/csra.rs
+++ b/crates/sracha-vdb/src/csra.rs
@@ -111,11 +111,10 @@ fn open_kar(path: &Path) -> Result<KarArchive<std::io::BufReader<std::fs::File>>
 /// actionable message beats the opaque "idx1 not found" that bubbles
 /// up from `ColumnReader::open`.
 fn external_refseq_error() -> Error {
-    Error::Format(
+    Error::CsraUnsupported(
         "cSRA: REFERENCE table has no embedded CMP_READ column — reference \
-         bases are stored externally (fetched from NCBI refseq by SEQ_ID). \
-         sracha does not yet implement external refseq fetch; decode this \
-         archive with `fasterq-dump` for now."
+         bases are stored externally (fetched from NCBI refseq by SEQ_ID), \
+         which sracha does not yet reconstruct."
             .into(),
     )
 }
@@ -127,10 +126,10 @@ fn external_refseq_error() -> Error {
 /// requires physical READ_LEN; the static-metadata fallback is tracked
 /// as a follow-up.
 fn fixed_length_readlen_error() -> Error {
-    Error::Format(
+    Error::CsraUnsupported(
         "cSRA: SEQUENCE.READ_LEN is not a physical column — this archive \
          encodes a fixed spot layout in static metadata, which sracha does \
-         not yet synthesize. Decode this archive with `fasterq-dump` for now."
+         not yet synthesize."
             .into(),
     )
 }

--- a/crates/sracha-vdb/src/encoding.rs
+++ b/crates/sracha-vdb/src/encoding.rs
@@ -61,7 +61,7 @@ const DNA_4NA: [u8; 16] = [
 /// `.rodata` with zero runtime cost.
 const LUT_2NA: [[u8; 4]; 256] = {
     let mut lut = [[0u8; 4]; 256];
-    let bases = [b'A', b'C', b'G', b'T'];
+    let bases = *b"ACGT";
     let mut i = 0u16;
     while i < 256 {
         let b = i as u8;

--- a/crates/sracha-vdb/src/error.rs
+++ b/crates/sracha-vdb/src/error.rs
@@ -6,6 +6,15 @@ pub enum Error {
     #[error("VDB format error: {0}")]
     Format(String),
 
+    /// A reference-compressed cSRA whose shape sracha's `CsraCursor` cannot
+    /// reconstruct (external refseq, static-metadata READ_LEN, …). Distinct
+    /// from [`Format`] so callers can offer an ENA fallback instead of
+    /// treating it as a decoder bug. The string is a human-readable diagnosis
+    /// of *why* it can't be decoded (no trailing recommendation — the CLI owns
+    /// that).
+    #[error("{0}")]
+    CsraUnsupported(String),
+
     #[error("{kind} mismatch: stored={stored}, computed={computed}")]
     BlobIntegrity {
         kind: &'static str,

--- a/crates/sracha-vdb/src/restore.rs
+++ b/crates/sracha-vdb/src/restore.rs
@@ -129,10 +129,7 @@ pub fn reverse_complement_4na(bases: &mut [u8]) {
 pub fn fourna_to_ascii(bases: &[u8]) -> Vec<u8> {
     // Indexed by low 4 bits. 0x0 = gap (we emit 'N' rather than '-' to
     // keep FASTQ callers happy). This is the same mapping vdb-dump uses.
-    const LUT: [u8; 16] = [
-        b'N', b'A', b'C', b'M', b'G', b'R', b'S', b'V', b'T', b'W', b'Y', b'H', b'K', b'D', b'B',
-        b'N',
-    ];
+    const LUT: [u8; 16] = *b"NACMGRSVTWYHKDBN";
     bases.iter().map(|&b| LUT[(b & 0x0F) as usize]).collect()
 }
 

--- a/crates/sracha/Cargo.toml
+++ b/crates/sracha/Cargo.toml
@@ -17,6 +17,7 @@ chrono.workspace = true
 clap.workspace = true
 indicatif.workspace = true
 owo-colors.workspace = true
+reqwest.workspace = true
 serde_json.workspace = true
 sracha-core.workspace = true
 tabled.workspace = true

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -288,6 +288,8 @@ async fn main() -> Result<()> {
                 args.gzip_level,
             );
 
+            // Inputs skipped because sracha can't reconstruct their cSRA.
+            let mut fastq_skipped: Vec<String> = Vec::new();
             for input in &args.inputs {
                 let sra_path = std::path::Path::new(input);
                 if !sra_path.exists() {
@@ -335,7 +337,19 @@ async fn main() -> Result<()> {
                     metadata_service: None,
                 };
 
-                let stats = sracha_core::pipeline::run_fastq(sra_path, None, &pipeline_config)?;
+                let stats = match sracha_core::pipeline::run_fastq(sra_path, None, &pipeline_config)
+                {
+                    Ok(s) => s,
+                    // Undecodable cSRA — suggest ENA and skip this input
+                    // instead of aborting the whole invocation.
+                    Err(sracha_core::error::Error::CsraUnsupported { accession, message }) => {
+                        let client = sracha_core::http::default_client();
+                        suggest_ena_fallback(&client, &accession, &message).await;
+                        fastq_skipped.push(accession);
+                        continue;
+                    }
+                    Err(e) => return Err(e.into()),
+                };
 
                 eprintln!(
                     "{}: {} spots, {} reads written",
@@ -348,6 +362,15 @@ async fn main() -> Result<()> {
                         eprintln!("  wrote {}", style::path(path.display()));
                     }
                 }
+            }
+
+            if !fastq_skipped.is_empty() {
+                anyhow::bail!(
+                    "{} input(s) skipped — sracha can't reconstruct their cSRA: {} \
+                     (see the per-input hints above for the ENA fallback)",
+                    fastq_skipped.len(),
+                    fastq_skipped.join(", "),
+                );
             }
 
             Ok(())
@@ -522,6 +545,10 @@ async fn main() -> Result<()> {
             }
 
             let mut completed_accessions: Vec<String> = Vec::new();
+            // Accessions skipped because sracha can't reconstruct their cSRA
+            // (external refseq, static READ_LEN). Each gets an ENA suggestion
+            // inline; collected here so the batch exits non-zero at the end.
+            let mut skipped_accessions: Vec<String> = Vec::new();
             let mut interrupted_accession: Option<String> = None;
             let mut interrupt_phase: Option<InterruptPhase> = None;
 
@@ -753,6 +780,12 @@ async fn main() -> Result<()> {
                         interrupt_phase = Some(InterruptPhase::Decode);
                         break;
                     }
+                    // cSRA sracha can't reconstruct — don't abort the whole
+                    // batch. Point the user at ENA's FASTQ mirror and move on.
+                    Err(sracha_core::error::Error::CsraUnsupported { accession, message }) => {
+                        suggest_ena_fallback(&http_client, &accession, &message).await;
+                        skipped_accessions.push(accession);
+                    }
                     Err(e) => return Err(e.into()),
                 }
             }
@@ -794,6 +827,15 @@ async fn main() -> Result<()> {
                     );
                 }
                 std::process::exit(130);
+            }
+
+            if !skipped_accessions.is_empty() {
+                anyhow::bail!(
+                    "{} accession(s) skipped — sracha can't reconstruct their cSRA: {} \
+                     (see the per-accession hints above for the ENA fallback)",
+                    skipped_accessions.len(),
+                    skipped_accessions.join(", "),
+                );
             }
 
             Ok(())
@@ -1102,6 +1144,34 @@ fn collect_accessions(positional: &[String], list_file: Option<&Path>) -> Result
 /// resolved to their constituent runs via the NCBI EUtils API.
 async fn resolve_to_runs(inputs: &[String], client: &SdlClient) -> Result<(Vec<String>, bool)> {
     resolve_to_runs_inner(inputs, client, false).await
+}
+
+/// Report an undecodable cSRA and, where possible, point the user at ENA's
+/// FASTQ mirror. `message` is the decode diagnosis carried by
+/// [`sracha_core::error::Error::CsraUnsupported`]. Best-effort: any ENA lookup
+/// or network failure degrades to a generic `--prefer-ena` hint rather than an
+/// error, since the decode has already failed and this is only guidance.
+async fn suggest_ena_fallback(client: &reqwest::Client, accession: &str, message: &str) {
+    eprintln!(
+        "{} {}: {}",
+        style::warn_label("skipped:"),
+        style::header(accession),
+        message,
+    );
+    let hint = |body: String| eprintln!("  {} {}", style::label("hint:"), body);
+    match sracha_core::ena::resolve_ena(client, accession).await {
+        Ok(Some(_)) => hint(format!(
+            "ENA hosts FASTQ for this run — fetch it with: {}",
+            style::value(format!("sracha get --prefer-ena {accession}")),
+        )),
+        Ok(None) => {
+            hint("no FASTQ mirror on ENA; decode with NCBI sra-tools (fasterq-dump)".to_string())
+        }
+        Err(_) => hint(format!(
+            "could not reach ENA to check for a FASTQ mirror; try: {}",
+            style::value(format!("sracha get --prefer-ena {accession}")),
+        )),
+    }
 }
 
 /// Output filename for `fetch --prefer-ena`. ENA always serves gzip'd FASTQ,

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ Download pre-built binaries from the
 
 ### From source
 
-Requires Rust 1.92+.
+Requires Rust 1.95+.
 
 ```bash
 cargo install --git https://github.com/rnabioco/sracha-rs sracha

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,7 +6,7 @@ channels = ["conda-forge", "bioconda"]
 platforms = ["linux-64", "osx-arm64"]
 
 [dependencies]
-rust = ">=1.92"
+rust = ">=1.95"
 python = ">=3.14.4,<3.15"
 sra-tools = ">=3.4.1,<4"
 vhs = ">=0.11.0,<0.12"


### PR DESCRIPTION
## What

When sracha can't reconstruct a reference-compressed cSRA, it now checks ENA for a FASTQ mirror and points the user at `--prefer-ena` instead of aborting with an opaque error.

Before:
```
Error: unsupported format: aligned SRA (cSRA) — schema=NCBI:align:db:alignment_sorted#2. ...
```

After:
```
skipped: ERR10213669: aligned SRA (cSRA) — schema=NCBI:align:db:alignment_sorted#2. ...
  hint: ENA hosts FASTQ for this run — fetch it with: sracha get --prefer-ena ERR10213669
Error: 1 accession(s) skipped — sracha can't reconstruct their cSRA: ERR10213669 ...
```

## Why

Modern human/model-organism cSRA runs (e.g. **ERR10213669**, a GRCh38 NovaSeq WXS run) keep their `PRIMARY_ALIGNMENT` + `REFERENCE` tables in a `.sra.vdbcache` sidecar that `sracha get` doesn't download. `looks_like_decodable_csra()` returns false, the plain VdbCursor path hits `reject_if_csra`, and the batch died with `UnsupportedFormat`. For these accessions ENA almost always hosts the decoded FASTQ, so pointing users there is the pragmatic fix until native `.vdbcache` decode lands (#74).

## Behavior

- Undecodable cSRA is **soft-skipped**, not fatal: the rest of the batch still runs.
- ENA is probed per skipped accession; the hint adapts:
  - ENA has FASTQ → `sracha get --prefer-ena <acc>`
  - no ENA mirror → suggests fasterq-dump
  - ENA unreachable → best-effort `--prefer-ena` hint
- The command exits **non-zero** when anything was skipped, so scripts still see the failure.
- The temp `.sra` is preserved (the `--prefer-ena` re-run pulls from ENA and doesn't reuse it — see caveat).

## Changes

- **sracha-vdb** — `Error::CsraUnsupported` variant for the `CsraCursor` preflight cases (external refseq, static-metadata READ_LEN); messages carry the diagnosis only, the CLI owns the recommendation.
- **sracha-core** — `Error::CsraUnsupported { accession, message }`; remap the unsupported-cSRA `UnsupportedFormat` in **both** decode entry points (`run_fastq` for `sracha fastq`, `decode_sra` for `sracha get`).
- **sracha** — `suggest_ena_fallback()` helper wired into `get` and `fastq`; added the `reqwest` dep to name the client.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run` — 639 passed
- **End-to-end**: downloaded ERR10213669 (~1 GiB), confirmed the skip + hint, then confirmed the suggested `sracha get --prefer-ena ERR10213669` pulls real FASTQ from ENA.

## Follow-up

Native decode of these archives needs the `.vdbcache` download path — filed as #74.