### PR TITLE
fix(fastq): route --split-files by original read slot (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- `--split-files` now numbers output files by each read's original slot
+  instead of its position among the reads that survived filtering (#76).
+  Zero-length, technical, and too-short reads still consume their file
+  number, matching fasterq-dump. Runs whose spots store an empty leading
+  slot (`READ_LEN=[0, 150]`, e.g. SRR18959644) wrote every read to `_1`,
+  silently concatenating R2 onto R1; they now split into `_1`/`_2`.
+  Runs whose leading read is marked technical (e.g. DRR004435, a 2 bp
+  adapter ahead of a 34 bp biological read) now write that read to `_2`
+  rather than `_1`, and produce no `_1` at all.
+- `--split-3` decides pairing from the spot's biological read count rather
+  than the number of surviving segments, so `--include-technical` no longer
+  turns an unpaired spot into a `_1`/`_2` pair, and spots with more than two
+  reads are numbered `_1.._N` instead of collapsing into the unpaired file.
+- READ_TYPE is interpreted as INSDC `xread_type` bits throughout. Bit 0 is
+  the biological flag and bits 1-2 carry orientation, so reads typed
+  `BIOLOGICAL|FORWARD` or `BIOLOGICAL|REVERSE` — common in aligned cSRA — are
+  no longer dropped as technical. Previously the physical `READ_TYPE` column
+  was compared against 0 using the inverted convention that only the
+  metadata and cSRA fallbacks produced.
+- READ_TYPE blobs are expanded through their page map. VDB stores only the
+  distinct type rows plus run lengths, so indexing the raw buffer per spot
+  read the wrong row for every spot after the first — technical reads were
+  effectively filtered on one spot per blob and ignored for the rest, and a
+  spot sitting on a change in read types could lose its biological read
+  entirely. SRR18959644 dropped exactly one read this way.
+- The physical `READ_TYPE` column is located by row id rather than blob
+  index, matching what ALTREAD and NAME_FMT already do — its blobs can be
+  coarser than READ's, so index pairing read types from the wrong rows.
+
 ## 0.3.11 (2026-07-12)
 
 ### Features

--- a/crates/sracha-core/src/fastq/mod.rs
+++ b/crates/sracha-core/src/fastq/mod.rs
@@ -93,7 +93,10 @@ pub struct SpotRecord {
     pub quality: Vec<u8>,
     /// Length of each read segment within `sequence`/`quality`.
     pub read_lengths: Vec<u32>,
-    /// Read type per segment: 0 = biological, 1 = technical.
+    /// Read type per segment, as INSDC `xread_type` bits: bit 0 is the
+    /// biological flag (0 = technical, 1 = biological) and bits 1-2 carry
+    /// orientation (`FORWARD` = 2, `REVERSE` = 4). Read it through
+    /// [`read_is_biological`] rather than comparing against 0.
     pub read_types: Vec<u8>,
     /// Read filter per segment: 0 = pass, 1 = reject.
     pub read_filter: Vec<u8>,
@@ -445,6 +448,22 @@ pub fn append_fasta_record(
     out.push(b'\n');
 }
 
+/// INSDC `xread_type` bit 0: set for biological reads, clear for technical.
+const READ_TYPE_BIOLOGICAL: u8 = 1;
+
+/// Whether read `i` of a spot is biological, given the spot's READ_TYPE row.
+///
+/// Bits 1-2 of `xread_type` carry orientation (`FORWARD` = 2, `REVERSE` = 4),
+/// so a plain `!= 0` test misreads `BIOLOGICAL|FORWARD` (3) as technical. A
+/// read with no READ_TYPE entry is biological, matching fasterq-dump's
+/// `num_read_type > read_id_0` guard in `tbl_join.c`.
+pub fn read_is_biological(read_types: &[u8], i: usize) -> bool {
+    match read_types.get(i) {
+        Some(&rtype) => rtype & READ_TYPE_BIOLOGICAL != 0,
+        None => true,
+    }
+}
+
 /// A read segment extracted from a spot, after filtering.
 struct ReadSegment<'a> {
     sequence: &'a [u8],
@@ -452,6 +471,51 @@ struct ReadSegment<'a> {
     /// 1-based read index within the spot, before filtering (the `$ri`
     /// value for custom deflines).
     mate_idx: u32,
+    /// Whether this segment's READ_TYPE marks it biological. Technical
+    /// segments only survive filtering under `--include-technical`, but
+    /// split-3 still counts biological reads to decide pairing.
+    biological: bool,
+}
+
+/// Destination slot for one surviving read segment.
+///
+/// Mirrors fasterq-dump's `tbl_join.c`, where the two split modes number
+/// their output files differently:
+///
+/// - `--split-files` (`print_fastq_n_reads_split_file`) bumps `write_id_1`
+///   once per *slot*, outside the filter branch, so a read always lands in
+///   the file matching its original READ_LEN position. Zero-length,
+///   technical, and too-short reads still consume their file number — a
+///   spot of `[0, 150]` writes to `_2`, never `_1`.
+/// - `--split-3` (`print_fastq_n_reads_split_3`) bumps `write_id_1` only for
+///   reads it actually emits, so survivors compact into `_1.._N`; and when
+///   the spot holds fewer than two biological reads it forces `write_id_1`
+///   to 0, sending everything to the unpaired file.
+///
+/// `mate_idx` is the 1-based original slot, `emit_idx` the 0-based position
+/// among surviving segments, and `bio_reads` the number of biological reads
+/// that passed the zero-length and min-length filters.
+pub(crate) fn slot_for_segment(
+    split_mode: SplitMode,
+    mate_idx: u32,
+    emit_idx: usize,
+    bio_reads: usize,
+) -> OutputSlot {
+    match split_mode {
+        SplitMode::SplitFiles => OutputSlot::ReadN(mate_idx.saturating_sub(1)),
+        SplitMode::Split3 => {
+            if bio_reads < 2 {
+                OutputSlot::Unpaired
+            } else {
+                match emit_idx {
+                    0 => OutputSlot::Read1,
+                    1 => OutputSlot::Read2,
+                    n => OutputSlot::ReadN(n as u32),
+                }
+            }
+        }
+        SplitMode::Interleaved | SplitMode::SplitSpot => OutputSlot::Single,
+    }
 }
 
 /// Format a spot into FASTQ records, routing each to the appropriate output slot.
@@ -460,14 +524,12 @@ struct ReadSegment<'a> {
 /// writing each record to the file corresponding to its slot.
 ///
 /// Filtering rules applied in order:
-/// 1. Technical reads are dropped when `config.skip_technical` is `true`.
-/// 2. Reads shorter than `config.min_read_len` are dropped.
+/// 1. Zero-length reads are dropped.
+/// 2. Technical reads are dropped when `config.skip_technical` is `true`.
+/// 3. Reads shorter than `config.min_read_len` are dropped.
 ///
-/// Routing depends on `config.split_mode`:
-/// - **Split3**: 2 biological reads -> `Read1` + `Read2`; otherwise each to `Unpaired`.
-/// - **SplitFiles**: Nth surviving read -> `ReadN(N)` (0-indexed).
-/// - **SplitSpot**: all reads -> `Single`.
-/// - **Interleaved**: all reads -> `Single` (R1/R2 alternating in one file).
+/// Surviving segments are then routed by [`slot_for_segment`]; note that
+/// dropping a read never renumbers the files in `--split-files` mode.
 pub fn format_spot(
     spot: &SpotRecord,
     run_name: &str,
@@ -509,11 +571,10 @@ fn filter_spot_segments<'a>(spot: &'a SpotRecord, config: &FastqConfig) -> Vec<R
             continue;
         }
 
+        let biological = read_is_biological(&spot.read_types, i);
+
         // Filter: skip technical reads if configured.
-        if config.skip_technical
-            && let Some(&rtype) = spot.read_types.get(i)
-            && rtype != 0
-        {
+        if config.skip_technical && !biological {
             continue;
         }
 
@@ -528,17 +589,16 @@ fn filter_spot_segments<'a>(spot: &'a SpotRecord, config: &FastqConfig) -> Vec<R
             sequence: seq,
             quality: qual,
             mate_idx: (i + 1) as u32,
+            biological,
         });
     }
 
     segments
 }
 
