### PR TITLE
feat(validation): impact sweep + A/B corpus harnesses for #76

### DIFF
--- a/validation/ab_corpus.sh
+++ b/validation/ab_corpus.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+#
+# Phase 2 of the #76 impact assessment: for accessions flagged by
+# impact_sweep.sh (plus controls), run the pre-fix binary, the post-fix
+# binary, and fasterq-dump over the same archive and record exactly what
+# changed.
+#
+# random_corpus.sh answers "does sracha match fasterq-dump?". That is not
+# quite the question here. Before releasing a change that renames output
+# files we want the three-way verdict per accession:
+#
+#   FIXED        baseline disagreed with fasterq-dump, candidate agrees
+#   UNCHANGED    both agree with fasterq-dump, byte-identical to each other
+#   CHANGED_OK   output changed and candidate agrees (baseline also agreed --
+#                worth eyeballing, means we altered already-correct output)
+#   REGRESSED    baseline agreed with fasterq-dump, candidate does not
+#   STILL_BROKEN neither agrees with fasterq-dump
+#
+# Usage:
+#   # build the two binaries first (they cannot both live at target/release)
+#   git worktree add /tmp/sracha-base main
+#   cargo build --release --manifest-path /tmp/sracha-base/Cargo.toml
+#   cargo build --release            # candidate, on the PR branch
+#
+#   bash validation/ab_corpus.sh --sbatch \
+#       --baseline /tmp/sracha-base/target/release/sracha \
+#       --candidate target/release/sracha \
+#       -a hits.txt
+#
+#   bash validation/ab_corpus.sh --summary --resume-dir DIR
+#
+# Results: validation/ab-corpus-results/<YYYYMMDD-HHMMSS>/
+#   accessions.txt, results.tsv, logs/<ACC>.<split>.log (non-UNCHANGED only)
+
+set -uo pipefail
+
+# ---------- defaults ----------
+BASELINE=""
+CANDIDATE=""
+ACCESSIONS_FILE=""
+SPLITS="split-files,split-3"
+TIMEOUT_MIN=25
+RESUME_DIR=""
+SBATCH_SUBMIT=0
+SUMMARY_ONLY=0
+RUN_FASTERQ=1
+KEEP_INTERMEDIATES=0
+CONCURRENCY=8
+CPUS_PER_TASK=8
+MEM="16G"
+TMP=""
+PARTITION="rna"
+JOB_NAME="sracha-ab-corpus"
+WORK_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --baseline) BASELINE="$2"; shift 2 ;;
+        --candidate) CANDIDATE="$2"; shift 2 ;;
+        -a|--accessions) ACCESSIONS_FILE="$2"; shift 2 ;;
+        --splits) SPLITS="$2"; shift 2 ;;
+        --timeout) TIMEOUT_MIN="$2"; shift 2 ;;
+        --resume-dir) RESUME_DIR="$2"; shift 2 ;;
+        --sbatch) SBATCH_SUBMIT=1; shift ;;
+        --summary) SUMMARY_ONLY=1; shift ;;
+        --no-fasterq) RUN_FASTERQ=0; shift ;;
+        --keep-intermediates) KEEP_INTERMEDIATES=1; shift ;;
+        --concurrency) CONCURRENCY="$2"; shift 2 ;;
+        --cpus) CPUS_PER_TASK="$2"; shift 2 ;;
+        --mem) MEM="$2"; shift 2 ;;
+        --tmp) TMP="$2"; shift 2 ;;
+        --partition) PARTITION="$2"; shift 2 ;;
+        --work-dir) WORK_DIR="$2"; shift 2 ;;
+        -h|--help) sed -n '3,32p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+# ---------- paths ----------
+if [[ -n "${SLURM_SUBMIT_DIR:-}" ]]; then
+    ROOT_DIR="$SLURM_SUBMIT_DIR"
+else
+    ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+SCRIPT_DIR="$ROOT_DIR/validation"
+SCRIPT_SELF="$SCRIPT_DIR/ab_corpus.sh"
+COMPARE_PY="$SCRIPT_DIR/compare_fastq.py"
+
+# ---------- results dir ----------
+if [[ -n "$RESUME_DIR" ]]; then
+    RESULTS_DIR="$RESUME_DIR"
+    [[ -d "$RESULTS_DIR" ]] || { echo "no such results dir: $RESULTS_DIR" >&2; exit 1; }
+elif [[ -n "${SLURM_ARRAY_TASK_ID:-}" ]]; then
+    echo "array task requires --resume-dir" >&2; exit 1
+else
+    RESULTS_DIR="$SCRIPT_DIR/ab-corpus-results/$(date +%Y%m%d-%H%M%S)"
+    mkdir -p "$RESULTS_DIR/logs"
+fi
+RESULTS_TSV="$RESULTS_DIR/results.tsv"
+RESULTS_LOCK="$RESULTS_DIR/results.lock"
+ACC_LIST="$RESULTS_DIR/accessions.txt"
+
+if [[ ! -f "$RESULTS_TSV" ]]; then
+    printf 'accession\tsplit\tverdict\tbaseline_files\tcandidate_files\tfasterq_files\tbase_vs_cand\tcand_vs_fasterq\tbase_vs_fasterq\tnote\n' > "$RESULTS_TSV"
+fi
+
+print_summary() {
+    echo "== A/B corpus: $RESULTS_DIR"
+    awk -F'\t' 'NR>1 {c[$2"/"$3]++; tot++} END {
+        printf "  total rows: %d\n", tot
+        for (k in c) printf "  %-28s %5d\n", k, c[k]
+    }' "$RESULTS_TSV" | sort
+    echo
+    echo "  non-UNCHANGED rows:"
+    awk -F'\t' 'NR>1 && $3 != "UNCHANGED" {printf "    %-14s %-12s %-14s %s\n", $1, $2, $3, $10}' "$RESULTS_TSV"
+}
+
+[[ "$SUMMARY_ONLY" == "1" ]] && { print_summary; exit 0; }
+
+# ---------- accession list ----------
+if [[ ! -f "$ACC_LIST" ]]; then
+    [[ -n "$ACCESSIONS_FILE" ]] || { echo "need -a <accessions file> (e.g. impact_sweep.sh --hits)" >&2; exit 2; }
+    cp "$ACCESSIONS_FILE" "$ACC_LIST"
+    echo "accessions: $(grep -cv '^$\|^#' "$ACC_LIST") -> $ACC_LIST"
+fi
+
+# ---------- binaries ----------
+# Resolve to absolute paths before sbatch: array tasks start in a different cwd.
+[[ -n "$BASELINE" ]] && BASELINE="$(cd "$(dirname "$BASELINE")" && pwd)/$(basename "$BASELINE")"
+[[ -n "$CANDIDATE" ]] && CANDIDATE="$(cd "$(dirname "$CANDIDATE")" && pwd)/$(basename "$CANDIDATE")"
+for b in "$BASELINE" "$CANDIDATE"; do
+    [[ -x "$b" ]] || { echo "not executable: '$b' (pass --baseline and --candidate)" >&2; exit 1; }
+done
+
+# ---------- sbatch submission ----------
+if [[ "$SBATCH_SUBMIT" == "1" ]]; then
+    command -v sbatch >/dev/null || { echo "sbatch not found" >&2; exit 1; }
+    TOTAL=$(grep -cv '^$\|^#' "$ACC_LIST")
+    (( TOTAL < 1 )) && { echo "empty accession list" >&2; exit 1; }
+    SLURM_TIME=$(( TIMEOUT_MIN * 4 + 20 ))
+
+    echo "results dir : $RESULTS_DIR"
+    echo "accessions  : $TOTAL   splits: $SPLITS"
+    echo "baseline    : $BASELINE"
+    echo "candidate   : $CANDIDATE"
+    echo "partition   : $PARTITION   concurrency: $CONCURRENCY"
+
+    SBATCH_ARGS=(
+        --job-name="$JOB_NAME"
+        --comment="$JOB_NAME"
+        --partition="$PARTITION"
+        --array="1-${TOTAL}%${CONCURRENCY}"
+        --cpus-per-task="$CPUS_PER_TASK"
+        --mem="$MEM"
+        --time="${SLURM_TIME}"
+        --output="$RESULTS_DIR/logs/slurm-%A_%a.out"
+        --parsable
+    )
+    [[ -n "$TMP" ]] && SBATCH_ARGS+=(--tmp="$TMP")
+
+    FORWARD=(--resume-dir "$RESULTS_DIR" --baseline "$BASELINE" --candidate "$CANDIDATE"
+             --splits "$SPLITS" --timeout "$TIMEOUT_MIN")
+    (( RUN_FASTERQ )) || FORWARD+=(--no-fasterq)
+    (( KEEP_INTERMEDIATES )) && FORWARD+=(--keep-intermediates)
+    [[ -n "$WORK_DIR" ]] && FORWARD+=(--work-dir "$WORK_DIR")
+
+    JOB_ID=$(sbatch "${SBATCH_ARGS[@]}" "$SCRIPT_SELF" "${FORWARD[@]}")
+    echo "submitted array job $JOB_ID"
+    echo "watch   : squeue -u \$USER -n $JOB_NAME"
+    echo "summary : bash validation/ab_corpus.sh --summary --resume-dir $RESULTS_DIR"
+    exit 0
+fi
+
+# ---------- tooling ----------
+FASTERQ_DUMP=""
+if (( RUN_FASTERQ )); then
+    if ! command -v fasterq-dump >/dev/null 2>&1; then
+        if declare -F module >/dev/null 2>&1 || [[ -f /etc/profile.d/modules.sh ]]; then
+            # shellcheck disable=SC1091
+            source /etc/profile.d/modules.sh 2>/dev/null || true
+            module load sratoolkit/3.2.1 2>/dev/null || true
+        fi
+    fi
+    FASTERQ_DUMP="$(command -v fasterq-dump || true)"
+    [[ -z "$FASTERQ_DUMP" ]] && { echo "fasterq-dump not found. Try: module load sratoolkit/3.2.1, or pass --no-fasterq" >&2; exit 1; }
+fi
+
+[[ -z "$WORK_DIR" ]] && WORK_DIR="${TMPDIR:-/tmp}/sracha-ab-corpus.${SLURM_ARRAY_JOB_ID:-$$}.${SLURM_ARRAY_TASK_ID:-0}"
+mkdir -p "$WORK_DIR"
+CURRENT_ACC=""
+cleanup_current() {
+    [[ "$KEEP_INTERMEDIATES" == "1" || -z "$CURRENT_ACC" ]] && return
+    rm -rf "${WORK_DIR:?}/sra/$CURRENT_ACC" "${WORK_DIR:?}/out/$CURRENT_ACC"
+}
+trap 'cleanup_current; rm -rf "${WORK_DIR:?}"; exit 130' INT TERM
+trap 'cleanup_current; [[ "$KEEP_INTERMEDIATES" == "1" ]] || rm -rf "${WORK_DIR:?}"' EXIT
+
+if command -v flock >/dev/null 2>&1; then
+    record() {
+        flock -x 200
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$@" >> "$RESULTS_TSV"
+        flock -u 200
+    } 200>"$RESULTS_LOCK"
+else
+    record() { printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$@" >> "$RESULTS_TSV"; }
+fi
+
+# Sorted list of FASTQ basenames a tool produced. The file *set* is half the
+# answer here -- slot-based numbering means a run can legitimately emit _2 and
+# _4 with no _1/_3, so comparing a fixed _1/_2 pair would miss the change
+# entirely.
+file_set() { (cd "$1" 2>/dev/null && ls -- *.fastq 2>/dev/null | sort | tr '\n' ',' ); }
+
+# Compare two output dirs over the union of their basenames.
+# Echoes one of: IDENTICAL | CONTENT (deflines differ) | DIFFER:<detail>
+compare_dirs() {
+    local a="$1" b="$2" log="$3" strict_content="${4:-0}"
+    local names detail="" worst="IDENTICAL"
+    names=$( { ls "$a"/*.fastq "$b"/*.fastq; } 2>/dev/null | xargs -n1 basename 2>/dev/null | sort -u )
+    if [[ -z "$names" ]]; then echo "DIFFER:no-fastq-either-side"; return; fi
+    local n fa fb ma mb
+    for n in $names; do
+        fa="$a/$n"; fb="$b/$n"
+        if [[ ! -f "$fa" ]]; then detail="${detail}${n}:missing-left "; worst="DIFFER"; continue; fi
+        if [[ ! -f "$fb" ]]; then detail="${detail}${n}:missing-right "; worst="DIFFER"; continue; fi
+        ma=$(md5sum "$fa" 2>/dev/null | cut -d' ' -f1); mb=$(md5sum "$fb" 2>/dev/null | cut -d' ' -f1)
+        # Empty digests would compare equal and silently report a false match --
+        # the exact failure mode this harness exists to catch. Fail loudly.
+        if [[ -z "$ma" || -z "$mb" ]]; then
+            detail="${detail}${n}:md5-unavailable "; worst="DIFFER"; continue
+        fi
+        [[ "$ma" == "$mb" ]] && continue
+        if (( strict_content )); then
+            detail="${detail}${n}:md5 "; worst="DIFFER"
+        else
+            # Tolerate defline-only differences the way random_corpus.sh does,
+            # so a cosmetic header change is not reported as a content change.
+            if python3 "$COMPARE_PY" "$fa" "$fb" >>"$log" 2>&1; then
+                [[ "$worst" == "IDENTICAL" ]] && worst="CONTENT"
+            else
+                detail="${detail}${n}:content "; worst="DIFFER"
+            fi
+        fi
+    done
+    if [[ "$worst" == "DIFFER" ]]; then echo "DIFFER:${detail% }"; else echo "$worst"; fi
+}
+
+run_tool() {
+    local bin="$1" sra="$2" out="$3" split="$4" log="$5"
+    mkdir -p "$out"
+    timeout "${TIMEOUT_MIN}m" "$bin" fastq "$sra" --split "$split" --no-gzip -O "$out" -f --no-progress >>"$log" 2>&1
+}
+
+process_accession() {
+    local acc="$1"
+    CURRENT_ACC="$acc"
+    local sra_dir="$WORK_DIR/sra/$acc"
+    mkdir -p "$sra_dir"
+
+    local fetch_log="$RESULTS_DIR/logs/${acc}.fetch.log"
+    : > "$fetch_log"
+    # Fetch once with the candidate; download path is not what is under test.
+    local fetch_rc=0
+    timeout "${TIMEOUT_MIN}m" "$CANDIDATE" fetch "$acc" -O "$sra_dir" --no-progress >>"$fetch_log" 2>&1 || fetch_rc=$?
+    if (( fetch_rc != 0 )); then
+        # Capture rc on the same line as the call: a bare `local s` in between
+        # would reset $? to local's own (zero) status and lose the 124.
+        local s=ERROR_FETCH
+        (( fetch_rc == 124 )) && s=TIMEOUT
+        record "$acc" "-" "$s" - - - - - - "fetch failed (rc=$fetch_rc), see logs/${acc}.fetch.log"
+        cleanup_current; return
+    fi
+    rm -f "$fetch_log"
+
+    local sra
+    sra=$(find "$sra_dir" -maxdepth 2 -type f \( -name '*.sra' -o -name '*.sralite' \) | head -1)
+    if [[ -z "$sra" ]]; then
+        record "$acc" "-" ERROR_FETCH - - - - - - "no archive after fetch"
+        cleanup_current; return
+    fi
+
+    local split
+    IFS=',' read -r -a split_arr <<< "$SPLITS"
+    for split in "${split_arr[@]}"; do
+        local log="$RESULTS_DIR/logs/${acc}.${split}.log"
+        : > "$log"
+        local base_out="$WORK_DIR/out/$acc/base" cand_out="$WORK_DIR/out/$acc/cand" fq_out="$WORK_DIR/out/$acc/fq"
+        rm -rf "$WORK_DIR/out/$acc"; mkdir -p "$base_out" "$cand_out" "$fq_out"
+
+        local base_rc=0 cand_rc=0
+        run_tool "$BASELINE" "$sra" "$base_out" "$split" "$log" || base_rc=$?
+        run_tool "$CANDIDATE" "$sra" "$cand_out" "$split" "$log" || cand_rc=$?
+
+        # A run both binaries refuse (aligned cSRA, unsupported platform) is
+        # handled, not a finding -- record and move on.
+        if (( base_rc != 0 && cand_rc != 0 )); then
+            local why=REJECTED_BOTH
+            grep -qiE 'aligned SRA|cSRA' "$log" && why=REJECT_CSRA
+            grep -qiE 'unsupported platform' "$log" && why=REJECT_PLATFORM
+            record "$acc" "$split" "$why" - - - - - - "both binaries exited non-zero"
+            continue
+        fi
+        if (( cand_rc != 0 )); then
+            record "$acc" "$split" REGRESSED "$(file_set "$base_out")" - - - - - "candidate failed (rc=$cand_rc), baseline succeeded"
+            continue
+        fi
+        if (( base_rc != 0 )); then
+            record "$acc" "$split" FIXED - "$(file_set "$cand_out")" - - - - "baseline failed (rc=$base_rc), candidate succeeded"
+            continue
+        fi
+
+        local fq_rc=0 fq_files="-" cand_fq="-" base_fq="-"
+        if (( RUN_FASTERQ )); then
+            timeout "${TIMEOUT_MIN}m" "$FASTERQ_DUMP" "$sra" "--${split}" -O "$fq_out" -f -t "$fq_out/tmp" >>"$log" 2>&1 || fq_rc=$?
+            rm -rf "$fq_out/tmp"
+        fi
+
+        # baseline vs candidate: strict md5, since "did the bytes change" is
+        # exactly the question. vs fasterq-dump uses the defline tolerance.
+        local bvc; bvc=$(compare_dirs "$base_out" "$cand_out" "$log" 1)
+        if (( RUN_FASTERQ && fq_rc == 0 )); then
+            cand_fq=$(compare_dirs "$cand_out" "$fq_out" "$log" 0)
+            base_fq=$(compare_dirs "$base_out" "$fq_out" "$log" 0)
+            fq_files=$(file_set "$fq_out")
+        elif (( RUN_FASTERQ )); then
+            cand_fq="FASTERQ_FAILED"; base_fq="FASTERQ_FAILED"
+        fi
+
+        local ok_c=0 ok_b=0
+        [[ "$cand_fq" == IDENTICAL || "$cand_fq" == CONTENT ]] && ok_c=1
+        [[ "$base_fq" == IDENTICAL || "$base_fq" == CONTENT ]] && ok_b=1
+
+        local verdict
+        if (( ! RUN_FASTERQ )); then
+            [[ "$bvc" == "IDENTICAL" ]] && verdict=UNCHANGED || verdict=CHANGED
+        elif [[ "$cand_fq" == "FASTERQ_FAILED" ]]; then
+            verdict=FASTERQ_FAILED
+        elif (( ok_c && ! ok_b )); then verdict=FIXED
+        elif (( ok_c && ok_b )); then
+            [[ "$bvc" == "IDENTICAL" ]] && verdict=UNCHANGED || verdict=CHANGED_OK
+        elif (( ! ok_c && ok_b )); then verdict=REGRESSED
+        else verdict=STILL_BROKEN
+        fi
+
+        record "$acc" "$split" "$verdict" \
+            "$(file_set "$base_out")" "$(file_set "$cand_out")" "$fq_files" \
+            "$bvc" "$cand_fq" "$base_fq" "-"
+
+        [[ "$verdict" == "UNCHANGED" ]] && rm -f "$log"
+        rm -rf "$WORK_DIR/out/$acc"
+    done
+
+    cleanup_current
+}
+
+# ---------- dispatch ----------
+if [[ -n "${SLURM_ARRAY_TASK_ID:-}" ]]; then
+    ACC=$(awk 'NF && !/^#/' "$ACC_LIST" | sed -n "${SLURM_ARRAY_TASK_ID}p")
+    [[ -z "$ACC" ]] && { echo "no accession at index $SLURM_ARRAY_TASK_ID" >&2; exit 1; }
+    echo "# array task $SLURM_ARRAY_TASK_ID on $(hostname) -> $ACC"
+    process_accession "$ACC"
+    exit 0
+fi
+
+declare -A DONE=()
+while IFS=$'\t' read -r a _rest; do
+    [[ "$a" == "accession" ]] && continue
+    DONE["$a"]=1
+done < "$RESULTS_TSV"
+
+while read -r acc; do
+    [[ -z "$acc" || "$acc" == \#* ]] && continue
+    [[ -n "${DONE[$acc]:-}" ]] && { echo "skip $acc (already recorded)"; continue; }
+    echo "-> $acc"
+    process_accession "$acc"
+done < <(awk 'NF && !/^#/' "$ACC_LIST")
+
+print_summary

--- a/validation/impact_sweep.sh
+++ b/validation/impact_sweep.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+#
+# Phase 1 of the #76 impact assessment: classify how many public runs change
+# output under the split-mode / READ_TYPE fixes, WITHOUT downloading archives.
+#
+# Why this exists as a separate pass from random_corpus.sh: that harness
+# downloads each archive and runs both tools, which is minutes and gigabytes
+# per accession. Deciding whether a run is even *affected* only needs the
+# READ_LEN and READ_TYPE columns, and sra-tools' vdb-dump streams those over
+# HTTP range requests — seconds per run, no download. So we screen cheaply
+# here, then spend the expensive A/B pass (ab_corpus.sh) only on the hits.
+#
+# NOTE: the prober is deliberately vdb-dump, not sracha. The thing being
+# measured is sracha's own routing/READ_TYPE handling, so classifying with
+# sracha's decoder would be circular — a decoder bug would hide exactly the
+# runs that matter. See #78 for giving sracha its own remote-inspection path;
+# even then an independent oracle is the right call for this sweep.
+#
+# Usage:
+#   bash validation/impact_sweep.sh --sbatch                 # sample 500, submit array
+#   bash validation/impact_sweep.sh --sbatch -n 2000 --concurrency 40
+#   bash validation/impact_sweep.sh -a accessions.txt        # serial, explicit list
+#   bash validation/impact_sweep.sh --summary --resume-dir DIR
+#   bash validation/impact_sweep.sh --hits --resume-dir DIR  # affected accessions, for ab_corpus.sh
+#
+# Results: validation/impact-sweep-results/<YYYYMMDD-HHMMSS>/
+#   accessions.txt, results.tsv, strata.tsv, logs/<ACC>.log (errors only)
+
+set -uo pipefail
+
+# ---------- defaults ----------
+N=500
+SEED=""
+ACCESSIONS_FILE=""
+# Platforms sracha actually supports; legacy ones are rejected outright and
+# would only add PROBE_ERR noise. Kept as an ENA instrument_platform list.
+PLATFORMS="ILLUMINA,BGISEQ,DNBSEQ,ELEMENT,ULTIMA,PACBIO_SMRT,OXFORD_NANOPORE"
+# first_public strata. The ENA portal returns rows in accession order and
+# rejects `offset`, so a single query is heavily skewed toward the earliest
+# accessions (a naive 90-run draw came back 100% DRR). Slicing by release
+# year and platform is the cheapest way to spread the sample across
+# submitters and loader versions -- which is what actually drives these
+# archive shapes.
+YEARS="2011,2013,2015,2017,2019,2021,2023,2025"
+MIN_BASES=50000000
+MAX_BASES=50000000000
+# 0 = scan every row (exact). >0 = probe that many evenly spaced rows (fast,
+# but can miss a shape change: SRR18959644 flips at its exact midpoint, and a
+# run that flips at 90% would slip past a coarse probe). Full scan of a 44M
+# row archive is ~4 min, so exact is affordable and is the default.
+SAMPLE_ROWS=0
+TIMEOUT_MIN=20
+RESUME_DIR=""
+SBATCH_SUBMIT=0
+SUMMARY_ONLY=0
+HITS_ONLY=0
+CONCURRENCY=25
+CPUS_PER_TASK=2
+MEM="2G"
+TMP=""
+PARTITION="rna"
+JOB_NAME="sracha-impact-sweep"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -n) N="$2"; shift 2 ;;
+        -s|--seed) SEED="$2"; shift 2 ;;
+        -a|--accessions) ACCESSIONS_FILE="$2"; shift 2 ;;
+        --platforms) PLATFORMS="$2"; shift 2 ;;
+        --years) YEARS="$2"; shift 2 ;;
+        --min-bases) MIN_BASES="$2"; shift 2 ;;
+        --max-bases) MAX_BASES="$2"; shift 2 ;;
+        --sample) SAMPLE_ROWS="$2"; shift 2 ;;
+        --timeout) TIMEOUT_MIN="$2"; shift 2 ;;
+        --resume-dir) RESUME_DIR="$2"; shift 2 ;;
+        --sbatch) SBATCH_SUBMIT=1; shift ;;
+        --summary) SUMMARY_ONLY=1; shift ;;
+        --hits) HITS_ONLY=1; shift ;;
+        --concurrency) CONCURRENCY="$2"; shift 2 ;;
+        --cpus) CPUS_PER_TASK="$2"; shift 2 ;;
+        --mem) MEM="$2"; shift 2 ;;
+        --tmp) TMP="$2"; shift 2 ;;
+        --partition) PARTITION="$2"; shift 2 ;;
+        -h|--help) sed -n '3,30p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+# ---------- paths ----------
+# Under sbatch, BASH_SOURCE points at the spool copy, so prefer the submit dir
+# and hand sbatch the repo copy of this script (same trick as random_corpus.sh).
+if [[ -n "${SLURM_SUBMIT_DIR:-}" ]]; then
+    ROOT_DIR="$SLURM_SUBMIT_DIR"
+else
+    ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+SCRIPT_DIR="$ROOT_DIR/validation"
+SCRIPT_SELF="$SCRIPT_DIR/impact_sweep.sh"
+
+# ---------- results dir ----------
+if [[ -n "$RESUME_DIR" ]]; then
+    RESULTS_DIR="$RESUME_DIR"
+    [[ -d "$RESULTS_DIR" ]] || { echo "no such results dir: $RESULTS_DIR" >&2; exit 1; }
+elif [[ -n "${SLURM_ARRAY_TASK_ID:-}" ]]; then
+    echo "array task requires --resume-dir" >&2; exit 1
+else
+    RESULTS_DIR="$SCRIPT_DIR/impact-sweep-results/$(date +%Y%m%d-%H%M%S)"
+    mkdir -p "$RESULTS_DIR/logs"
+fi
+RESULTS_TSV="$RESULTS_DIR/results.tsv"
+RESULTS_LOCK="$RESULTS_DIR/results.lock"
+ACC_LIST="$RESULTS_DIR/accessions.txt"
+
+if [[ ! -f "$RESULTS_TSV" ]]; then
+    printf 'accession\tclass\tspots\tmax_slots\tsplit_files_changed\tsplit3_changed\torientation_bits\thas_technical\trows_scanned\tsecs\tnote\n' > "$RESULTS_TSV"
+fi
+
+# ---------- reporting modes ----------
+print_summary() {
+    echo "== impact sweep: $RESULTS_DIR"
+    awk -F'\t' 'NR>1 {c[$2]++; tot++} END {
+        printf "  total classified: %d\n", tot
+        for (k in c) printf "  %-22s %6d  (%5.1f%%)\n", k, c[k], 100*c[k]/tot
+    }' "$RESULTS_TSV" | sort
+    # Wilson score interval for the affected proportion. A plain point estimate
+    # invites over-reading a handful of hits out of a few hundred runs.
+    awk -F'\t' 'NR>1 && $2 != "PROBE_ERR" {
+        n++; if ($2 != "UNAFFECTED") k++
+    } END {
+        if (n == 0) { print "  no classified runs"; exit }
+        p = k/n; z = 1.96
+        d = 1 + z*z/n
+        c = (p + z*z/(2*n)) / d
+        m = z*sqrt(p*(1-p)/n + z*z/(4*n*n)) / d
+        printf "\n  affected: %d/%d = %.2f%%  (95%% CI %.2f%% - %.2f%%)\n", k, n, 100*p, 100*(c-m), 100*(c+m)
+    }' "$RESULTS_TSV"
+}
+
+print_hits() {
+    # Affected accessions only, for feeding straight into ab_corpus.sh -a.
+    awk -F'\t' 'NR>1 && $2 != "UNAFFECTED" && $2 != "PROBE_ERR" {print $1}' "$RESULTS_TSV"
+}
+
+[[ "$SUMMARY_ONLY" == "1" ]] && { print_summary; exit 0; }
+[[ "$HITS_ONLY" == "1" ]] && { print_hits; exit 0; }
+
+# ---------- sampling ----------
+# Stratified draw: for each (platform, year) cell pull a pool from ENA, then
+# take an equal share from each cell. Cells that return nothing are skipped and
+# their quota is absorbed by the shuffle at the end.
+sample_accessions() {
+    local seed="$1" want="$2"
+    local strata_log="$RESULTS_DIR/strata.tsv"
+    : > "$strata_log"
+    IFS=',' read -r -a plats <<< "$PLATFORMS"
+    IFS=',' read -r -a yrs <<< "$YEARS"
+    local cells=$(( ${#plats[@]} * ${#yrs[@]} ))
+    (( cells < 1 )) && cells=1
+    # Over-draw per cell so the final shuffle has slack when cells come up short.
+    local per_cell=$(( want / cells * 4 + 25 ))
+
+    local p y q
+    for p in "${plats[@]}"; do
+        for y in "${yrs[@]}"; do
+            q="instrument_platform=${p} AND base_count>=${MIN_BASES} AND base_count<=${MAX_BASES}"
+            q="$q AND first_public>=${y}-01-01 AND first_public<=${y}-12-31"
+            curl -sS -X POST "https://www.ebi.ac.uk/ena/portal/api/search" \
+                --data-urlencode "result=read_run" \
+                --data-urlencode "query=$q" \
+                --data-urlencode "fields=run_accession,instrument_platform,library_layout,base_count,first_public" \
+                --data-urlencode "limit=${per_cell}" \
+                --data-urlencode "format=tsv" 2>/dev/null \
+                | tail -n +2 | awk -F'\t' -v p="$p" -v y="$y" 'NF {print $0"\t"p"\t"y}'
+        done
+    done > "$strata_log"
+
+    local pool
+    pool=$(wc -l < "$strata_log")
+    echo "# stratified pool: $pool rows across $cells cells (platforms=$PLATFORMS years=$YEARS)" >&2
+    if (( pool == 0 )); then
+        echo "ENA returned no rows for any stratum" >&2
+        return 1
+    fi
+    # Deterministic shuffle, same construction as sample_accessions.sh.
+    local src
+    src=$(mktemp)
+    openssl enc -aes-256-ctr -pass "pass:${seed}" -nosalt < /dev/zero 2>/dev/null | head -c 1048576 > "$src"
+    cut -f1 "$strata_log" | sort -u | shuf -n "$want" --random-source="$src"
+    rm -f "$src"
+}
+
+if [[ ! -f "$ACC_LIST" ]]; then
+    if [[ -n "$ACCESSIONS_FILE" ]]; then
+        cp "$ACCESSIONS_FILE" "$ACC_LIST"
+    else
+        [[ -z "$SEED" ]] && SEED="${RANDOM}${RANDOM}"
+        echo "$SEED" > "$RESULTS_DIR/seed"
+        sample_accessions "$SEED" "$N" > "$ACC_LIST" || exit 1
+    fi
+    echo "accessions: $(grep -cv '^$\|^#' "$ACC_LIST") -> $ACC_LIST"
+fi
+
+# ---------- sbatch submission ----------
+if [[ "$SBATCH_SUBMIT" == "1" ]]; then
+    command -v sbatch >/dev/null || { echo "sbatch not found" >&2; exit 1; }
+    TOTAL=$(grep -cv '^$\|^#' "$ACC_LIST")
+    (( TOTAL < 1 )) && { echo "empty accession list" >&2; exit 1; }
+    SLURM_TIME=$(( TIMEOUT_MIN * 2 + 10 ))
+
+    echo "results dir : $RESULTS_DIR"
+    echo "accessions  : $TOTAL"
+    echo "partition   : $PARTITION   concurrency: $CONCURRENCY"
+    echo "per task    : ${CPUS_PER_TASK} cpu, ${MEM}, ${SLURM_TIME}min"
+
+    SBATCH_ARGS=(
+        --job-name="$JOB_NAME"
+        --comment="$JOB_NAME"
+        --partition="$PARTITION"
+        --array="1-${TOTAL}%${CONCURRENCY}"
+        --cpus-per-task="$CPUS_PER_TASK"
+        --mem="$MEM"
+        --time="${SLURM_TIME}"
+        --output="$RESULTS_DIR/logs/slurm-%A_%a.out"
+        --parsable
+    )
+    # --tmp stays opt-in: idle nodes on this cluster advertise TmpDisk=0 even
+    # though /tmp exists, and a non-empty value makes the array un-schedulable.
+    [[ -n "$TMP" ]] && SBATCH_ARGS+=(--tmp="$TMP")
+
+    JOB_ID=$(sbatch "${SBATCH_ARGS[@]}" "$SCRIPT_SELF" \
+        --resume-dir "$RESULTS_DIR" --timeout "$TIMEOUT_MIN" --sample "$SAMPLE_ROWS")
+    echo "submitted array job $JOB_ID"
+    echo "watch   : squeue -u \$USER -n $JOB_NAME"
+    echo "summary : bash validation/impact_sweep.sh --summary --resume-dir $RESULTS_DIR"
+    echo "hits    : bash validation/impact_sweep.sh --hits --resume-dir $RESULTS_DIR"
+    exit 0
+fi
+
+# ---------- tooling ----------
+if ! command -v vdb-dump >/dev/null 2>&1; then
+    if declare -F module >/dev/null 2>&1 || [[ -f /etc/profile.d/modules.sh ]]; then
+        # shellcheck disable=SC1091
+        source /etc/profile.d/modules.sh 2>/dev/null || true
+        module load sratoolkit/3.2.1 2>/dev/null || true
+    fi
+fi
+VDB_DUMP="$(command -v vdb-dump || true)"
+[[ -z "$VDB_DUMP" ]] && { echo "vdb-dump not found. Try: module load sratoolkit/3.2.1" >&2; exit 1; }
+
+# sra-tools wants a writable settings file; array tasks share $HOME, so give
+# each one its own to avoid concurrent first-run config writes racing.
+export NCBI_SETTINGS="${NCBI_SETTINGS:-${TMPDIR:-/tmp}/sracha-sweep-ncbi.${SLURM_ARRAY_JOB_ID:-$$}.${SLURM_ARRAY_TASK_ID:-0}.mkfg}"
+
+# Array tasks append concurrently, so serialise on a lock file. flock is
+# Linux/util-linux; on a dev mac it is simply absent, and a serial run has no
+# concurrent writers to protect anyway.
+if command -v flock >/dev/null 2>&1; then
+    record() {
+        flock -x 200
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$@" >> "$RESULTS_TSV"
+        flock -u 200
+    } 200>"$RESULTS_LOCK"
+else
+    record() {
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$@" >> "$RESULTS_TSV"
+    }
+fi
+
+# ---------- the classifier ----------
+#
+# Reproduces the filter/routing rules from crates/sracha-core/src/fastq/mod.rs
+# under default options (skip technical, no --min-read-len):
+#
+#   kept(i)  = READ_LEN[i] > 0 AND READ_TYPE[i] is biological
+#
+#   split-files changes iff some kept slot i has a dropped slot j < i.
+#     Old code numbered by position among survivors, new code by slot, so the
+#     two differ exactly when something ahead of a survivor was dropped.
+#
+#   split-3 changes iff a spot has >= 3 kept biological reads.
+#     Old rule was `== 2 -> _1/_2, else unpaired`; new rule is
+#     `>= 2 -> _1.._N`, so only the 3+ case moves.
+#
+#   orientation_bits: READ_TYPE carries FORWARD/REVERSE. The old `rtype != 0`
+#     test read those as technical, so these runs change content, not just
+#     filenames.
+#
+# A missing READ_TYPE column means "all biological", matching the decoder's
+# fallback and fasterq-dump's `num_read_type > read_id_0` guard.
+classify_stream() {
+    awk -F'\t' '
+    {
+        nl = split($1, L, /[, ]+/)
+        nt = split($2, T, /[, ]+/)
+        kept = 0; dropped_before = 0; changed = 0
+        for (i = 1; i <= nl; i++) {
+            len = L[i] + 0
+            if (nt == 0) bio = 1
+            else bio = (T[i] ~ /BIOLOGICAL/) ? 1 : 0
+            if (nt > 0 && T[i] ~ /(FORWARD|REVERSE)/) orient = 1
+            if (len > 0 && !bio) tech = 1
+            if (len > 0 && bio) {
+                kept++
+                if (dropped_before) changed = 1
+            } else {
+                dropped_before = 1
+            }
+        }
+        if (changed) sf = 1
+        if (kept >= 3) s3 = 1
+        if (nl > maxn) maxn = nl
+        rows++
+    }
+    END { printf "%d\t%d\t%d\t%d\t%d\t%d\n", rows+0, maxn+0, sf+0, s3+0, orient+0, tech+0 }
+    '
+}
+
+process_accession() {
+    local acc="$1"
+    local log="$RESULTS_DIR/logs/${acc}.log"
+    local t0 secs spots info rows_arg out
+    t0=$(date +%s)
+
+    info=$(timeout "${TIMEOUT_MIN}m" "$VDB_DUMP" "$acc" --info 2>>"$log")
+    spots=$(awk -F': *' '/^SEQ/ {gsub(/[, ]/, "", $2); print $2}' <<< "$info")
+    if [[ -z "$spots" || "$spots" -lt 1 ]] 2>/dev/null; then
+        record "$acc" PROBE_ERR 0 0 0 0 0 0 0 "$(( $(date +%s) - t0 ))" "no SEQ row count from vdb-dump --info"
+        return
+    fi
+
+    rows_arg=""
+    if (( SAMPLE_ROWS > 0 )); then
+        # Evenly spaced offsets including both ends.
+        rows_arg=$(awk -v n="$spots" -v k="$SAMPLE_ROWS" 'BEGIN {
+            if (k > n) k = n
+            for (i = 0; i < k; i++) printf "%s%d", (i ? "," : ""), 1 + int(i * (n - 1) / (k > 1 ? k - 1 : 1))
+        }')
+    fi
+
+    # Runs with no physical READ_TYPE column make the two-column form fail;
+    # fall back to READ_LEN alone, which the classifier reads as all-biological.
+    if [[ -n "$rows_arg" ]]; then
+        out=$(timeout "${TIMEOUT_MIN}m" "$VDB_DUMP" "$acc" -R "$rows_arg" -C READ_LEN,READ_TYPE -f tab 2>>"$log" | classify_stream)
+        [[ "${out%%$'\t'*}" == "0" ]] && out=$(timeout "${TIMEOUT_MIN}m" "$VDB_DUMP" "$acc" -R "$rows_arg" -C READ_LEN -f tab 2>>"$log" | classify_stream)
+    else
+        out=$(timeout "${TIMEOUT_MIN}m" "$VDB_DUMP" "$acc" -C READ_LEN,READ_TYPE -f tab 2>>"$log" | classify_stream)
+        [[ "${out%%$'\t'*}" == "0" ]] && out=$(timeout "${TIMEOUT_MIN}m" "$VDB_DUMP" "$acc" -C READ_LEN -f tab 2>>"$log" | classify_stream)
+    fi
+
+    secs=$(( $(date +%s) - t0 ))
+    IFS=$'\t' read -r rows maxn sf s3 orient tech <<< "$out"
+
+    if [[ -z "${rows:-}" || "$rows" == "0" ]]; then
+        record "$acc" PROBE_ERR "$spots" 0 0 0 0 0 0 "$secs" "vdb-dump produced no rows"
+        return
+    fi
+
+    local class=UNAFFECTED
+    if (( sf && s3 )); then class="SPLIT_FILES+SPLIT3"
+    elif (( sf )); then class="SPLIT_FILES"
+    elif (( s3 )); then class="SPLIT3"
+    elif (( orient )); then class="READTYPE_ORIENTATION"
+    fi
+
+    local note="-"
+    (( SAMPLE_ROWS > 0 )) && note="sampled ${rows}/${spots} rows"
+
+    record "$acc" "$class" "$spots" "$maxn" "$sf" "$s3" "$orient" "$tech" "$rows" "$secs" "$note"
+    # Keep logs only for genuine problems.
+    [[ "$class" != "PROBE_ERR" ]] && rm -f "$log"
+}
+
+# ---------- dispatch ----------
+if [[ -n "${SLURM_ARRAY_TASK_ID:-}" ]]; then
+    ACC=$(awk 'NF && !/^#/' "$ACC_LIST" | sed -n "${SLURM_ARRAY_TASK_ID}p")
+    [[ -z "$ACC" ]] && { echo "no accession at index $SLURM_ARRAY_TASK_ID" >&2; exit 1; }
+    echo "# array task $SLURM_ARRAY_TASK_ID on $(hostname) -> $ACC"
+    process_accession "$ACC"
+    exit 0
+fi
+
+# Serial mode: skip accessions already recorded so an interrupted run resumes.
+declare -A DONE=()
+while IFS=$'\t' read -r a _rest; do
+    [[ "$a" == "accession" ]] && continue
+    DONE["$a"]=1
+done < "$RESULTS_TSV"
+
+while read -r acc; do
+    [[ -z "$acc" || "$acc" == \#* ]] && continue
+    [[ -n "${DONE[$acc]:-}" ]] && { echo "skip $acc (already recorded)"; continue; }
+    echo "-> $acc"
+    process_accession "$acc"
+done < <(awk 'NF && !/^#/' "$ACC_LIST")
+
+print_summary


### PR DESCRIPTION
Cluster tooling to answer "how many accessions does #77 actually change?" before we tag a release that renames output files. Two phases, both extending the `random_corpus.sh` conventions.

## Phase 1 — `validation/impact_sweep.sh` (classification, no downloads)

Deciding whether a run is *affected* only needs READ_LEN and READ_TYPE, and `vdb-dump` streams those over HTTP range requests. Measured: a six-offset probe on the 4.2 GB SRR18959644 returns in 4.3 s, and a full scan of all 44M rows takes a few minutes — versus gigabytes and minutes per accession for the download-and-diff harness.

Classifies each run by replaying the decoder's filter rules:

| class | condition |
| --- | --- |
| `SPLIT_FILES` | some kept slot has a dropped slot before it |
| `SPLIT3` | some spot has 3+ kept biological reads |
| `READTYPE_ORIENTATION` | READ_TYPE carries FORWARD/REVERSE bits |
| `UNAFFECTED` | none of the above |

`--hits` emits just the affected accessions, to pipe into Phase 2.

Two things worth flagging in review:

**The prober is `vdb-dump`, not sracha, on purpose.** What's being measured is sracha's own routing and READ_TYPE handling, so classifying with sracha's decoder would be circular — a decoder bug would hide exactly the runs that matter. That is not hypothetical: the READ_TYPE page-map bug in #77 went unnoticed until output was diffed against the archive's row count. #78 tracks giving sracha its own remote-inspection path; an independent oracle is still the right call here.

**Sampling is stratified by platform × `first_public` year.** The ENA portal returns rows in accession order and rejects `offset`, so a single query is badly skewed toward the earliest accessions — a naive 90-run draw came back 100% `DRR`. `sample_accessions.sh` has the same limitation (pool of 5000, then shuffle within it), which is fine for its purpose but not for a prevalence estimate. Rates are reported with a Wilson score interval so a handful of hits in a few hundred runs isn't over-read.

Full scan is the default rather than sampled offsets: SRR18959644 flips shape at its exact midpoint, which a coarse probe happens to catch, but a run flipping at 90% would slip past. `--sample N` is there for a fast first pass.

## Phase 2 — `validation/ab_corpus.sh` (three-way A/B)

`random_corpus.sh` answers "does sracha match fasterq-dump?". That's not quite the question when the change renames files, so this runs the pre-fix binary, the post-fix binary, and fasterq-dump over the same archive and records a verdict per accession per split mode:

`FIXED` · `UNCHANGED` · `CHANGED_OK` · `REGRESSED` · `STILL_BROKEN`

Comparison is over the **union** of produced basenames — slot-based numbering means a run can legitimately emit `_2` and `_4` with no `_1`/`_3`, so a fixed `_1`/`_2` pair would miss the change entirely. baseline-vs-candidate uses strict md5 ("did the bytes change"); the vs-fasterq comparisons keep `random_corpus.sh`'s defline tolerance via `compare_fastq.py`.

## Verified locally

Classifier, against shapes confirmed independently with `vdb-dump`:

- `UNAFFECTED` — SRR28588231 (`[301,301]`, both biological) and DRR059050 (`[151,0]`, uniformly). The second is the useful negative: a trailing empty slot does **not** change routing, since the survivor is in slot 0 either way. A naive "has a zero-length slot" screen would have called it a hit.
- `SPLIT_FILES` — DRR004435 (`[2,34]`, `[TECHNICAL, BIOLOGICAL]`) and the reported SRR18959644 / SRR18959653.

A/B, end to end:

- DRR004435 → `FIXED`. Baseline writes `DRR004435_1.fastq`, candidate and fasterq-dump both write `DRR004435_2.fastq`, byte-identical.
- SRR28588231 → `UNCHANGED`. SRR000001 → `REJECT_PLATFORM` (both binaries refuse LS454).

## Running it

```bash
# Phase 1
bash validation/impact_sweep.sh --sbatch -n 2000 --concurrency 40
bash validation/impact_sweep.sh --summary --resume-dir <DIR>
bash validation/impact_sweep.sh --hits --resume-dir <DIR> > hits.txt

# Phase 2 — needs both binaries; they cannot share target/release
git worktree add /tmp/sracha-base main
cargo build --release --manifest-path /tmp/sracha-base/Cargo.toml
cargo build --release          # candidate, on the #77 branch

bash validation/ab_corpus.sh --sbatch -a hits.txt \
    --baseline /tmp/sracha-base/target/release/sracha \
    --candidate target/release/sracha
```

`validation/` is gitignored, so both scripts needed `git add -f` — worth knowing before adding more there.

No production code touched; this is validation tooling only.