-/// Route the filtered `segments` to output slots per [`SplitMode`].
-/// Extracted from [`format_spot`]: the routing decision tree is the only
-/// thing that varies across split modes, and pulling it out makes the
-/// Split3 / Interleaved / SplitFiles / SplitSpot behaviors trivial to
-/// eyeball side-by-side.
+/// Format the filtered `segments` and pair each with its [`slot_for_segment`]
+/// destination. Extracted from [`format_spot`] so the record-formatting
+/// concern stays separate from the slot-numbering rules.
 fn route_segments_to_slots(
     segments: &[ReadSegment<'_>],
     spot_name: &[u8],
@@ -568,27 +628,10 @@ fn route_segments_to_slots(
         }
     };
 
-    match config.split_mode {
-        SplitMode::Split3 => {
-            if segments.len() == 2 {
-                results.push((OutputSlot::Read1, format(&segments[0])));
-                results.push((OutputSlot::Read2, format(&segments[1])));
-            } else {
-                for seg in segments {
-                    results.push((OutputSlot::Unpaired, format(seg)));
-                }
-            }
-        }
-        SplitMode::Interleaved | SplitMode::SplitSpot => {
-            for seg in segments {
-                results.push((OutputSlot::Single, format(seg)));
-            }
-        }
-        SplitMode::SplitFiles => {
-            for (file_idx, seg) in segments.iter().enumerate() {
-                results.push((OutputSlot::ReadN(file_idx as u32), format(seg)));
-            }
-        }
+    let bio_reads = segments.iter().filter(|s| s.biological).count();
+    for (emit_idx, seg) in segments.iter().enumerate() {
+        let slot = slot_for_segment(config.split_mode, seg.mate_idx, emit_idx, bio_reads);
+        results.push((slot, format(seg)));
     }
 
     results
@@ -663,6 +706,11 @@ mod tests {
     // Helpers
     // -----------------------------------------------------------------------
 
+    /// INSDC `xread_type` values, spelled out so the fixtures below read as
+    /// read-type tables rather than bare 0/1 columns.
+    const BIO: u8 = 1;
+    const TECH: u8 = 0;
+
     /// Build a simple single-read spot with the given sequence.
     fn single_read_spot(name: &[u8], seq: &[u8], qual: &[u8]) -> SpotRecord {
         let len = seq.len() as u32;
@@ -671,7 +719,7 @@ mod tests {
             sequence: seq.to_vec(),
             quality: qual.to_vec(),
             read_lengths: vec![len],
-            read_types: vec![0],  // biological
+            read_types: vec![BIO],
             read_filter: vec![0], // pass
             spot_group: Vec::new(),
         }
@@ -694,7 +742,7 @@ mod tests {
             sequence: seq,
             quality: qual,
             read_lengths: vec![seq1.len() as u32, seq2.len() as u32],
-            read_types: vec![0, 0], // both biological
+            read_types: vec![BIO, BIO],
             read_filter: vec![0, 0],
             spot_group: Vec::new(),
         }
@@ -725,7 +773,7 @@ mod tests {
                 bio1_seq.len() as u32,
                 bio2_seq.len() as u32,
             ],
-            read_types: vec![1, 0, 0], // technical, biological, biological
+            read_types: vec![TECH, BIO, BIO],
             read_filter: vec![0, 0, 0],
             spot_group: Vec::new(),
         }
@@ -945,14 +993,14 @@ mod tests {
         };
         let results = format_spot(&spot, "SRR1", &config);
 
-        // All three reads should be present. With 3 reads in Split3 mode, all
-        // go to Unpaired because there are not exactly 2.
+        // Two biological reads make the spot "paired" for split-3 purposes
+        // even though the technical read is also emitted, so all three
+        // compact into _1/_2/_3 — fasterq-dump counts only biological reads
+        // when deciding, but numbers every read it writes.
         assert_eq!(results.len(), 3);
-        assert!(
-            results
-                .iter()
-                .all(|(slot, _)| *slot == OutputSlot::Unpaired)
-        );
+        assert_eq!(results[0].0, OutputSlot::Read1);
+        assert_eq!(results[1].0, OutputSlot::Read2);
+        assert_eq!(results[2].0, OutputSlot::ReadN(2));
     }
 
     #[test]
@@ -1043,7 +1091,7 @@ mod tests {
             sequence: b"ACGT".to_vec(),
             quality: b"????".to_vec(),
             read_lengths: vec![4, 0],
-            read_types: vec![0, 0],
+            read_types: vec![BIO, BIO],
             read_filter: vec![0, 0],
             spot_group: Vec::new(),
         };
@@ -1064,7 +1112,7 @@ mod tests {
             sequence: b"ACGT".to_vec(),
             quality: b"????".to_vec(),
             read_lengths: vec![0, 4],
-            read_types: vec![0, 0],
+            read_types: vec![BIO, BIO],
             read_filter: vec![0, 0],
             spot_group: Vec::new(),
         };
@@ -1085,7 +1133,7 @@ mod tests {
             sequence: b"ACGTACGT".to_vec(),
             quality: b"????????".to_vec(),
             read_lengths: vec![8, 0],
-            read_types: vec![0, 0],
+            read_types: vec![BIO, BIO],
             read_filter: vec![0, 0],
             spot_group: Vec::new(),
         };
@@ -1141,7 +1189,7 @@ mod tests {
     }
 
     #[test]
-    fn three_biological_reads_in_split3_are_unpaired() {
+    fn three_biological_reads_in_split3_compact_into_numbered_files() {
         let mut seq = b"AAAA".to_vec();
         seq.extend_from_slice(b"CCCC");
         seq.extend_from_slice(b"GGGG");
@@ -1154,7 +1202,7 @@ mod tests {
             sequence: seq,
             quality: qual,
             read_lengths: vec![4, 4, 4],
-            read_types: vec![0, 0, 0],
+            read_types: vec![BIO, BIO, BIO],
             read_filter: vec![0, 0, 0],
             spot_group: Vec::new(),
         };
@@ -1165,12 +1213,12 @@ mod tests {
         };
         let results = format_spot(&spot, "SRR1", &config);
 
+        // >= 2 biological reads means "paired", and the surviving reads are
+        // numbered 1..N rather than collapsed into the unpaired file.
         assert_eq!(results.len(), 3);
-        assert!(
-            results
-                .iter()
-                .all(|(slot, _)| *slot == OutputSlot::Unpaired)
-        );
+        assert_eq!(results[0].0, OutputSlot::Read1);
+        assert_eq!(results[1].0, OutputSlot::Read2);
+        assert_eq!(results[2].0, OutputSlot::ReadN(2));
     }
 
     #[test]
@@ -1187,7 +1235,7 @@ mod tests {
             sequence: seq,
             quality: qual,
             read_lengths: vec![4, 4, 4],
-            read_types: vec![0, 0, 0],
+            read_types: vec![BIO, BIO, BIO],
             read_filter: vec![0, 0, 0],
             spot_group: Vec::new(),
         };
@@ -1202,6 +1250,222 @@ mod tests {
         assert_eq!(results[0].0, OutputSlot::ReadN(0));
         assert_eq!(results[1].0, OutputSlot::ReadN(1));
         assert_eq!(results[2].0, OutputSlot::ReadN(2));
+    }
+
+    // -----------------------------------------------------------------------
+    // Slot preservation in split-files (issue #76)
+    //
+    // fasterq-dump's `print_fastq_n_reads_split_file` (tbl_join.c) advances
+    // its destination counter once per READ_LEN slot, outside the filter
+    // branch, so a dropped read still consumes its file number. Deriving the
+    // number from the surviving-read order instead silently rewrites mates
+    // into the wrong file.
+    // -----------------------------------------------------------------------
+
+    /// Build a spot from `(read_len, read_type)` pairs, filling each read with
+    /// a distinct base so records can be told apart.
+    fn spot_from_slots(slots: &[(u32, u8)]) -> SpotRecord {
+        const BASES: &[u8] = b"ACGTN";
+        let mut sequence = Vec::new();
+        let mut quality = Vec::new();
+        for (i, &(len, _)) in slots.iter().enumerate() {
+            sequence.extend(std::iter::repeat_n(BASES[i % BASES.len()], len as usize));
+            quality.extend(std::iter::repeat_n(b'?', len as usize));
+        }
+        SpotRecord {
+            name: b"1".to_vec(),
+            sequence,
+            quality,
+            read_lengths: slots.iter().map(|&(len, _)| len).collect(),
+            read_types: slots.iter().map(|&(_, ty)| ty).collect(),
+            read_filter: vec![0; slots.len()],
+            spot_group: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn zero_length_leading_slot_still_routes_read_2_to_read_n1() {
+        // The issue #76 shape: SRR18959644's second half stores every spot as
+        // READ_LEN=[0, 150], so the surviving read belongs in `_2.fastq`.
+        let spot = spot_from_slots(&[(0, TECH), (150, BIO)]);
+        let config = FastqConfig {
+            split_mode: SplitMode::SplitFiles,
+            ..default_config()
+        };
+        let results = format_spot(&spot, "SRR1", &config);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, OutputSlot::ReadN(1));
+    }
+
+    #[test]
+    fn technical_leading_slot_still_routes_read_2_to_read_n1() {
+        // 10x-style layout: a technical barcode read in slot 1 is dropped by
+        // default, but the biological read stays in `_2.fastq`.
+        let spot = spot_from_slots(&[(26, TECH), (98, BIO)]);
+        let config = FastqConfig {
+            split_mode: SplitMode::SplitFiles,
+            ..default_config()
+        };
+        let results = format_spot(&spot, "SRR1", &config);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, OutputSlot::ReadN(1));
+    }
+
+    #[test]
+    fn split_files_preserves_slots_across_alternating_technical_reads() {
+        // SRR000001 spot 2: READ_LEN=[4, 115, 44, 99] with READ_TYPE
+        // [T, B, T, B]. Verified against fasterq-dump 3.2.1, which writes
+        // only SRR000001_2.fastq and SRR000001_4.fastq for this run.
+        let spot = spot_from_slots(&[(4, TECH), (115, BIO), (44, TECH), (99, BIO)]);
+        let config = FastqConfig {
+            split_mode: SplitMode::SplitFiles,
+            ..default_config()
+        };
+        let results = format_spot(&spot, "SRR1", &config);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, OutputSlot::ReadN(1));
+        assert_eq!(results[1].0, OutputSlot::ReadN(3));
+    }
+
+    #[test]
+    fn split_files_slot_survives_min_read_len_drop() {
+        // A read removed by --min-read-len consumes its slot too, so the
+        // survivor keeps its own number rather than sliding down to `_1`.
+        let spot = spot_from_slots(&[(5, BIO), (100, BIO)]);
+        let config = FastqConfig {
+            split_mode: SplitMode::SplitFiles,
+            min_read_len: Some(10),
+            ..default_config()
+        };
+        let results = format_spot(&spot, "SRR1", &config);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, OutputSlot::ReadN(1));
+    }
+
+    #[test]
+    fn split_files_filenames_follow_slot_numbers() {
+        let compression = CompressionMode::None;
+        assert_eq!(
+            output_filename(
+                "SRR18959644",
+                OutputSlot::ReadN(1),
+                false,
+                &compression,
+                PairedSuffix::Numeric,
+            ),
+            "SRR18959644_2.fastq"
+        );
+        assert_eq!(
+            output_filename(
+                "SRR000001",
+                OutputSlot::ReadN(3),
+                false,
+                &compression,
+                PairedSuffix::Numeric,
+            ),
+            "SRR000001_4.fastq"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // split-3 pairing rule
+    //
+    // `print_fastq_n_reads_split_3` counts biological reads across the whole
+    // spot, forces the unpaired file when there are fewer than two, and
+    // otherwise numbers the reads it writes 1..N.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn split3_sends_lone_read_to_unpaired_regardless_of_slot() {
+        for slots in [
+            [(0, TECH), (150, BIO)].as_slice(),
+            [(150, BIO), (0, TECH)].as_slice(),
+        ] {
+            let spot = spot_from_slots(slots);
+            let config = FastqConfig {
+                split_mode: SplitMode::Split3,
+                ..default_config()
+            };
+            let results = format_spot(&spot, "SRR1", &config);
+
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].0, OutputSlot::Unpaired, "slots={slots:?}");
+        }
+    }
+
+    #[test]
+    fn split3_compacts_surviving_reads_past_technical_slots() {
+        // SRR000001 spot 2 again: slots 2 and 4 are the biological reads, and
+        // split-3 renumbers them into `_1`/`_2` (unlike split-files). Matches
+        // fasterq-dump, which reports 236,041 pairs for that run.
+        let spot = spot_from_slots(&[(4, TECH), (115, BIO), (44, TECH), (99, BIO)]);
+        let config = FastqConfig {
+            split_mode: SplitMode::Split3,
+            ..default_config()
+        };
+        let results = format_spot(&spot, "SRR1", &config);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, OutputSlot::Read1);
+        assert_eq!(results[1].0, OutputSlot::Read2);
+    }
+
+    #[test]
+    fn split3_counts_only_biological_reads_when_technical_included() {
+        // One biological read plus an included technical read is still
+        // "unpaired" for split-3 — fasterq-dump's valid_bio_reads ignores
+        // skip_tech, so both records land in the unpaired file.
+        let spot = spot_from_slots(&[(26, TECH), (98, BIO)]);
+        let config = FastqConfig {
+            split_mode: SplitMode::Split3,
+            skip_technical: false,
+            ..default_config()
+        };
+        let results = format_spot(&spot, "SRR1", &config);
+
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|(s, _)| *s == OutputSlot::Unpaired));
+    }
+
+    // -----------------------------------------------------------------------
+    // READ_TYPE interpretation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn read_type_orientation_bits_do_not_make_a_read_technical() {
+        // xread_type packs orientation into bits 1-2, so BIOLOGICAL|FORWARD
+        // (3) and BIOLOGICAL|REVERSE (5) are still biological reads. Aligned
+        // cSRA rows routinely carry these.
+        let bio_forward = BIO | 2;
+        let bio_reverse = BIO | 4;
+        let tech_forward = TECH | 2;
+
+        assert!(read_is_biological(&[bio_forward], 0));
+        assert!(read_is_biological(&[bio_reverse], 0));
+        assert!(!read_is_biological(&[tech_forward], 0));
+
+        // A read with no READ_TYPE entry is biological, matching
+        // fasterq-dump's `num_read_type > read_id_0` guard.
+        assert!(read_is_biological(&[], 0));
+        assert!(read_is_biological(&[BIO], 5));
+    }
+
+    #[test]
+    fn oriented_biological_read_is_not_filtered_as_technical() {
+        let spot = spot_from_slots(&[(50, BIO | 4), (50, BIO | 2)]);
+        let config = FastqConfig {
+            split_mode: SplitMode::SplitFiles,
+            ..default_config()
+        };
+        let results = format_spot(&spot, "SRR1", &config);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, OutputSlot::ReadN(0));
+        assert_eq!(results[1].0, OutputSlot::ReadN(1));
     }
 
     #[test]

--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -118,6 +118,72 @@ pub(crate) use crate::vdb::blob_codecs::{
     decode_irzip_column, decode_quality_encoding, decode_raw, decode_zip_encoding,
 };
 
+/// Materialize the READ_TYPE rows covering one READ blob, one row per spot.
+///
+/// VDB stores only the distinct READ_TYPE rows; the page map's `data_runs[i]`
+/// says how many consecutive spots share record `i`. A run whose read types
+/// never change collapses to a single record — SRR18959644's first record
+/// covers 22,227,968 spots — and a blob straddling a change in read types
+/// holds two. Indexing the unexpanded buffer per spot therefore reads the
+/// wrong record for every spot past the first, which silently dropped the one
+/// spot whose biological read picked up its neighbour's technical flag.
+///
+/// Expanding the whole blob would cost tens of MiB per READ blob against
+/// those long runs, so only the `[skip_rows, skip_rows + take_rows)` window
+/// this blob needs is built. The result is indexed from row 0.
+///
+/// Blobs with no page map (or no `data_runs`) already carry one row per spot
+/// and are sliced directly.
+fn read_type_rows_for_blob(
+    data: &[u8],
+    page_map: Option<&crate::vdb::blob::PageMap>,
+    reads_per_spot: usize,
+    skip_rows: usize,
+    take_rows: usize,
+) -> Vec<u8> {
+    if data.is_empty() || reads_per_spot == 0 || take_rows == 0 {
+        return Vec::new();
+    }
+    // `lengths` counts elements per row; READ_TYPE elements are single bytes.
+    let row_len = page_map
+        .and_then(|pm| pm.lengths.first().copied())
+        .filter(|&l| l > 0)
+        .map_or(reads_per_spot, |l| l as usize);
+    if data.len() < row_len {
+        return Vec::new();
+    }
+
+    let runs = page_map.map(|pm| pm.data_runs.as_slice()).unwrap_or(&[]);
+    if runs.is_empty() {
+        // One row per spot already. A blob holding a single row against many
+        // spots is a constant column stored without runs; repeat it.
+        if data.len() == row_len {
+            return data.repeat(take_rows);
+        }
+        let start = (skip_rows * row_len).min(data.len());
+        let end = (start + take_rows * row_len).min(data.len());
+        return data[start..end].to_vec();
+    }
+
+    let mut out = Vec::with_capacity(take_rows * row_len);
+    let mut row = 0usize; // first logical row of the current record
+    for (i, record) in data.chunks_exact(row_len).enumerate() {
+        let repeat = runs.get(i).copied().unwrap_or(1) as usize;
+        let end = row + repeat;
+        // Overlap of this record's row span with the requested window.
+        let from = row.max(skip_rows);
+        let to = end.min(skip_rows + take_rows);
+        for _ in from..to {
+            out.extend_from_slice(record);
+        }
+        row = end;
+        if row >= skip_rows + take_rows {
+            break;
+        }
+    }
+    out
+}
+
 // ---------------------------------------------------------------------------
 // Phase 2: Parse VDB + output FASTQ
 // ---------------------------------------------------------------------------
@@ -191,6 +257,11 @@ pub(crate) struct RawBlobData<'a> {
     pub(crate) read_type_raw: &'a [u8],
     /// Row count for the READ_TYPE blob (0 if absent).
     pub(crate) read_type_id_range: u64,
+    /// First row id covered by the READ_TYPE blob. Like READ_LEN, the
+    /// column's blob boundaries need not line up with READ's, so the blob is
+    /// located by row id and this offset skips to the rows that pair with
+    /// this READ blob.
+    pub(crate) read_type_start_id: i64,
     /// Checksum type for the READ_TYPE column.
     pub(crate) read_type_cs: u8,
     /// Whether there is a READ_LEN column at all.
@@ -1120,20 +1191,42 @@ pub(crate) fn decode_blob_to_fastq(
     };
 
     // ------------------------------------------------------------------
-    // Decode READ_TYPE blob -> byte array of per-read type codes.
-    // 0 = biological, 1 = technical (SRA_READ_TYPE values).
+    // Decode READ_TYPE blob -> byte array of per-read INSDC xread_type
+    // codes (bit 0 = biological flag, bits 1-2 = orientation). Interpret
+    // via `read_is_biological`, never by comparing against 0.
+    //
+    // The blob stores only the *distinct* type rows plus a page map saying
+    // how many consecutive spots share each; expand it so the buffer holds
+    // one row per spot and can be indexed positionally below.
     // ------------------------------------------------------------------
     let read_type_data: Vec<u8> = if raw.has_read_type && !raw.read_type_raw.is_empty() {
         let rtdecoded = decode_raw(raw.read_type_raw, raw.read_type_cs, raw.read_type_id_range)?;
         let raw_bytes = decode_zip_encoding(&rtdecoded)?;
-        if !raw_bytes.is_empty() {
+        let page_map = rtdecoded.page_map;
+        let bytes = if !raw_bytes.is_empty() {
             raw_bytes
         } else {
             rtdecoded.data.into_owned()
-        }
+        };
+        read_type_rows_for_blob(
+            &bytes,
+            page_map.as_ref(),
+            reads_per_spot.max(1),
+            (raw.read_start_id - raw.read_type_start_id).max(0) as usize,
+            raw.read_id_range as usize,
+        )
     } else {
         Vec::new()
     };
+
+    if blob_idx == 0 {
+        tracing::debug!(
+            "READ_TYPE: {} values, has_read_type={}, first_10={:?}",
+            read_type_data.len(),
+            raw.has_read_type,
+            &read_type_data[..read_type_data.len().min(10)],
+        );
+    }
 
     // ------------------------------------------------------------------
     // Iterate spots and produce FASTQ records directly (fused path).
@@ -1173,6 +1266,8 @@ pub(crate) fn decode_blob_to_fastq(
     let per_slot_reserve = est_output / expected_slots.max(1);
     let mut seq_offset: usize = 0;
     let mut qual_offset: usize = 0;
+    // `read_type_rows_for_blob` already trimmed to this blob's rows, so this
+    // walks it from the start, one row per spot.
     let mut rt_offset: usize = 0;
     let mut spot_idx_in_blob: usize = 0;
     let mut rl_cursor = 0usize;
@@ -1191,6 +1286,7 @@ pub(crate) fn decode_blob_to_fastq(
         start: usize,
         len: usize,
         mate_idx: u32,
+        biological: bool,
     }
     let mut segments: Vec<ReadSeg> = Vec::with_capacity(rps);
 
@@ -1272,18 +1368,17 @@ pub(crate) fn decode_blob_to_fastq(
         };
 
         // Read types for this spot: borrow from decoded data or default to biological.
-        let spot_read_types: &[u8] =
-            if !read_type_data.is_empty() && rt_offset + rps <= read_type_data.len() {
-                let rt = &read_type_data[rt_offset..rt_offset + rps];
-                rt_offset += rps;
-                rt
-            } else if let Some(meta_rt) = raw.fallback_read_types.filter(|rt| rt.len() == rps) {
-                rt_offset += rps;
-                meta_rt
-            } else {
-                rt_offset += rps;
-                &[] // empty = all biological (checked below)
-            };
+        let spot_read_types: &[u8] = if rt_offset + rps <= read_type_data.len() {
+            let rt = &read_type_data[rt_offset..rt_offset + rps];
+            rt_offset += rps;
+            rt
+        } else if let Some(meta_rt) = raw.fallback_read_types.filter(|rt| rt.len() == rps) {
+            rt_offset += rps;
+            meta_rt
+        } else {
+            rt_offset += rps;
+            &[] // empty = all biological (checked below)
+        };
 
         // ------------------------------------------------------------------
         // Inline format_spot logic: split reads, filter, route, format.
@@ -1301,18 +1396,18 @@ pub(crate) fn decode_blob_to_fastq(
             // so mirroring keeps split-3 routing consistent (e.g., SINGLE
             // runs with a 0-length placeholder segment would otherwise
             // route into `_1.fastq`/`_2.fastq` instead of `.fastq`).
+            // The slot is still consumed: `mate_idx` below preserves it.
             if rlen_usize == 0 {
                 read_offset = end;
                 continue;
             }
 
+            let biological = crate::fastq::read_is_biological(spot_read_types, i);
+
             // Filter: skip technical reads if configured.
-            if config.skip_technical {
-                let rtype = spot_read_types.get(i).copied().unwrap_or(0);
-                if rtype != 0 {
-                    read_offset = end;
-                    continue;
-                }
+            if config.skip_technical && !biological {
+                read_offset = end;
+                continue;
             }
 
             // Filter: skip reads shorter than the minimum length.
@@ -1327,6 +1422,7 @@ pub(crate) fn decode_blob_to_fastq(
                 start: read_offset,
                 len: rlen_usize,
                 mate_idx: (i + 1) as u32,
+                biological,
             });
             read_offset = end;
         }
@@ -1405,14 +1501,16 @@ pub(crate) fn decode_blob_to_fastq(
                 };
 
             match config.split_mode {
-                SplitMode::Split3 => {
-                    if segments.len() == 2 {
-                        emit(OutputSlot::Read1, &segments[0], spot_number, description);
-                        emit(OutputSlot::Read2, &segments[1], spot_number, description);
-                    } else {
-                        for seg in &segments {
-                            emit(OutputSlot::Unpaired, seg, spot_number, description);
-                        }
+                SplitMode::Split3 | SplitMode::SplitFiles => {
+                    let bio_reads = segments.iter().filter(|s| s.biological).count();
+                    for (emit_idx, seg) in segments.iter().enumerate() {
+                        let slot = crate::fastq::slot_for_segment(
+                            config.split_mode,
+                            seg.mate_idx,
+                            emit_idx,
+                            bio_reads,
+                        );
+                        emit(slot, seg, spot_number, description);
                     }
                 }
                 SplitMode::Interleaved | SplitMode::SplitSpot => {
@@ -1438,16 +1536,6 @@ pub(crate) fn decode_blob_to_fastq(
                         emit(OutputSlot::Single, seg, &name_buf, desc);
                     }
                 }
-                SplitMode::SplitFiles => {
-                    for (file_idx, seg) in segments.iter().enumerate() {
-                        emit(
-                            OutputSlot::ReadN(file_idx as u32),
-                            seg,
-                            spot_number,
-                            description,
-                        );
-                    }
-                }
             }
         }
 
@@ -1468,6 +1556,93 @@ pub(crate) fn decode_blob_to_fastq(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vdb::blob::PageMap;
+
+    // -----------------------------------------------------------------------
+    // expand_read_type_rows — run-length-encoded READ_TYPE blobs
+    //
+    // READ_TYPE blobs store only the distinct type rows. Indexing the
+    // unexpanded buffer per spot reads the wrong row for every spot after
+    // the first, which cost SRR18959644 exactly one read: the spot whose
+    // `[biological, technical]` row was read as its neighbour's
+    // `[technical, biological]`, leaving nothing to emit.
+    // -----------------------------------------------------------------------
+
+    fn page_map(lengths: Vec<u32>, leng_runs: Vec<u32>, data_runs: Vec<u32>) -> PageMap {
+        PageMap {
+            data_recs: data_runs.len() as u64,
+            lengths,
+            leng_runs,
+            data_runs,
+        }
+    }
+
+    #[test]
+    fn read_type_constant_row_expands_to_every_spot() {
+        // One record covering 4 spots of 2 reads each.
+        let pm = page_map(vec![2], vec![4], vec![4]);
+        let out = read_type_rows_for_blob(&[1, 0], Some(&pm), 2, 0, 4);
+        assert_eq!(out, vec![1, 0, 1, 0, 1, 0, 1, 0]);
+    }
+
+    #[test]
+    fn read_type_blob_spanning_a_change_expands_both_rows() {
+        // The SRR18959644 shape: [biological, technical] for the first two
+        // spots, then [technical, biological] for the next three.
+        let pm = page_map(vec![2], vec![5], vec![2, 3]);
+        let out = read_type_rows_for_blob(&[1, 0, 0, 1], Some(&pm), 2, 0, 5);
+        assert_eq!(out, vec![1, 0, 1, 0, 0, 1, 0, 1, 0, 1]);
+
+        // Spot 1 must keep its own row rather than borrowing spot 2's — that
+        // borrow is what cost SRR18959644 a read.
+        assert!(crate::fastq::read_is_biological(&out[2..4], 0));
+        assert!(!crate::fastq::read_is_biological(&out[4..6], 0));
+    }
+
+    #[test]
+    fn read_type_window_starts_at_the_requested_row() {
+        // A READ blob starting mid-record only materializes its own rows,
+        // so a long constant run costs nothing to skip past.
+        let pm = page_map(vec![2], vec![5], vec![2, 3]);
+        let out = read_type_rows_for_blob(&[1, 0, 0, 1], Some(&pm), 2, 1, 3);
+        assert_eq!(out, vec![1, 0, 0, 1, 0, 1]);
+
+        let tail = read_type_rows_for_blob(&[1, 0, 0, 1], Some(&pm), 2, 4, 4);
+        assert_eq!(tail, vec![0, 1], "window clamps at the last row");
+    }
+
+    #[test]
+    fn read_type_without_page_map_is_sliced_not_expanded() {
+        let data = [1, 0, 0, 1];
+        assert_eq!(read_type_rows_for_blob(&data, None, 2, 0, 2), data.to_vec());
+        assert_eq!(read_type_rows_for_blob(&data, None, 2, 1, 1), vec![0, 1]);
+
+        // A page map with no data_runs already holds one row per spot.
+        let pm = page_map(vec![2], vec![2], vec![]);
+        assert_eq!(
+            read_type_rows_for_blob(&data, Some(&pm), 2, 0, 2),
+            data.to_vec()
+        );
+    }
+
+    #[test]
+    fn read_type_single_row_without_runs_is_treated_as_constant() {
+        // No page map to describe the repeat, but one row against many spots
+        // can only mean a column that never varies.
+        assert_eq!(
+            read_type_rows_for_blob(&[1, 0], None, 2, 0, 3),
+            vec![1, 0, 1, 0, 1, 0]
+        );
+    }
+
+    #[test]
+    fn read_type_falls_back_when_row_length_exceeds_data() {
+        // Truncated payload: yield nothing rather than panicking on
+        // chunks_exact or fabricating rows. An empty result reads as "no
+        // READ_TYPE", which treats every read as biological.
+        let pm = page_map(vec![4], vec![2], vec![2]);
+        assert!(read_type_rows_for_blob(&[1, 0], Some(&pm), 4, 0, 2).is_empty());
+    }
 
     // -----------------------------------------------------------------------
     // encode_raw_quality_for_fastq — PHRED+33 invariant

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -794,17 +794,25 @@ fn decode_and_write(
                             (&[], 0)
                         };
 
-                        let (rt_raw, rt_id_range): (&[u8], u64) =
-                            if has_read_type && bi < read_type_blob_count {
-                                let rtcol = cursor.read_type_col().unwrap();
-                                let rtblob = &rtcol.blobs()[bi];
-                                (
+                        // READ_TYPE by row id, not blob index: its blobs can
+                        // be coarser than READ's (SRR18959644 stores READ in
+                        // 43,415 blobs of 1,024 rows but READ_TYPE in 21,709
+                        // of 2,048), and that run's read types flip halfway
+                        // through, so index pairing reads the wrong half.
+                        let (rt_raw, rt_id_range, rt_start_id): (&[u8], u64, i64) = if has_read_type
+                        {
+                            let rtcol = cursor.read_type_col().unwrap();
+                            match rtcol.find_blob(read_start_id) {
+                                Some(rtblob) => (
                                     rtcol.read_raw_blob_slice(rtblob.start_id)?,
                                     rtblob.id_range as u64,
-                                )
-                            } else {
-                                (&[], 0)
-                            };
+                                    rtblob.start_id,
+                                ),
+                                None => (&[], 0, 0),
+                            }
+                        } else {
+                            (&[], 0, 0)
+                        };
 
                         // ALTREAD column: 4na ambiguity mask (also triggers
                         // Illumina name reconstruction when X + Y present).
@@ -885,6 +893,7 @@ fn decode_and_write(
                             name_cs,
                             read_type_raw: rt_raw,
                             read_type_id_range: rt_id_range,
+                            read_type_start_id: rt_start_id,
                             read_type_cs,
                             altread_raw: alt_raw,
                             altread_id_range: alt_id_range,
@@ -1371,18 +1380,15 @@ fn run_fastq_csra(
             let s = csra.read_spot(row_id)?;
             let sequence = fourna_to_ascii(&s.bases);
             let quality: Vec<u8> = s.quality.iter().map(|q| q.wrapping_add(33)).collect();
-            let read_types: Vec<u8> = s
-                .read_types
-                .iter()
-                .map(|&rt| if rt & 0x01 != 0 { 0 } else { 1 })
-                .collect();
             let spot_num_str = itoa_buf.format(row_id).to_string();
             let spot = SpotRecord {
                 name: spot_num_str.as_bytes().to_vec(),
                 sequence,
                 quality,
                 read_lengths: s.read_lens,
-                read_types,
+                // Already INSDC `xread_type` bytes, orientation bits and all;
+                // `SpotRecord::read_types` takes them as-is.
+                read_types: s.read_types,
                 read_filter: Vec::new(),
                 spot_group: Vec::new(),
             };

--- a/crates/sracha-vdb/src/cursor.rs
+++ b/crates/sracha-vdb/src/cursor.rs
@@ -305,16 +305,17 @@ impl VdbCursor {
 
     /// Per-read technical/biological types from VDB metadata, if available.
     ///
-    /// Returns a byte per read: `0` for biological (`B`), `1` for technical
-    /// (`T`, any other flag). Used as a fallback when the physical
-    /// `READ_TYPE` column is absent — common in older DDBJ/SRA submissions
-    /// where read-type info lives only in the schema metadata.
+    /// Returns one INSDC `xread_type` byte per read — `1` for biological
+    /// (`B`), `0` for technical (`T`, any other flag) — so callers can treat
+    /// it interchangeably with the physical `READ_TYPE` column. Used as a
+    /// fallback when that column is absent, common in older DDBJ/SRA
+    /// submissions where read-type info lives only in the schema metadata.
     pub fn metadata_read_types(&self) -> Option<Vec<u8>> {
         let descs = self.metadata_read_descs.as_ref()?;
         Some(
             descs
                 .iter()
-                .map(|d| if d.read_type == b'B' { 0u8 } else { 1u8 })
+                .map(|d| u8::from(d.read_type == b'B'))
                 .collect(),
         )
     }
@@ -1391,8 +1392,8 @@ mod tests {
         let mut archive = KarArchive::open(Cursor::new(archive_bytes)).unwrap();
         let cursor = VdbCursor::open(&mut archive, &sra_path).unwrap();
 
-        // 1 = technical, 0 = biological.
-        assert_eq!(cursor.metadata_read_types(), Some(vec![1, 0]));
+        // INSDC xread_type: 0 = technical, 1 = biological.
+        assert_eq!(cursor.metadata_read_types(), Some(vec![0, 1]));
         let _ = std::fs::remove_file(&sra_path);
     }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -392,7 +392,7 @@ How common `fasterq-dump` / `fastq-dump` options map to sracha:
 | `-O, --outdir <DIR>` | `-O, --output-dir <DIR>` | Same |
 | `-e, --threads <N>` | `-t, --threads <N>` | Decode + compression threads |
 | `--split-3` | `--split split-3` | Default in both |
-| `--split-files` | `--split split-files` | One file per read |
+| `--split-files` | `--split split-files` | One file per read slot; skipped reads still consume their number |
 | `--split-spot` | `--split split-spot` | All reads of a spot in one file |
 | `--concatenate-reads` / no split | `--split interleaved` | Single interleaved stream |
 | `-Z, --stdout` | `-Z, --stdout` | Interleaved FASTQ to stdout |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,10 +138,16 @@ Quality scores will be uniform: Q30 for pass-filter reads, Q3 for rejects.
 
 | Mode | Flag | Output |
 |------|------|--------|
-| split-3 (default) | `--split split-3` | `_1.fastq.gz`, `_2.fastq.gz`, `_0.fastq.gz` |
-| split-files | `--split split-files` | `_1.fastq.gz`, `_2.fastq.gz`, ... |
+| split-3 (default) | `--split split-3` | `_1.fastq.gz`, `_2.fastq.gz`, plus `.fastq.gz` for spots with fewer than two biological reads |
+| split-files | `--split split-files` | one file per read slot: `_1.fastq.gz`, `_2.fastq.gz`, ... |
 | split-spot | `--split split-spot` | single file |
 | interleaved | `--split interleaved` | single file, R1/R2 alternating |
+
+In `split-files` the number comes from the read's slot in the spot, matching
+fasterq-dump: if a spot's first read is empty or technical, its second read
+still goes to `_2.fastq.gz` and no `_1.fastq.gz` is written. `split-3`
+instead numbers only the reads it writes, so the same spot's lone read lands
+in the unpaired `.fastq.gz`.
 
 ## Compression options
 

--- a/validation/compare_with_fasterq_dump.sh
+++ b/validation/compare_with_fasterq_dump.sh
@@ -305,16 +305,28 @@ test_3_splitfiles_fastq() {
     echo "  sracha files:      $(ls "$sracha_out"/)"
     echo "  fasterq-dump files: $(ls "$fasterq_out"/)"
 
-    # split-files for 2-read paired data should produce _1 and _2
-    for suffix in _1 _2; do
-        local sf="$sracha_out/${ACCESSION}${suffix}.fastq"
-        local ff="$fasterq_out/${ACCESSION}${suffix}.fastq"
+    # Compare every file either tool produced, not a hardcoded _1/_2 pair.
+    # split-files numbers by read slot, so a run whose odd slots are empty or
+    # technical yields _2 and _4 with no _1/_3 (SRR000001 does exactly this);
+    # a fixed pair would silently skip the files that actually got written.
+    local names
+    names=$(ls "$sracha_out"/*.fastq "$fasterq_out"/*.fastq 2>/dev/null |
+        xargs -n1 basename 2>/dev/null | sort -u)
+
+    if [[ -z "$names" ]]; then
+        fail "split-files — neither tool produced any FASTQ"
+    fi
+
+    local name
+    for name in $names; do
+        local sf="$sracha_out/$name"
+        local ff="$fasterq_out/$name"
         if [[ -f "$sf" && -f "$ff" ]]; then
-            compare_files "$sf" "$ff" "split-files ${suffix}"
+            compare_files "$sf" "$ff" "split-files ${name}"
         elif [[ -f "$sf" ]]; then
-            fail "split-files ${suffix} — fasterq-dump did not produce ${suffix}.fastq"
-        elif [[ -f "$ff" ]]; then
-            fail "split-files ${suffix} — sracha did not produce ${suffix}.fastq"
+            fail "split-files ${name} — fasterq-dump did not produce it"
+        else
+            fail "split-files ${name} — sracha did not produce it"
         fi
     done
     echo
@@ -406,21 +418,24 @@ test_7_sralite_splitspot() {
 test_8_interleaved() {
     log "Test 8: interleaved (FASTQ, paired-end)"
 
-    # sracha's interleaved mode currently produces _1/_2 files (same routing
-    # as split-3; the writer doesn't merge into one stream yet). Verify that
-    # the content matches fasterq-dump split-3 output.
+    # Interleaved writes one file with both mates alternating and `/1`,`/2`
+    # defline suffixes -- the same stream fasterq-dump produces for
+    # --split-spot. (This test used to expect _1/_2 files, left over from
+    # before the writer merged them into a single stream.)
     local sracha_out="$TMPDIR_BASE/test8_sracha"
     local fasterq_out="$TMPDIR_BASE/test8_fasterq"
     mkdir -p "$sracha_out" "$fasterq_out"
 
     "$SRACHA" fastq "$SRA_FILE" --split interleaved --no-gzip -O "$sracha_out" -f --no-progress 2>&1 | tail -2
-    "$FASTERQ_DUMP" "$SRA_FILE" --split-3 -O "$fasterq_out" -f 2>&1 | tail -2
+    "$FASTERQ_DUMP" "$SRA_FILE" --split-spot -O "$fasterq_out" -f 2>&1 | tail -2
 
     echo "  sracha files:      $(ls "$sracha_out"/)"
     echo "  fasterq-dump files: $(ls "$fasterq_out"/)"
 
-    compare_files "$sracha_out/${ACCESSION}_1.fastq" "$fasterq_out/${ACCESSION}_1.fastq" "interleaved read 1"
-    compare_files "$sracha_out/${ACCESSION}_2.fastq" "$fasterq_out/${ACCESSION}_2.fastq" "interleaved read 2"
+    for stray in "$sracha_out/${ACCESSION}_1.fastq" "$sracha_out/${ACCESSION}_2.fastq"; do
+        [[ -f "$stray" ]] && fail "interleaved — split output $(basename "$stray") should not exist"
+    done
+    compare_files "$sracha_out/${ACCESSION}.fastq" "$fasterq_out/${ACCESSION}.fastq" "interleaved"
     echo
 }
 


### PR DESCRIPTION
Fixes #76.

## The bug

`--split-files` derived each output file number from a read's position among
the reads that *survived* filtering, rather than from its original READ_LEN
slot. Any dropped read — zero-length, technical, or below `--min-read-len` —
shifted every later read down a file.

For the accessions in #76 (SRR18959644 and friends) this silently corrupts the
output. Those runs store R1-only spots followed by R2-only spots:

```
rows 1 .. 22,228,621           READ_LEN=[150, 0]   READ_TYPE=[BIOLOGICAL, TECHNICAL]
rows 22,228,622 .. 44,457,242  READ_LEN=[0, 150]   READ_TYPE=[TECHNICAL, BIOLOGICAL]
```

sracha wrote all 44,457,242 reads to `_1.fastq` and never created `_2.fastq`,
concatenating every R2 onto the end of R1. The result looks like a valid
single-end FASTQ, which is worse than a hard failure.

## Reference behaviour

From sra-tools `tools/external/fasterq-dump/tbl_join.c`, the two split modes
number their files differently:

- `print_fastq_n_reads_split_file` advances `write_id_1` once per slot,
  *outside* the filter branch — skipped reads still consume their file number.
- `print_fastq_n_reads_split_3` advances it only for reads it emits (so
  survivors compact into `_1.._N`), and forces `write_id_1 = 0` when the spot
  has fewer than two biological reads.

Verified against fasterq-dump 3.2.1 on SRR000001, a 454 run with
`READ_TYPE=[T, B, T, B]`:

| mode | fasterq-dump output |
| --- | --- |
| `--split-files` | `_2.fastq` (470,519 reads), `_4.fastq` (236,507) — no `_1`/`_3` |
| `--split-3` | `_1`/`_2` (236,041 each), `.fastq` (234,944) |

## Changes

- `--split-files` routes by the read's original slot (`mate_idx`), so a
  `[0, 150]` spot writes to `_2`, and a spot whose leading read is technical
  writes its biological read to `_2` rather than `_1`.
- `--split-3` decides pairing from the spot's biological read count instead of
  `segments.len() == 2`. Previously `--include-technical` could turn an
  unpaired spot into a bogus `_1`/`_2` pair, and spots with 3+ reads collapsed
  into the unpaired file instead of being numbered `_1.._N`.
- Both split modes now share one `slot_for_segment` decision function. The
  routing was duplicated between `fastq::route_segments_to_slots` and the fused
  `blob_decode` hot path, which is how the two drifted.
- READ_TYPE is treated as INSDC `xread_type` bits everywhere. Bit 0 is the
  biological flag; bits 1-2 are orientation. The old `rtype != 0` test read
  `BIOLOGICAL|FORWARD` (3) and `BIOLOGICAL|REVERSE` (5) as technical — values
  aligned cSRA rows routinely carry. This also removes an inverted internal
  convention: `metadata_read_types()` and the cSRA path each mapped biological
  to `0`, while the physical READ_TYPE column was passed through raw, so the
  same filter was being applied to two opposite encodings.
- READ_TYPE blobs are expanded through their page map. VDB stores only the
  *distinct* type rows plus run lengths — SRR18959644's first record covers
  22,227,968 spots — so indexing the raw buffer per spot read the wrong record
  for every spot after the first. Technical reads were effectively filtered on
  one spot per blob and ignored for the rest.

  This also silently lost a read. Spot 22,227,970 sits in the blob straddling
  the change in read types, so it picked up its neighbour's
  `[technical, biological]` row while actually being a `[150, 0]` spot: its
  150 bp read was discarded as technical, its second slot was empty, and the
  spot emitted nothing at all. Found by diffing the output's spot numbers
  against the archive's row count.

  Only the window a given READ blob needs is materialized — expanding a
  22-million-row record for each of 21,707 READ blobs would have cost tens of
  MiB apiece.
- The physical READ_TYPE column is located by row id rather than blob index,
  matching what ALTREAD and NAME_FMT already do, since its blob boundaries do
  not line up with READ's.

## Verification

- 655 unit tests pass, including 16 new ones covering slot preservation across
  zero-length / technical / too-short slots, the split-3 pairing rule,
  orientation-bit handling, and page-map expansion of READ_TYPE (constant runs,
  blobs straddling a change, windowing, and truncated payloads).
- End-to-end on SRR18959644, all 44,457,242 spots decoded and
  44,457,242 reads written: `_1.fastq` and `_2.fastq` with **22,228,621
  reads each**, exactly matching the archive's READ_LEN distribution
  (`sracha vdb dump -C READ_LEN,READ_TYPE` over every row gives 22,228,621
  spots of each shape). Integrity counters all zero. Before this change:
  a single `_1.fastq` with all 44,457,242 reads and no `_2.fastq`.
- End-to-end on DRR004435, an Illumina run with a technical leading read
  (`READ_LEN=[2, 34]`, `READ_TYPE=[TECHNICAL, BIOLOGICAL]`): sracha and
  fasterq-dump both write **only `DRR004435_2.fastq`** and no `_1`, and the
  files are byte-identical (md5 `6036a079f44e7e62d2cd73a92d210d6b`,
  36,805,747 reads). This is the case the old code sent to `_1`.
- `validation/compare_with_fasterq_dump.sh` is green — every mode
  byte-identical to fasterq-dump, including split-files, split-3, split-spot,
  FASTA, SRA-lite, gzip round-trip, and PacBio.
- All `--run-ignored` integration tests pass (one needs its 312 MiB fixture
  cached; it times out on a cold download).
- `cargo clippy --all-targets --all-features -- -D warnings` and
  `cargo fmt --check` are clean.

## Two drive-by fixes in the validation harness

- The split-files comparison only ever checked `_1`/`_2`. Slot-based
  numbering means a run can legitimately produce `_2` and `_4` and no
  `_1`/`_3`, which the old loop would have skipped silently; it now compares
  every file either tool wrote.
- The interleaved test still expected `_1`/`_2` files from before the writer
  merged them into a single stream, so it had been failing regardless of this
  change. It now compares sracha's single interleaved file against
  fasterq-dump `--split-spot` (byte-identical) and asserts no split files are
  left behind.

## Compatibility

This changes output filenames for affected runs, so it wants a minor bump
rather than a patch — flagged for 0.4.0. Runs whose spots have no empty or
technical slots are unaffected; every existing byte-identity fixture still
matches.
