### PR TITLE
feat(vdb): inspect remote archives over HTTP range requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Features
+
+- `sracha vdb` subcommands now accept an accession or URL as well as a local
+  path, reading the archive in place over HTTP range requests (#78).
+  `sracha vdb info SRR18959644` answers in ~1 s and ~256 KiB against a 4.2 GB
+  run. `dump` fetches only the blobs covering `-R`. Remote decode
+  (`sracha fastq`) is unchanged — it still needs a local file.
+
 ### Fixes
 
 - `--split-files` now numbers output files by each read's original slot

--- a/crates/sracha-core/Cargo.toml
+++ b/crates/sracha-core/Cargo.toml
@@ -24,7 +24,7 @@ libdeflater.workspace = true
 md-5.workspace = true
 memmap2.workspace = true
 rayon.workspace = true
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["blocking"] }
 serde.workspace = true
 serde_json.workspace = true
 sracha-vdb.workspace = true

--- a/crates/sracha-core/src/lib.rs
+++ b/crates/sracha-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod http;
 pub mod info;
 pub mod metadata;
 pub mod pipeline;
+pub mod remote;
 pub mod s3;
 pub mod sdl;
 pub mod util;

--- a/crates/sracha-core/src/remote.rs
+++ b/crates/sracha-core/src/remote.rs
@@ -1,0 +1,461 @@
+//! `Read + Seek` over an HTTP resource, backed by range requests.
+//!
+//! This exists so `sracha vdb` can inspect an archive that lives on NCBI's
+//! S3 mirror without downloading it. A KAR archive is laid out so that the
+//! answers to every inspection question — the TOC, then a handful of small
+//! column index files — sit in a few kilobytes scattered through a file
+//! that may be gigabytes long, which is exactly the access pattern range
+//! requests are for.
+//!
+//! Reads are served from a block cache: a miss fetches the aligned block(s)
+//! covering the request in a single `Range` GET, so the sequential
+//! `seek` + `read_exact` pattern `KarArchive` uses costs one round trip per
+//! new region rather than one per read.
+//!
+//! Deliberately blocking. [`sracha_vdb::kar::KarArchive`] is generic over
+//! `Read + Seek`, and the inspection paths are latency-bound rather than
+//! throughput-bound, so an async reader would buy nothing and force a
+//! parallel set of decode entry points. The client owns a private runtime
+//! on its own thread (`reqwest::blocking`), so constructing one inside an
+//! async context is safe — call it from `spawn_blocking` to avoid parking
+//! a runtime worker.
+
+use std::collections::HashMap;
+use std::io::{self, Read, Seek, SeekFrom};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+/// Cache block size. Sized so that the cluster of `idx`/`idx1`/`idx2`
+/// files belonging to one column usually lands in a single fetch, while
+/// still being small enough that a metadata-only command stays in the tens
+/// of kilobytes.
+const BLOCK_SIZE: u64 = 64 * 1024;
+
+/// Upper bound on cached blocks (~32 MiB). Blocks past this are evicted in
+/// insertion order, which suits the forward-ish walk of a TOC scan.
+const MAX_CACHED_BLOCKS: usize = 512;
+
+/// Matches `download::MAX_RETRIES` — transient 5xx and connection resets
+/// on NCBI's mirror are common enough to be worth retrying, rare enough
+/// that three attempts is plenty.
+const MAX_RETRIES: u32 = 3;
+
+/// Counts bytes actually pulled over the wire.
+///
+/// Shared with the caller so a test can assert that an inspection command
+/// stays proportional to the metadata it reads rather than to the archive
+/// size — the regression this whole module exists to prevent.
+#[derive(Debug, Clone, Default)]
+pub struct TransferStats(Arc<Inner>);
+
+#[derive(Debug, Default)]
+struct Inner {
+    bytes: AtomicU64,
+    requests: AtomicU64,
+}
+
+impl TransferStats {
+    /// Total response-body bytes received.
+    pub fn bytes_fetched(&self) -> u64 {
+        self.0.bytes.load(Ordering::Relaxed)
+    }
+
+    /// Number of HTTP requests issued, including the initial HEAD.
+    pub fn requests(&self) -> u64 {
+        self.0.requests.load(Ordering::Relaxed)
+    }
+}
+
+/// A seekable reader over an HTTP resource that supports byte ranges.
+pub struct HttpRangeReader {
+    client: reqwest::blocking::Client,
+    url: String,
+    len: u64,
+    pos: u64,
+    blocks: HashMap<u64, Arc<[u8]>>,
+    /// Block indices in insertion order, for eviction.
+    order: std::collections::VecDeque<u64>,
+    stats: TransferStats,
+}
+
+impl HttpRangeReader {
+    /// Open `url`, learning its length from a HEAD request.
+    ///
+    /// Fails if the server does not advertise `Accept-Ranges: bytes`;
+    /// without ranges every read would pull the whole object and the
+    /// caller is better off downloading it properly.
+    pub fn open(url: &str) -> io::Result<Self> {
+        Self::with_stats(url, TransferStats::default())
+    }
+
+    /// Same as [`open`](Self::open), but reporting transfer volume into a
+    /// caller-owned [`TransferStats`].
+    pub fn with_stats(url: &str, stats: TransferStats) -> io::Result<Self> {
+        let client = reqwest::blocking::Client::builder()
+            .user_agent(format!("sracha/{}", env!("CARGO_PKG_VERSION")))
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(60))
+            .build()
+            .map_err(io::Error::other)?;
+
+        stats.0.requests.fetch_add(1, Ordering::Relaxed);
+        let resp = client.head(url).send().map_err(io::Error::other)?;
+        if !resp.status().is_success() {
+            return Err(io::Error::other(format!(
+                "HEAD {url} returned HTTP {}",
+                resp.status()
+            )));
+        }
+
+        let supports_range = resp
+            .headers()
+            .get(reqwest::header::ACCEPT_RANGES)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| v.contains("bytes"));
+        if !supports_range {
+            return Err(io::Error::other(format!(
+                "{url} does not advertise Accept-Ranges: bytes; \
+                 remote inspection needs range support"
+            )));
+        }
+
+        let len = resp
+            .headers()
+            .get(reqwest::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok())
+            .ok_or_else(|| io::Error::other(format!("missing Content-Length for {url}")))?;
+
+        tracing::debug!("remote archive {url}: {len} bytes, range requests supported");
+
+        Ok(Self {
+            client,
+            url: url.to_string(),
+            len,
+            pos: 0,
+            blocks: HashMap::new(),
+            order: std::collections::VecDeque::new(),
+            stats,
+        })
+    }
+
+    /// Total size of the remote object.
+    pub fn len(&self) -> u64 {
+        self.len
+    }
+
+    /// Whether the remote object is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Transfer counters for this reader.
+    pub fn stats(&self) -> &TransferStats {
+        &self.stats
+    }
+
+    /// Fetch `[start, start + len)` with retries and exponential backoff.
+    fn fetch(&self, start: u64, len: u64) -> io::Result<Vec<u8>> {
+        let end = start + len - 1;
+        let range = format!("bytes={start}-{end}");
+        let mut last: Option<io::Error> = None;
+
+        for attempt in 0..MAX_RETRIES {
+            if attempt > 0 {
+                let backoff = Duration::from_millis(200 << (attempt - 1));
+                tracing::debug!(
+                    "retrying range {range} of {} (attempt {}/{MAX_RETRIES}), backoff {backoff:?}",
+                    self.url,
+                    attempt + 1,
+                );
+                std::thread::sleep(backoff);
+            }
+
+            self.stats.0.requests.fetch_add(1, Ordering::Relaxed);
+            match self.try_fetch(&range) {
+                Ok(bytes) => {
+                    self.stats
+                        .0
+                        .bytes
+                        .fetch_add(bytes.len() as u64, Ordering::Relaxed);
+                    return Ok(bytes);
+                }
+                Err(e) => last = Some(e),
+            }
+        }
+
+        Err(last.unwrap_or_else(|| io::Error::other("range request failed")))
+    }
+
+    fn try_fetch(&self, range: &str) -> io::Result<Vec<u8>> {
+        let resp = self
+            .client
+            .get(&self.url)
+            .header(reqwest::header::RANGE, range)
+            .send()
+            .map_err(io::Error::other)?;
+
+        // Require 206. A server that ignored the Range header and replied
+        // 200 would hand us the whole archive, which we would then splice
+        // in at the wrong offset — silent corruption, and the transfer we
+        // were trying to avoid.
+        if resp.status() != reqwest::StatusCode::PARTIAL_CONTENT {
+            return Err(io::Error::other(format!(
+                "range request {range} returned HTTP {} (expected 206)",
+                resp.status()
+            )));
+        }
+
+        resp.bytes()
+            .map(|b| b.to_vec())
+            .map_err(|e| io::Error::other(format!("reading range {range}: {e}")))
+    }
+
+    /// Return the cached block `idx`, fetching it (with any adjacent
+    /// missing blocks up to `through`) if absent.
+    fn block(&mut self, idx: u64, through: u64) -> io::Result<Arc<[u8]>> {
+        if let Some(b) = self.blocks.get(&idx) {
+            return Ok(b.clone());
+        }
+
+        // Extend the fetch over the contiguous run of missing blocks the
+        // caller is about to ask for, so one read_exact spanning several
+        // blocks costs one request rather than one per block.
+        let mut last = idx;
+        while last < through && !self.blocks.contains_key(&(last + 1)) {
+            last += 1;
+        }
+
+        let start = idx * BLOCK_SIZE;
+        let end = ((last + 1) * BLOCK_SIZE).min(self.len);
+        let bytes = self.fetch(start, end - start)?;
+
+        let mut wanted = None;
+        for (i, chunk) in bytes.chunks(BLOCK_SIZE as usize).enumerate() {
+            let block_idx = idx + i as u64;
+            let block: Arc<[u8]> = Arc::from(chunk);
+            if block_idx == idx {
+                wanted = Some(block.clone());
+            }
+            if self.blocks.insert(block_idx, block).is_none() {
+                self.order.push_back(block_idx);
+            }
+        }
+        while self.order.len() > MAX_CACHED_BLOCKS {
+            if let Some(evict) = self.order.pop_front() {
+                self.blocks.remove(&evict);
+            }
+        }
+
+        wanted.ok_or_else(|| io::Error::other("short range response"))
+    }
+}
+
+impl Read for HttpRangeReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.pos >= self.len || buf.is_empty() {
+            return Ok(0);
+        }
+        let want = (buf.len() as u64).min(self.len - self.pos);
+        let idx = self.pos / BLOCK_SIZE;
+        let last = (self.pos + want - 1) / BLOCK_SIZE;
+
+        let block = self.block(idx, last)?;
+        let off = (self.pos - idx * BLOCK_SIZE) as usize;
+        // One block per call; `read_exact` loops for the rest, and the
+        // read-ahead in `block` means those iterations are cache hits.
+        let n = (block.len() - off).min(want as usize);
+        buf[..n].copy_from_slice(&block[off..off + n]);
+        self.pos += n as u64;
+        Ok(n)
+    }
+}
+
+impl Seek for HttpRangeReader {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        let new = match pos {
+            SeekFrom::Start(n) => n as i64,
+            SeekFrom::Current(d) => self.pos as i64 + d,
+            SeekFrom::End(d) => self.len as i64 + d,
+        };
+        if new < 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "seek to a negative position",
+            ));
+        }
+        self.pos = new as u64;
+        Ok(self.pos)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::{TcpListener, TcpStream};
+
+    /// Minimal HTTP/1.1 server that understands HEAD and single-range GET.
+    ///
+    /// Hand-rolled rather than wiremock because the reader under test is
+    /// blocking and wiremock is async — driving one from the other in a
+    /// test buys more complexity than the ~40 lines here.
+    fn serve(body: Vec<u8>) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else { break };
+                if !handle_one(stream, &body) {
+                    break;
+                }
+            }
+        });
+        (format!("http://{addr}/archive.sra"), handle)
+    }
+
+    /// Returns false when the client asked us to stop.
+    fn handle_one(mut stream: TcpStream, body: &[u8]) -> bool {
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut request_line = String::new();
+        if reader.read_line(&mut request_line).is_err() || request_line.is_empty() {
+            return true;
+        }
+        let mut range = None;
+        loop {
+            let mut line = String::new();
+            if reader.read_line(&mut line).unwrap_or(0) == 0 || line == "\r\n" {
+                break;
+            }
+            if let Some(v) = line.to_ascii_lowercase().strip_prefix("range: bytes=") {
+                let v = v.trim().to_string();
+                let (a, b) = v.split_once('-').unwrap();
+                range = Some((
+                    a.parse::<usize>().unwrap(),
+                    b.parse::<usize>().unwrap_or(body.len() - 1),
+                ));
+            }
+        }
+
+        if request_line.starts_with("SHUTDOWN") {
+            return false;
+        }
+
+        if request_line.starts_with("HEAD") {
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(head.as_bytes());
+            return true;
+        }
+
+        let (start, end) = range.unwrap_or((0, body.len() - 1));
+        let end = end.min(body.len() - 1);
+        let slice = &body[start..=end];
+        let head = format!(
+            "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\n\
+             Content-Range: bytes {start}-{end}/{}\r\nConnection: close\r\n\r\n",
+            slice.len(),
+            body.len()
+        );
+        let _ = stream.write_all(head.as_bytes());
+        let _ = stream.write_all(slice);
+        true
+    }
+
+    fn shutdown(url: &str) {
+        let addr = url.trim_start_matches("http://");
+        let addr = addr.split('/').next().unwrap();
+        if let Ok(mut s) = TcpStream::connect(addr) {
+            let _ = s.write_all(b"SHUTDOWN / HTTP/1.1\r\n\r\n");
+        }
+    }
+
+    fn body(len: usize) -> Vec<u8> {
+        (0..len).map(|i| (i % 251) as u8).collect()
+    }
+
+    #[test]
+    fn reads_a_slice_from_the_middle() {
+        let data = body(300_000);
+        let (url, handle) = serve(data.clone());
+
+        let mut r = HttpRangeReader::open(&url).unwrap();
+        assert_eq!(r.len(), 300_000);
+        r.seek(SeekFrom::Start(100_000)).unwrap();
+        let mut buf = vec![0u8; 4096];
+        r.read_exact(&mut buf).unwrap();
+        assert_eq!(buf, data[100_000..104_096]);
+
+        shutdown(&url);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn a_small_read_transfers_one_block_not_the_file() {
+        let data = body(4 * 1024 * 1024);
+        let (url, handle) = serve(data.clone());
+
+        let mut r = HttpRangeReader::open(&url).unwrap();
+        let mut buf = [0u8; 24];
+        r.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, &data[..24]);
+        assert_eq!(r.stats().bytes_fetched(), BLOCK_SIZE);
+
+        shutdown(&url);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn repeat_reads_of_a_cached_region_cost_nothing() {
+        let data = body(300_000);
+        let (url, handle) = serve(data.clone());
+
+        let mut r = HttpRangeReader::open(&url).unwrap();
+        let mut buf = vec![0u8; 1000];
+        r.read_exact(&mut buf).unwrap();
+        let after_first = r.stats().bytes_fetched();
+
+        for _ in 0..5 {
+            r.seek(SeekFrom::Start(0)).unwrap();
+            r.read_exact(&mut buf).unwrap();
+        }
+        assert_eq!(r.stats().bytes_fetched(), after_first);
+
+        shutdown(&url);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn a_read_spanning_blocks_is_one_request() {
+        let data = body(1024 * 1024);
+        let (url, handle) = serve(data.clone());
+
+        let mut r = HttpRangeReader::open(&url).unwrap();
+        let before = r.stats().requests();
+        let mut buf = vec![0u8; (BLOCK_SIZE * 3) as usize];
+        r.read_exact(&mut buf).unwrap();
+        assert_eq!(buf, data[..buf.len()]);
+        assert_eq!(r.stats().requests() - before, 1);
+
+        shutdown(&url);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn reads_clamp_at_end_of_file() {
+        let data = body(1000);
+        let (url, handle) = serve(data.clone());
+
+        let mut r = HttpRangeReader::open(&url).unwrap();
+        r.seek(SeekFrom::End(-10)).unwrap();
+        let mut buf = Vec::new();
+        r.read_to_end(&mut buf).unwrap();
+        assert_eq!(buf, data[990..]);
+
+        shutdown(&url);
+        handle.join().unwrap();
+    }
+}

--- a/crates/sracha-core/tests/remote_vdb.rs
+++ b/crates/sracha-core/tests/remote_vdb.rs
@@ -1,0 +1,259 @@
+//! End-to-end checks for remote `vdb` inspection over HTTP range requests.
+//!
+//! The point of the feature is that inspecting an archive should cost
+//! kilobytes, not the archive's size, and should give the same answers as
+//! inspecting a local copy. Both are asserted here against a real SRA
+//! fixture served over a loopback HTTP server.
+//!
+//! Marked `#[ignore]` because the fixture is downloaded from NCBI on first
+//! run. Run with:
+//!
+//! ```bash
+//! cargo nextest run -p sracha-core --run-ignored=ignored-only -E 'test(remote_vdb)'
+//! ```
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::fs::FileExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::Once;
+
+use sracha_core::remote::{HttpRangeReader, TransferStats};
+use sracha_core::vdb::dump::{self, DumpFormat, DumpSpec};
+use sracha_core::vdb::inspect;
+use sracha_core::vdb::kar::KarArchive;
+use sracha_core::vdb::kdb::ColumnData;
+use sracha_core::vdb::row_range::RowRanges;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+/// Ensure the SRR28588231 fixture (Illumina paired-end SRA-Lite, ~23 MiB).
+/// Mirrors `pipeline.rs::ensure_srr28588231` — cargo does not order test
+/// binaries, so each one fetches for itself.
+fn ensure_srr28588231() -> PathBuf {
+    static DOWNLOAD: Once = Once::new();
+    let path = fixtures_dir().join("SRR28588231.sra");
+
+    DOWNLOAD.call_once(|| {
+        if path.exists() {
+            return;
+        }
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let url = "https://sra-pub-run-odp.s3.amazonaws.com/sra/SRR28588231/SRR28588231";
+        eprintln!("downloading SRR28588231 fixture from {url} ...");
+        let resp = reqwest::blocking::get(url)
+            .unwrap_or_else(|e| panic!("failed to download SRR28588231: {e}"));
+        assert!(resp.status().is_success(), "HTTP {}", resp.status());
+        std::fs::write(&path, resp.bytes().unwrap()).unwrap();
+    });
+
+    assert!(path.exists(), "fixture not found at {}", path.display());
+    path
+}
+
+// ---------------------------------------------------------------------------
+// A loopback HTTP server that serves one file with byte-range support
+// ---------------------------------------------------------------------------
+
+struct Server {
+    url: String,
+    addr: std::net::SocketAddr,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        // The accept loop is single-threaded and serves one request per
+        // connection, so the stop signal has to be its own late connection
+        // rather than a socket held open for the server's lifetime.
+        if let Ok(mut s) = TcpStream::connect(self.addr) {
+            let _ = s.write_all(b"SHUTDOWN / HTTP/1.1\r\n\r\n");
+        }
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+fn serve(path: &Path) -> Server {
+    let file = Arc::new(File::open(path).unwrap());
+    let len = file.metadata().unwrap().len();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let handle = std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { break };
+            if !handle_one(stream, &file, len) {
+                break;
+            }
+        }
+    });
+
+    Server {
+        url: format!("http://{addr}/SRR28588231"),
+        addr,
+        handle: Some(handle),
+    }
+}
+
+/// Returns false once the client asks the server to stop.
+fn handle_one(mut stream: TcpStream, file: &File, len: u64) -> bool {
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).unwrap_or(0) == 0 {
+        return true;
+    }
+
+    let mut range = None;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).unwrap_or(0) == 0 || line == "\r\n" {
+            break;
+        }
+        if let Some(v) = line.to_ascii_lowercase().strip_prefix("range: bytes=") {
+            let v = v.trim().to_string();
+            let (a, b) = v.split_once('-').unwrap();
+            range = Some((
+                a.parse::<u64>().unwrap(),
+                b.parse::<u64>().unwrap_or(len - 1),
+            ));
+        }
+    }
+
+    if request_line.starts_with("SHUTDOWN") {
+        return false;
+    }
+
+    if request_line.starts_with("HEAD") {
+        let head = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {len}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n"
+        );
+        let _ = stream.write_all(head.as_bytes());
+        return true;
+    }
+
+    let (start, end) = range.unwrap_or((0, len - 1));
+    let end = end.min(len - 1);
+    let mut buf = vec![0u8; (end - start + 1) as usize];
+    file.read_exact_at(&mut buf, start).unwrap();
+    let head = format!(
+        "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\n\
+         Content-Range: bytes {start}-{end}/{len}\r\nConnection: close\r\n\r\n",
+        buf.len()
+    );
+    let _ = stream.write_all(head.as_bytes());
+    let _ = stream.write_all(&buf);
+    true
+}
+
+fn open_remote(url: &str) -> (KarArchive<HttpRangeReader>, TransferStats) {
+    let stats = TransferStats::default();
+    let reader = HttpRangeReader::with_stats(url, stats.clone()).unwrap();
+    (KarArchive::open(reader).unwrap(), stats)
+}
+
+fn open_local(path: &Path) -> KarArchive<BufReader<File>> {
+    KarArchive::open(BufReader::new(File::open(path).unwrap())).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore] // requires network on first run; cached thereafter
+fn remote_vdb_info_matches_local_and_stays_small() {
+    let path = ensure_srr28588231();
+    let archive_size = std::fs::metadata(&path).unwrap().len();
+    let server = serve(&path);
+
+    let mut local = open_local(&path);
+    let expected = inspect::gather_info(&mut local, ColumnData::Local(&path)).unwrap();
+
+    let (mut remote, stats) = open_remote(&server.url);
+    let actual = inspect::gather_info(&mut remote, ColumnData::Ranged).unwrap();
+
+    assert_eq!(actual.kind, expected.kind);
+    assert_eq!(actual.schema_name, expected.schema_name);
+    assert_eq!(actual.platform, expected.platform);
+    assert_eq!(actual.tables, expected.tables);
+    assert!(
+        expected.primary_row_count().unwrap() > 0,
+        "fixture should have rows"
+    );
+
+    // The regression this guards: any change that reintroduces whole-file
+    // reads turns a ~100 KiB inspection back into a 23 MiB download.
+    let fetched = stats.bytes_fetched();
+    assert!(
+        fetched < archive_size / 20,
+        "vdb info transferred {fetched} bytes of a {archive_size}-byte archive; \
+         metadata-only commands must stay a small fraction of the file"
+    );
+    eprintln!("vdb info: {fetched} bytes in {} requests", stats.requests());
+}
+
+#[test]
+#[ignore] // requires network on first run; cached thereafter
+fn remote_vdb_id_range_matches_local() {
+    let path = ensure_srr28588231();
+    let server = serve(&path);
+
+    let mut local = open_local(&path);
+    let expected = inspect::id_range(&mut local, ColumnData::Local(&path), None, None).unwrap();
+
+    let (mut remote, stats) = open_remote(&server.url);
+    let actual = inspect::id_range(&mut remote, ColumnData::Ranged, None, None).unwrap();
+
+    assert_eq!(actual, expected);
+    eprintln!(
+        "vdb id-range: {} bytes in {} requests",
+        stats.bytes_fetched(),
+        stats.requests()
+    );
+}
+
+#[test]
+#[ignore] // requires network on first run; cached thereafter
+fn remote_vdb_dump_matches_local_for_a_row_range() {
+    let path = ensure_srr28588231();
+    let archive_size = std::fs::metadata(&path).unwrap().len();
+    let server = serve(&path);
+
+    // SRR28588231 is SRA-Lite (no physical QUALITY column), so dump the
+    // columns that are actually on disk.
+    let spec = || DumpSpec {
+        columns: vec!["READ".into(), "X".into(), "Y".into()],
+        exclude: Vec::new(),
+        rows: RowRanges::parse("1-5").unwrap(),
+        format: DumpFormat::Json,
+        raw: false,
+    };
+
+    let mut local = open_local(&path);
+    let expected = dump::dump_to_vec(&mut local, ColumnData::Local(&path), None, spec()).unwrap();
+
+    let (mut remote, stats) = open_remote(&server.url);
+    let actual = dump::dump_to_vec(&mut remote, ColumnData::Ranged, None, spec()).unwrap();
+
+    assert_eq!(
+        std::str::from_utf8(&actual).unwrap(),
+        std::str::from_utf8(&expected).unwrap(),
+        "remote dump output must be identical to the local one"
+    );
+
+    let fetched = stats.bytes_fetched();
+    assert!(
+        fetched < archive_size / 4,
+        "dumping 5 rows transferred {fetched} bytes of a {archive_size}-byte archive"
+    );
+    eprintln!(
+        "vdb dump -R 1-5: {fetched} bytes in {} requests",
+        stats.requests()
+    );
+}

--- a/crates/sracha-vdb/src/dump.rs
+++ b/crates/sracha-vdb/src/dump.rs
@@ -16,7 +16,6 @@
 
 use std::collections::HashSet;
 use std::io::{Read, Seek, Write};
-use std::path::Path;
 
 use serde_json::{Value, json};
 
@@ -28,7 +27,7 @@ use crate::encoding::{phred_to_ascii, unpack_2na, unpack_4na};
 use crate::error::{Error, Result};
 use crate::inspect::{column_base_path_public, detect_kind, list_columns};
 use crate::kar::KarArchive;
-use crate::kdb::ColumnReader;
+use crate::kdb::{ColumnData, ColumnReader, RowWindow};
 use crate::row_range::RowRanges;
 
 // ---------------------------------------------------------------------------
@@ -173,7 +172,7 @@ impl<R: Read + Seek> DumpRunner<R> {
     /// Open the requested columns in the archive and prepare to iterate.
     pub fn new(
         archive: &mut KarArchive<R>,
-        sra_path: &Path,
+        data: ColumnData<'_>,
         table: Option<&str>,
         spec: DumpSpec,
     ) -> Result<Self> {
@@ -188,10 +187,15 @@ impl<R: Read + Seek> DumpRunner<R> {
             ));
         }
 
+        // Each column resolves the requested rows against its own row
+        // range, so a range-backed archive transfers only the blobs those
+        // rows land in. An empty `-R` still means every row.
+        let window = RowWindow::Rows(spec.rows.clone());
+
         let mut cols = Vec::with_capacity(requested.len());
         for name in &requested {
             let full = format!("{col_base}/{name}");
-            match ColumnReader::open(archive, &full, sra_path) {
+            match ColumnReader::open_windowed(archive, &full, data, &window) {
                 Ok(reader) => {
                     let kind = if spec.raw {
                         CellKind::HexRaw
@@ -865,11 +869,11 @@ fn write_hex<W: Write>(w: &mut W, bytes: &[u8]) -> Result<()> {
 /// against a `Vec<u8>` writer.
 pub fn dump_to_vec<R: Read + Seek>(
     archive: &mut KarArchive<R>,
-    sra_path: &Path,
+    data: ColumnData<'_>,
     table: Option<&str>,
     spec: DumpSpec,
 ) -> Result<Vec<u8>> {
-    let mut runner = DumpRunner::new(archive, sra_path, table, spec)?;
+    let mut runner = DumpRunner::new(archive, data, table, spec)?;
     let mut buf = Vec::new();
     runner.run(&mut buf)?;
     Ok(buf)

--- a/crates/sracha-vdb/src/inspect.rs
+++ b/crates/sracha-vdb/src/inspect.rs
@@ -6,12 +6,11 @@
 //! `vdb-dump` modes: `--info`, `-E`, `-o`, `-A`, `-r`).
 
 use std::io::{Read, Seek};
-use std::path::Path;
 
 use crate::blob::decode_blob;
 use crate::error::{Error, Result};
 use crate::kar::{KarArchive, KarEntry};
-use crate::kdb::ColumnReader;
+use crate::kdb::{ColumnData, ColumnReader, RowWindow};
 use crate::metadata::{self, MetaNode, SoftwareEvent};
 
 /// Whether a VDB archive is a Database (has `tbl/` subdirectories) or a
@@ -171,7 +170,7 @@ pub struct FirstBlobStats {
 /// Collect per-column stats for every column in a table.
 pub fn column_stats_all<R: Read + Seek>(
     archive: &mut KarArchive<R>,
-    sra_path: &Path,
+    data: ColumnData<'_>,
     table: Option<&str>,
 ) -> Result<Vec<ColumnStats>> {
     let cols = list_columns(archive, table)?;
@@ -179,7 +178,9 @@ pub fn column_stats_all<R: Read + Seek>(
     let mut out = Vec::with_capacity(cols.len());
     for col in cols {
         let full = format!("{col_base}/{col}");
-        match ColumnReader::open(archive, &full, sra_path) {
+        // Only the first blob is decoded for stats, so that is all a
+        // range-backed archive needs to transfer.
+        match ColumnReader::open_windowed(archive, &full, data, &RowWindow::First) {
             Ok(reader) => out.push(build_column_stats(col, &reader)),
             Err(e) => {
                 tracing::debug!("column_stats: skipping {full}: {e}");
@@ -224,7 +225,7 @@ fn build_column_stats(name: String, reader: &ColumnReader) -> ColumnStats {
 /// `vdb-dump --id_range` behavior of using whatever column is available.
 pub fn id_range<R: Read + Seek>(
     archive: &mut KarArchive<R>,
-    sra_path: &Path,
+    data: ColumnData<'_>,
     table: Option<&str>,
     column: Option<&str>,
 ) -> Result<(i64, u64)> {
@@ -239,7 +240,8 @@ pub fn id_range<R: Read + Seek>(
     };
 
     let col_full = format!("{col_base}/{column_name}");
-    let reader = ColumnReader::open(archive, &col_full, sra_path)?;
+    // Row bounds come entirely from the index files; no blob bytes needed.
+    let reader = ColumnReader::open_windowed(archive, &col_full, data, &RowWindow::None)?;
     let first = reader.first_row_id().unwrap_or(0);
     let count = reader.row_count();
     Ok((first, count))
@@ -250,10 +252,10 @@ pub fn id_range<R: Read + Seek>(
 /// Mirrors how vdb-dump fills `SEQ` etc. in `--info` output.
 pub fn table_row_count<R: Read + Seek>(
     archive: &mut KarArchive<R>,
-    sra_path: &Path,
+    data: ColumnData<'_>,
     table: Option<&str>,
 ) -> Result<u64> {
-    Ok(id_range(archive, sra_path, table, None)?.1)
+    Ok(id_range(archive, data, table, None)?.1)
 }
 
 /// Read and parse the metadata tree for a given table (or for the root in a
@@ -399,7 +401,7 @@ impl InfoReport {
 /// Collect everything needed for the `info` command.
 pub fn gather_info<R: Read + Seek>(
     archive: &mut KarArchive<R>,
-    sra_path: &Path,
+    data: ColumnData<'_>,
 ) -> Result<InfoReport> {
     let kind = detect_kind(archive)?;
 
@@ -453,13 +455,13 @@ pub fn gather_info<R: Read + Seek>(
             let names = list_tables(archive)?;
             let mut out = Vec::with_capacity(names.len());
             for name in names {
-                let count = table_row_count(archive, sra_path, Some(&name)).unwrap_or(0);
+                let count = table_row_count(archive, data, Some(&name)).unwrap_or(0);
                 out.push((name, count));
             }
             out
         }
         VdbKind::Table => {
-            let count = table_row_count(archive, sra_path, None).unwrap_or(0);
+            let count = table_row_count(archive, data, None).unwrap_or(0);
             vec![("SEQUENCE".into(), count)]
         }
     };
@@ -706,7 +708,7 @@ mod tests {
     fn column_stats_all_populates_first_blob() {
         let (bytes, sra_path) = single_column_kar();
         let mut kar = KarArchive::open(Cursor::new(bytes)).unwrap();
-        let stats = column_stats_all(&mut kar, &sra_path, None).unwrap();
+        let stats = column_stats_all(&mut kar, ColumnData::Local(&sra_path), None).unwrap();
         assert_eq!(stats.len(), 1);
         assert_eq!(stats[0].name, "READ");
         assert_eq!(stats[0].row_count, 1);

--- a/crates/sracha-vdb/src/kar.rs
+++ b/crates/sracha-vdb/src/kar.rs
@@ -389,6 +389,49 @@ impl<R: Read + Seek> KarArchive<R> {
         }
     }
 
+    /// Read a byte sub-range of a file in the archive.
+    ///
+    /// `offset` and `len` are relative to the start of the file entry, not
+    /// the archive. The request is clamped to the entry's size, so a caller
+    /// asking for more than is there gets a short buffer rather than an
+    /// error. Reading past the end of a file entry returns an empty vector.
+    ///
+    /// This exists so a range-backed reader (HTTP, object store) can pull
+    /// just the blobs it needs out of a multi-gigabyte `data` file instead
+    /// of the whole thing — see [`crate::kdb::ColumnReader::open_windowed`].
+    pub fn read_file_range(&mut self, path: &str, offset: u64, len: u64) -> Result<Vec<u8>> {
+        let entry = self
+            .entries
+            .get(path)
+            .ok_or_else(|| Error::InvalidKar(format!("file not found in archive: {path}")))?;
+
+        match entry {
+            KarEntry::File {
+                byte_offset,
+                byte_size,
+            } => {
+                if offset >= *byte_size {
+                    return Ok(Vec::new());
+                }
+                let avail = *byte_size - offset;
+                let size = len.min(avail) as usize;
+                let abs_offset = self.header.file_offset + byte_offset + offset;
+
+                self.reader.seek(SeekFrom::Start(abs_offset))?;
+                let mut buf = vec![0u8; size];
+                self.reader.read_exact(&mut buf)?;
+                Ok(buf)
+            }
+            KarEntry::EmptyFile => Ok(Vec::new()),
+            KarEntry::Directory => Err(Error::InvalidKar(format!(
+                "cannot read directory as file: {path}"
+            ))),
+            KarEntry::Softlink { .. } => Err(Error::InvalidKar(format!(
+                "cannot read softlink as file: {path}"
+            ))),
+        }
+    }
+
     /// Return the absolute byte offset and size of a file in the archive,
     /// without reading its contents.
     ///

--- a/crates/sracha-vdb/src/kdb.rs
+++ b/crates/sracha-vdb/src/kdb.rs
@@ -26,6 +26,7 @@ use byteorder::{ByteOrder, LittleEndian};
 
 use crate::error::{Error, Result};
 use crate::kar::KarArchive;
+use crate::row_range::RowRanges;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -150,6 +151,9 @@ pub struct BlockLoc {
 /// `OnDisk` stores the location of the data file within the SRA/KAR file
 /// so that individual blobs can be read on demand without loading the
 /// entire (potentially multi-GiB) data file into memory.
+/// `Windows` holds a sparse set of byte ranges fetched up front, for the
+/// case where the archive is behind a range-request reader and pulling the
+/// whole `data` file would defeat the point.
 enum DataSource {
     /// Data loaded in memory (for `from_parts` / selective fetch).
     InMemory(Vec<u8>),
@@ -163,7 +167,55 @@ enum DataSource {
         /// we map only the column's portion).
         _file_offset: u64,
     },
+    /// A sparse set of byte windows into the column's `data` file, fetched
+    /// eagerly when the reader was opened. Sorted by `start` and
+    /// non-overlapping, so a blob lookup is a binary search.
+    Windows(Vec<DataWindow>),
 }
+
+/// One contiguous stretch of a column's `data` file held in memory.
+struct DataWindow {
+    /// Byte offset of `bytes[0]` within the column's `data` file.
+    start: usize,
+    bytes: Vec<u8>,
+}
+
+/// Which rows' blob bytes a [`ColumnReader`] should fetch when it is opened
+/// against a range-backed archive.
+///
+/// Only meaningful for [`ColumnData::Ranged`] — a local mmap always covers
+/// the whole column, so the window is ignored there.
+#[derive(Debug, Clone, Default)]
+pub enum RowWindow {
+    /// Fetch nothing. The reader can report row counts, blob counts, and
+    /// column metadata, but [`ColumnReader::read_raw_blob_slice`] will fail.
+    #[default]
+    None,
+    /// Fetch only the first blob — enough for header/stats inspection.
+    First,
+    /// Fetch the blobs covering these rows, resolved against the column's
+    /// own row range. An empty `RowRanges` means every row.
+    Rows(RowRanges),
+    /// Fetch the entire `data` file.
+    All,
+}
+
+/// Where a column's `data` bytes come from.
+#[derive(Debug, Clone, Copy)]
+pub enum ColumnData<'a> {
+    /// A local archive file: mmap the column's data section. Zero-copy and
+    /// covers every blob, so [`RowWindow`] does not apply.
+    Local(&'a std::path::Path),
+    /// Read through the archive's own reader. Used when the archive is
+    /// backed by HTTP range requests, where only the requested
+    /// [`RowWindow`] is transferred.
+    Ranged,
+}
+
+/// Maximum gap between two wanted blobs that is still cheaper to swallow
+/// than to pay for a second round trip. Windows separated by less than this
+/// are merged into one fetch.
+const WINDOW_COALESCE_GAP: usize = 1 << 20;
 
 /// Reader for a single physical column within a KAR archive.
 ///
@@ -789,6 +841,31 @@ impl ColumnReader {
         col_path: &str,
         sra_path: &std::path::Path,
     ) -> Result<Self> {
+        Self::open_windowed(
+            archive,
+            col_path,
+            ColumnData::Local(sra_path),
+            &RowWindow::All,
+        )
+    }
+
+    /// Open a column, choosing where its `data` bytes come from.
+    ///
+    /// [`ColumnData::Local`] behaves exactly like [`open`](Self::open):
+    /// the column's data section is mmap'd and `window` is ignored.
+    ///
+    /// [`ColumnData::Ranged`] reads the index files through the archive's
+    /// own reader (as it always did) and then fetches only the byte windows
+    /// covering `window`. That keeps a remote archive's transfer
+    /// proportional to the rows actually asked for instead of to the file
+    /// size. Rows outside the window are not readable — `read_raw_blob_slice`
+    /// reports them rather than silently returning wrong bytes.
+    pub fn open_windowed<R: std::io::Read + Seek>(
+        archive: &mut KarArchive<R>,
+        col_path: &str,
+        data: ColumnData<'_>,
+        window: &RowWindow,
+    ) -> Result<Self> {
         let idx1_path = format!("{col_path}/idx1");
         let idx0_path = format!("{col_path}/idx0");
         let idx_path = format!("{col_path}/idx");
@@ -816,8 +893,8 @@ impl ColumnReader {
         // (the index files are small; only the data file is large).
         let mut reader = Self::from_parts(&idx1_buf, &idx0_buf, &idx_buf, &idx2_buf, Vec::new())?;
 
-        // Replace the InMemory(empty) data source with OnDisk if the data
-        // file exists in the archive.
+        // Replace the InMemory(empty) data source with the real one if the
+        // data file exists in the archive.
         if let Some((file_offset, file_size)) = data_location {
             // If no blob locators were found (from_parts skipped the
             // synthetic blob because data_bytes was empty), create one
@@ -828,21 +905,81 @@ impl ColumnReader {
                     .push(synthetic_single_blob(&reader.meta, file_size));
             }
 
-            let file = std::fs::File::open(sra_path)?;
-            let mmap = unsafe {
-                memmap2::MmapOptions::new()
-                    .offset(file_offset)
-                    .len(file_size as usize)
-                    .map(&file)
-                    .map_err(|e| Error::Format(format!("mmap failed: {e}")))?
-            };
-            reader.data = DataSource::Mmap {
-                mmap,
-                _file_offset: file_offset,
-            };
+            match data {
+                ColumnData::Local(sra_path) => {
+                    let file = std::fs::File::open(sra_path)?;
+                    let mmap = unsafe {
+                        memmap2::MmapOptions::new()
+                            .offset(file_offset)
+                            .len(file_size as usize)
+                            .map(&file)
+                            .map_err(|e| Error::Format(format!("mmap failed: {e}")))?
+                    };
+                    reader.data = DataSource::Mmap {
+                        mmap,
+                        _file_offset: file_offset,
+                    };
+                }
+                ColumnData::Ranged => {
+                    let ranges = reader.window_byte_ranges(window, file_size as usize);
+                    let mut windows = Vec::with_capacity(ranges.len());
+                    for (start, len) in ranges {
+                        let bytes =
+                            archive.read_file_range(&data_path, start as u64, len as u64)?;
+                        tracing::debug!(
+                            "{col_path}: fetched {} bytes at data+{start}",
+                            bytes.len()
+                        );
+                        windows.push(DataWindow { start, bytes });
+                    }
+                    reader.data = DataSource::Windows(windows);
+                }
+            }
         }
 
         Ok(reader)
+    }
+
+    /// Resolve a [`RowWindow`] to the coalesced byte ranges of the column's
+    /// `data` file that must be fetched to serve it.
+    fn window_byte_ranges(&self, window: &RowWindow, data_size: usize) -> Vec<(usize, usize)> {
+        let wanted: Vec<&BlobLoc> = match window {
+            RowWindow::None => Vec::new(),
+            RowWindow::All => return vec![(0, data_size)],
+            RowWindow::First => self.blobs.first().into_iter().collect(),
+            RowWindow::Rows(rows) if rows.is_empty() => return vec![(0, data_size)],
+            RowWindow::Rows(rows) => {
+                let first = self.first_row_id().unwrap_or(0);
+                let spans = rows.spans(first, self.row_count());
+                self.blobs
+                    .iter()
+                    .filter(|b| spans.iter().any(|&(lo, hi)| blob_overlaps(b, lo, hi)))
+                    .collect()
+            }
+        };
+
+        // Blobs are sorted by start_id, which need not be byte order, so
+        // sort by offset before coalescing.
+        let mut ranges: Vec<(usize, usize)> = wanted
+            .iter()
+            .map(|b| (self.blob_data_offset(b), b.size as usize))
+            .filter(|&(start, len)| len > 0 && start < data_size)
+            .map(|(start, len)| (start, len.min(data_size - start)))
+            .collect();
+        ranges.sort_unstable();
+
+        let mut out: Vec<(usize, usize)> = Vec::new();
+        for (start, len) in ranges {
+            match out.last_mut() {
+                Some((prev_start, prev_len))
+                    if start <= *prev_start + *prev_len + WINDOW_COALESCE_GAP =>
+                {
+                    *prev_len = (start + len).saturating_sub(*prev_start).max(*prev_len);
+                }
+                _ => out.push((start, len)),
+            }
+        }
+        out
     }
 
     /// Read the raw (unprocessed) blob bytes for a given row ID.
@@ -881,6 +1018,22 @@ impl ColumnReader {
                     )));
                 }
                 Ok(&mmap[blob_offset..blob_offset + size])
+            }
+            DataSource::Windows(windows) => {
+                let idx = windows
+                    .partition_point(|w| w.start <= blob_offset)
+                    .checked_sub(1);
+                let win = idx.map(|i| &windows[i]).filter(|w| {
+                    blob_offset >= w.start && blob_offset + size <= w.start + w.bytes.len()
+                });
+                let win = win.ok_or_else(|| {
+                    Error::Format(format!(
+                        "row {row_id} was not fetched: its blob at data+{blob_offset} \
+                         ({size} bytes) lies outside the requested row window"
+                    ))
+                })?;
+                let lo = blob_offset - win.start;
+                Ok(&win.bytes[lo..lo + size])
             }
         }
     }
@@ -947,6 +1100,18 @@ impl ColumnReader {
             (blob.pg * u64::from(self.meta.page_size)) as usize
         }
     }
+}
+
+/// Whether a blob covers any row in the inclusive span `lo..=hi`.
+///
+/// `id_range == 0` marks a synthetic blob standing in for a column with no
+/// locators, which covers every row by convention.
+fn blob_overlaps(blob: &BlobLoc, lo: i64, hi: i64) -> bool {
+    if blob.id_range == 0 {
+        return true;
+    }
+    let end = blob.start_id + i64::from(blob.id_range) - 1;
+    blob.start_id <= hi && end >= lo
 }
 
 // ---------------------------------------------------------------------------
@@ -1643,6 +1808,194 @@ mod tests {
 
         let blob_data = reader.read_blob_for_row(1).unwrap();
         assert_eq!(blob_data, b"ACGTN");
+
+        let _ = std::fs::remove_file(&sra_path);
+    }
+
+    // -----------------------------------------------------------------------
+    // Windowed (range-backed) opens
+    // -----------------------------------------------------------------------
+
+    /// Wraps a reader and tallies how many bytes come out of it — a stand-in
+    /// for "bytes pulled over the wire" in a hermetic test.
+    struct Counting<R> {
+        inner: R,
+        read: std::rc::Rc<std::cell::Cell<u64>>,
+    }
+
+    impl<R: std::io::Read> std::io::Read for Counting<R> {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let n = self.inner.read(buf)?;
+            self.read.set(self.read.get() + n as u64);
+            Ok(n)
+        }
+    }
+
+    impl<R: Seek> Seek for Counting<R> {
+        fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+            self.inner.seek(pos)
+        }
+    }
+
+    /// Four 1000-byte blobs, one row each, in a column named READ.
+    ///
+    /// Returns the archive bytes and the literal contents of each blob so a
+    /// test can check it got the right window, not merely the right size.
+    fn four_blob_archive() -> (Vec<u8>, Vec<Vec<u8>>) {
+        use crate::kar::test_helpers::*;
+
+        const BLOB_SIZE: usize = 1000;
+        let blobs: Vec<Vec<u8>> = (0..4).map(|i| vec![b'A' + i as u8; BLOB_SIZE]).collect();
+
+        let col_data: Vec<u8> = blobs.iter().flatten().copied().collect();
+        let idx1 = build_idx1_v1(col_data.len() as u64, 1, 0);
+        let idx0: Vec<u8> = (0..4)
+            .flat_map(|i| {
+                build_blob_loc((i * BLOB_SIZE) as u64, BLOB_SIZE as u32, 1, (i + 1) as i64)
+            })
+            .collect();
+
+        let mut data_section = Vec::new();
+        let idx1_offset = data_section.len() as u64;
+        data_section.extend_from_slice(&idx1);
+        let idx0_offset = data_section.len() as u64;
+        data_section.extend_from_slice(&idx0);
+        let col_data_offset = data_section.len() as u64;
+        data_section.extend_from_slice(&col_data);
+
+        let idx1_node = build_file_node("idx1", idx1_offset, idx1.len() as u64);
+        let idx0_node = build_file_node("idx0", idx0_offset, idx0.len() as u64);
+        let data_node = build_file_node("data", col_data_offset, col_data.len() as u64);
+        let read_dir = build_dir_node("READ", &[&data_node, &idx0_node, &idx1_node]);
+        let col_dir = build_dir_node("col", &[&read_dir]);
+        let seq_dir = build_dir_node("SEQUENCE", &[&col_dir]);
+        let tbl_dir = build_dir_node("tbl", &[&seq_dir]);
+        let root_dir = build_dir_node("SRR", &[&tbl_dir]);
+
+        (build_kar_archive(&[&root_dir], &data_section), blobs)
+    }
+
+    /// Open the fixture column with `window`, returning the reader and how
+    /// many bytes were pulled from the archive after the TOC was parsed.
+    fn open_ranged(archive_bytes: Vec<u8>, window: &RowWindow) -> (ColumnReader, u64) {
+        let counter = std::rc::Rc::new(std::cell::Cell::new(0u64));
+        let mut archive = KarArchive::open(Counting {
+            inner: std::io::Cursor::new(archive_bytes),
+            read: counter.clone(),
+        })
+        .unwrap();
+        counter.set(0);
+        let reader = ColumnReader::open_windowed(
+            &mut archive,
+            "SRR/tbl/SEQUENCE/col/READ",
+            ColumnData::Ranged,
+            window,
+        )
+        .unwrap();
+        (reader, counter.get())
+    }
+
+    #[test]
+    fn ranged_open_without_a_window_reads_no_blob_bytes() {
+        let (archive_bytes, _) = four_blob_archive();
+        let (reader, bytes) = open_ranged(archive_bytes, &RowWindow::None);
+
+        // Row bounds come from the index alone.
+        assert_eq!(reader.row_count(), 4);
+        assert_eq!(reader.first_row_id(), Some(1));
+        // Only the index files were touched — nothing from the 4000-byte
+        // data file. This is the property that keeps `vdb info` cheap.
+        assert!(bytes < 200, "read {bytes} bytes, expected index only");
+        assert!(reader.read_raw_blob_slice(1).is_err());
+    }
+
+    #[test]
+    fn ranged_open_fetches_only_the_requested_rows() {
+        let (archive_bytes, blobs) = four_blob_archive();
+        let (_, index_bytes) = open_ranged(archive_bytes.clone(), &RowWindow::None);
+
+        let rows = RowRanges::parse("2-3").unwrap();
+        let (reader, bytes) = open_ranged(archive_bytes, &RowWindow::Rows(rows));
+
+        assert_eq!(bytes - index_bytes, 2000, "expected two 1000-byte blobs");
+        assert_eq!(reader.read_raw_blob_slice(2).unwrap(), &blobs[1][..]);
+        assert_eq!(reader.read_raw_blob_slice(3).unwrap(), &blobs[2][..]);
+    }
+
+    #[test]
+    fn rows_outside_the_window_report_rather_than_mislead() {
+        let (archive_bytes, _) = four_blob_archive();
+        let rows = RowRanges::parse("2").unwrap();
+        let (reader, _) = open_ranged(archive_bytes, &RowWindow::Rows(rows));
+
+        let err = reader.read_raw_blob_slice(4).unwrap_err().to_string();
+        assert!(
+            err.contains("not fetched"),
+            "unhelpful error for an unfetched row: {err}"
+        );
+    }
+
+    #[test]
+    fn first_window_fetches_one_blob() {
+        let (archive_bytes, blobs) = four_blob_archive();
+        let (_, index_bytes) = open_ranged(archive_bytes.clone(), &RowWindow::None);
+        let (reader, bytes) = open_ranged(archive_bytes, &RowWindow::First);
+
+        assert_eq!(bytes - index_bytes, 1000);
+        assert_eq!(reader.read_raw_blob_slice(1).unwrap(), &blobs[0][..]);
+    }
+
+    #[test]
+    fn scattered_rows_coalesce_into_one_fetch() {
+        // Rows 1 and 4 sit 2000 bytes apart, well inside the coalescing
+        // gap, so swallowing the middle beats a second round trip.
+        let (archive_bytes, blobs) = four_blob_archive();
+        let rows = RowRanges::parse("1,4").unwrap();
+        let (reader, _) = open_ranged(archive_bytes, &RowWindow::Rows(rows));
+
+        match &reader.data {
+            DataSource::Windows(w) => {
+                assert_eq!(w.len(), 1, "expected a single coalesced window");
+                assert_eq!(w[0].bytes.len(), 4000);
+            }
+            _ => panic!("expected a windowed data source"),
+        }
+        assert_eq!(reader.read_raw_blob_slice(1).unwrap(), &blobs[0][..]);
+        assert_eq!(reader.read_raw_blob_slice(4).unwrap(), &blobs[3][..]);
+    }
+
+    #[test]
+    fn an_empty_row_range_means_every_row() {
+        let (archive_bytes, blobs) = four_blob_archive();
+        let (reader, _) = open_ranged(archive_bytes, &RowWindow::Rows(RowRanges::default()));
+        for (i, blob) in blobs.iter().enumerate() {
+            assert_eq!(reader.read_raw_blob_slice(i as i64 + 1).unwrap(), &blob[..]);
+        }
+    }
+
+    #[test]
+    fn windowed_and_local_opens_agree() {
+        let (archive_bytes, _) = four_blob_archive();
+        let sra_path = std::env::temp_dir().join(format!(
+            "sracha-kdb-window-{}-{:p}.sra",
+            std::process::id(),
+            &archive_bytes
+        ));
+        std::fs::write(&sra_path, &archive_bytes).unwrap();
+
+        let mut local_archive =
+            KarArchive::open(std::io::Cursor::new(archive_bytes.clone())).unwrap();
+        let local =
+            ColumnReader::open(&mut local_archive, "SRR/tbl/SEQUENCE/col/READ", &sra_path).unwrap();
+        let (ranged, _) = open_ranged(archive_bytes, &RowWindow::All);
+
+        assert_eq!(local.row_count(), ranged.row_count());
+        for row in 1..=4 {
+            assert_eq!(
+                local.read_raw_blob_slice(row).unwrap(),
+                ranged.read_raw_blob_slice(row).unwrap(),
+            );
+        }
 
         let _ = std::fs::remove_file(&sra_path);
     }

--- a/crates/sracha-vdb/src/row_range.rs
+++ b/crates/sracha-vdb/src/row_range.rs
@@ -55,6 +55,32 @@ impl RowRanges {
         &self.segments
     }
 
+    /// Resolve every segment to an inclusive `(lo, hi)` row-id span clamped
+    /// to `[first_row, first_row + row_count)`, dropping segments that fall
+    /// entirely outside. Unlike [`iter_row_ids`](Self::iter_row_ids) this
+    /// keeps the spans intact, which is what a range-backed reader needs to
+    /// decide which blobs to fetch without enumerating every row.
+    pub fn spans(&self, first_row: i64, row_count: u64) -> Vec<(i64, i64)> {
+        if row_count == 0 {
+            return Vec::new();
+        }
+        let last_row = first_row.saturating_add(row_count.saturating_sub(1) as i64);
+        self.segments
+            .iter()
+            .filter_map(|seg| {
+                let (lo, hi) = match *seg {
+                    Segment::Single(id) => (id, id),
+                    Segment::Closed(a, b) => (a.min(b), a.max(b)),
+                    Segment::FromStart(a) => (a, last_row),
+                    Segment::ToEnd(b) => (first_row, b),
+                };
+                let lo = lo.max(first_row);
+                let hi = hi.min(last_row);
+                (lo <= hi).then_some((lo, hi))
+            })
+            .collect()
+    }
+
     /// Iterate every row id covered by any segment, clamped to
     /// `[first_row, first_row + row_count)`. Preserves segment order;
     /// does not deduplicate across segments.

--- a/crates/sracha-vdb/tests/inspect.rs
+++ b/crates/sracha-vdb/tests/inspect.rs
@@ -15,6 +15,7 @@ use std::sync::Once;
 use sracha_vdb::dump::{self, DumpFormat, DumpSpec};
 use sracha_vdb::inspect::{self, VdbKind};
 use sracha_vdb::kar::KarArchive;
+use sracha_vdb::kdb::ColumnData;
 use sracha_vdb::metadata;
 use sracha_vdb::row_range::RowRanges;
 
@@ -73,7 +74,7 @@ fn srr28588231_info_smoke() {
     let cols = inspect::list_columns(&kar, None).unwrap();
     assert!(cols.iter().any(|c| c == "READ"), "READ column missing");
 
-    let report = inspect::gather_info(&mut kar, &path).unwrap();
+    let report = inspect::gather_info(&mut kar, ColumnData::Local(&path)).unwrap();
     assert!(report.primary_row_count().unwrap() > 0);
 
     if let Some(nodes) = inspect::read_table_metadata(&mut kar, None) {
@@ -88,7 +89,7 @@ fn srr28588231_id_range_matches_row_count() {
     let path = ensure_srr28588231();
     let f = File::open(&path).unwrap();
     let mut kar = KarArchive::open(BufReader::new(f)).unwrap();
-    let (first, count) = inspect::id_range(&mut kar, &path, None, None).unwrap();
+    let (first, count) = inspect::id_range(&mut kar, ColumnData::Local(&path), None, None).unwrap();
     assert!(count > 0);
     assert_eq!(first, 1, "row IDs are 1-indexed");
 }
@@ -108,7 +109,7 @@ fn srr28588231_dump_json_is_valid_ndjson() {
         format: DumpFormat::Json,
         raw: false,
     };
-    let buf = dump::dump_to_vec(&mut kar, &path, None, spec).unwrap();
+    let buf = dump::dump_to_vec(&mut kar, ColumnData::Local(&path), None, spec).unwrap();
     let text = std::str::from_utf8(&buf).unwrap();
     let lines: Vec<&str> = text.lines().collect();
     assert_eq!(lines.len(), 5, "expected 5 JSON lines, got {}", lines.len());
@@ -136,7 +137,7 @@ fn srr28588231_dump_csv_emits_row_per_line() {
         format: DumpFormat::Csv,
         raw: false,
     };
-    let buf = dump::dump_to_vec(&mut kar, &path, None, spec).unwrap();
+    let buf = dump::dump_to_vec(&mut kar, ColumnData::Local(&path), None, spec).unwrap();
     let text = std::str::from_utf8(&buf).unwrap();
     let lines: Vec<&str> = text.lines().collect();
     assert_eq!(lines.len(), 5);

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -72,7 +72,7 @@ pub enum Command {
     /// Validate SRA file integrity
     Validate(ValidateArgs),
 
-    /// Inspect VDB structure of a local .sra file (replacement for vdb-dump)
+    /// Inspect VDB structure of a local or remote .sra archive (replacement for vdb-dump)
     Vdb(VdbArgs),
 }
 
@@ -86,21 +86,21 @@ pub struct VdbArgs {
 pub enum VdbCmd {
     /// Print summary metadata (schema, platform, row counts, dates)
     Info {
-        /// Local .sra file path
-        file: PathBuf,
+        /// Local .sra path, https:// URL, or accession (fetched via HTTP range requests)
+        source: String,
         /// Emit a single JSON object instead of human-readable text
         #[arg(long)]
         json: bool,
     },
     /// List tables in the archive (Database only)
     Tables {
-        /// Local .sra file path
-        file: PathBuf,
+        /// Local .sra path, https:// URL, or accession (fetched via HTTP range requests)
+        source: String,
     },
     /// List columns in the chosen table
     Columns {
-        /// Local .sra file path
-        file: PathBuf,
+        /// Local .sra path, https:// URL, or accession (fetched via HTTP range requests)
+        source: String,
         /// Table to inspect (defaults to SEQUENCE / first table)
         #[arg(short = 'T', long)]
         table: Option<String>,
@@ -110,8 +110,8 @@ pub enum VdbCmd {
     },
     /// Dump the metadata tree (schema/stats/LOAD/SOFTWARE nodes)
     Meta {
-        /// Local .sra file path
-        file: PathBuf,
+        /// Local .sra path, https:// URL, or accession (fetched via HTTP range requests)
+        source: String,
         /// Table whose metadata tree to walk (defaults to SEQUENCE)
         #[arg(short = 'T', long)]
         table: Option<String>,
@@ -127,14 +127,14 @@ pub enum VdbCmd {
     },
     /// Print the embedded schema text
     Schema {
-        /// Local .sra file path
-        file: PathBuf,
+        /// Local .sra path, https:// URL, or accession (fetched via HTTP range requests)
+        source: String,
     },
     /// Print first row id and row count for the chosen table/column
     #[command(name = "id-range")]
     IdRange {
-        /// Local .sra file path
-        file: PathBuf,
+        /// Local .sra path, https:// URL, or accession (fetched via HTTP range requests)
+        source: String,
         /// Table to inspect (defaults to SEQUENCE / first table)
         #[arg(short = 'T', long)]
         table: Option<String>,
@@ -144,8 +144,8 @@ pub enum VdbCmd {
     },
     /// Dump row-level data for the chosen columns
     Dump {
-        /// Local .sra file path
-        file: PathBuf,
+        /// Local .sra path, https:// URL, or accession (fetched via HTTP range requests)
+        source: String,
         /// Table to dump from (defaults to SEQUENCE / first table)
         #[arg(short = 'T', long)]
         table: Option<String>,

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -1099,7 +1099,7 @@ async fn main() -> Result<()> {
 
             Ok(())
         }
-        Command::Vdb(args) => vdb_cmd::run(args.cmd),
+        Command::Vdb(args) => vdb_cmd::run(args.cmd).await,
     }
 }
 

--- a/crates/sracha/src/vdb_cmd.rs
+++ b/crates/sracha/src/vdb_cmd.rs
@@ -1,45 +1,181 @@
+//! `sracha vdb` — archive inspection, local or remote.
+//!
+//! Every subcommand accepts a local `.sra` path, an `https://` URL, or a
+//! bare run accession. For the latter two the archive is read in place over
+//! HTTP range requests: the KAR table of contents is a file prefix and the
+//! column index files are kilobytes, so answering "what shape is this run?"
+//! costs a few round trips instead of a multi-gigabyte download.
+
 use std::fs::File;
-use std::io::{BufReader, Write};
-use std::path::Path;
+use std::io::{BufReader, Read, Seek, Write};
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use sracha_core::remote::{HttpRangeReader, TransferStats};
 use sracha_core::vdb::dump::{self, DumpSpec};
 use sracha_core::vdb::inspect::{self, ColumnStats, InfoReport, VdbKind};
 use sracha_core::vdb::kar::KarArchive;
+use sracha_core::vdb::kdb::ColumnData;
 use sracha_core::vdb::metadata::{self, SoftwareEvent};
 use sracha_core::vdb::row_range::RowRanges;
 
 use crate::cli::{DumpFormat, VdbCmd};
 use crate::style;
 
-pub fn run(cmd: VdbCmd) -> Result<()> {
+/// A resolved `vdb` subcommand target.
+struct Target {
+    /// What the user typed, echoed back as the `acc` field of `info`.
+    input: String,
+    location: Location,
+}
+
+enum Location {
+    Local(PathBuf),
+    Remote(String),
+}
+
+pub async fn run(cmd: VdbCmd) -> Result<()> {
+    let target = resolve_target(source_of(&cmd)).await?;
+    // The inspection path is blocking (mmap, or a blocking range reader),
+    // so keep it off the runtime's worker threads.
+    tokio::task::spawn_blocking(move || execute(target, cmd))
+        .await
+        .context("vdb inspection task panicked")?
+}
+
+/// The source argument, which every subcommand carries.
+fn source_of(cmd: &VdbCmd) -> &str {
     match cmd {
-        VdbCmd::Info { file, json } => cmd_info(&file, json),
-        VdbCmd::Tables { file } => cmd_tables(&file),
-        VdbCmd::Columns { file, table, stats } => cmd_columns(&file, table.as_deref(), stats),
+        VdbCmd::Info { source, .. }
+        | VdbCmd::Tables { source }
+        | VdbCmd::Columns { source, .. }
+        | VdbCmd::Meta { source, .. }
+        | VdbCmd::Schema { source }
+        | VdbCmd::IdRange { source, .. }
+        | VdbCmd::Dump { source, .. } => source,
+    }
+}
+
+/// Decide whether the input names a local file, a URL, or an accession to
+/// resolve. A local path wins over accession lookup so a file literally
+/// named `SRR000001.sra` is never silently fetched from the network.
+async fn resolve_target(input: &str) -> Result<Target> {
+    if input.starts_with("http://") || input.starts_with("https://") {
+        return Ok(Target {
+            input: input.to_string(),
+            location: Location::Remote(input.to_string()),
+        });
+    }
+
+    let path = Path::new(input);
+    if path.exists() {
+        return Ok(Target {
+            input: input.to_string(),
+            location: Location::Local(path.to_path_buf()),
+        });
+    }
+
+    let acc = sracha_core::accession::parse(input)
+        .with_context(|| format!("{input} is not an existing file, a URL, or a run accession"))?;
+    let acc = acc.to_string();
+
+    let client = sracha_core::http::default_client();
+    let resolved = match sracha_core::s3::resolve_direct(&client, &acc).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!("S3 probe for {acc} failed ({e}); falling back to SDL");
+            sracha_core::sdl::SdlClient::with_client(client)
+                .resolve_one(&acc, sracha_core::sdl::FormatPreference::Sra)
+                .await
+                .with_context(|| format!("resolving {acc}"))?
+        }
+    };
+
+    let url = resolved
+        .sra_file
+        .mirrors
+        .first()
+        .map(|m| m.url.clone())
+        .ok_or_else(|| anyhow::anyhow!("no download URL found for {acc}"))?;
+
+    tracing::info!("{acc} resolved to {url}");
+    Ok(Target {
+        input: acc,
+        location: Location::Remote(url),
+    })
+}
+
+fn execute(target: Target, cmd: VdbCmd) -> Result<()> {
+    match target.location {
+        Location::Local(path) => {
+            let f = File::open(&path).with_context(|| format!("opening {}", path.display()))?;
+            let mut kar = KarArchive::open(BufReader::new(f))
+                .with_context(|| format!("parsing KAR archive at {}", path.display()))?;
+            let size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+            let where_ = path.display().to_string();
+            dispatch(
+                &mut kar,
+                ColumnData::Local(&path),
+                &target.input,
+                &where_,
+                size,
+                cmd,
+            )
+        }
+        Location::Remote(url) => {
+            let stats = TransferStats::default();
+            let reader = HttpRangeReader::with_stats(&url, stats.clone())
+                .with_context(|| format!("opening {url} for range reads"))?;
+            let size = reader.len();
+            let mut kar = KarArchive::open(reader)
+                .with_context(|| format!("parsing KAR table of contents from {url}"))?;
+            let result = dispatch(&mut kar, ColumnData::Ranged, &target.input, &url, size, cmd);
+            tracing::info!(
+                "transferred {} bytes in {} requests ({} archive bytes)",
+                stats.bytes_fetched(),
+                stats.requests(),
+                size,
+            );
+            result
+        }
+    }
+}
+
+fn dispatch<R: Read + Seek>(
+    kar: &mut KarArchive<R>,
+    data: ColumnData<'_>,
+    acc: &str,
+    where_: &str,
+    size: u64,
+    cmd: VdbCmd,
+) -> Result<()> {
+    match cmd {
+        VdbCmd::Info { json, .. } => cmd_info(kar, data, acc, where_, size, json),
+        VdbCmd::Tables { .. } => cmd_tables(kar),
+        VdbCmd::Columns { table, stats, .. } => cmd_columns(kar, data, table.as_deref(), stats),
         VdbCmd::Meta {
-            file,
             table,
             path,
             depth,
             db,
-        } => cmd_meta(&file, table.as_deref(), path.as_deref(), depth, db),
-        VdbCmd::Schema { file } => cmd_schema(&file),
-        VdbCmd::IdRange {
-            file,
-            table,
-            column,
-        } => cmd_id_range(&file, table.as_deref(), column.as_deref()),
+            ..
+        } => cmd_meta(kar, table.as_deref(), path.as_deref(), depth, db),
+        VdbCmd::Schema { .. } => cmd_schema(kar),
+        VdbCmd::IdRange { table, column, .. } => {
+            cmd_id_range(kar, data, table.as_deref(), column.as_deref())
+        }
         VdbCmd::Dump {
-            file,
             table,
             columns,
             exclude,
             rows,
             format,
             raw,
+            ..
         } => cmd_dump(
-            &file,
+            kar,
+            data,
+            where_,
             table.as_deref(),
             columns,
             exclude,
@@ -50,24 +186,22 @@ pub fn run(cmd: VdbCmd) -> Result<()> {
     }
 }
 
-fn open_kar(path: &Path) -> Result<KarArchive<BufReader<File>>> {
-    let f = File::open(path).with_context(|| format!("opening {}", path.display()))?;
-    KarArchive::open(BufReader::new(f))
-        .with_context(|| format!("parsing KAR archive at {}", path.display()))
-}
-
-fn cmd_info(path: &Path, as_json: bool) -> Result<()> {
-    let mut kar = open_kar(path)?;
-    let report = inspect::gather_info(&mut kar, path)?;
-    let file_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
-    let acc = path.display().to_string();
+fn cmd_info<R: Read + Seek>(
+    kar: &mut KarArchive<R>,
+    data: ColumnData<'_>,
+    acc: &str,
+    where_: &str,
+    file_size: u64,
+    as_json: bool,
+) -> Result<()> {
+    let report = inspect::gather_info(kar, data)?;
 
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     if as_json {
-        write_info_json(&mut out, &acc, path, file_size, &report)?;
+        write_info_json(&mut out, acc, where_, file_size, &report)?;
     } else {
-        write_info_text(&mut out, &acc, path, file_size, &report)?;
+        write_info_text(&mut out, acc, where_, file_size, &report)?;
     }
     Ok(())
 }
@@ -75,12 +209,12 @@ fn cmd_info(path: &Path, as_json: bool) -> Result<()> {
 fn write_info_text<W: Write>(
     w: &mut W,
     acc: &str,
-    path: &Path,
+    where_: &str,
     file_size: u64,
     r: &InfoReport,
 ) -> Result<()> {
     writeln!(w, "acc    : {acc}")?;
-    writeln!(w, "path   : {}", path.display())?;
+    writeln!(w, "path   : {where_}")?;
     if file_size != 0 {
         writeln!(w, "size   : {}", thousands(file_size))?;
     }
@@ -139,14 +273,14 @@ fn write_event_text<W: Write>(w: &mut W, prefix: &str, ev: Option<&SoftwareEvent
 fn write_info_json<W: Write>(
     w: &mut W,
     acc: &str,
-    path: &Path,
+    where_: &str,
     file_size: u64,
     r: &InfoReport,
 ) -> Result<()> {
     use serde_json::{Map, Value, json};
     let mut obj = Map::new();
     obj.insert("acc".into(), json!(acc));
-    obj.insert("path".into(), json!(path.display().to_string()));
+    obj.insert("path".into(), json!(where_));
     if file_size != 0 {
         obj.insert("size".into(), json!(file_size));
     }
@@ -192,13 +326,12 @@ fn write_info_json<W: Write>(
     Ok(())
 }
 
-fn cmd_tables(path: &Path) -> Result<()> {
-    let kar = open_kar(path)?;
+fn cmd_tables<R: Read + Seek>(kar: &KarArchive<R>) -> Result<()> {
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
-    match inspect::detect_kind(&kar)? {
+    match inspect::detect_kind(kar)? {
         VdbKind::Database => {
-            for t in inspect::list_tables(&kar)? {
+            for t in inspect::list_tables(kar)? {
                 writeln!(out, "{t}")?;
             }
         }
@@ -212,16 +345,19 @@ fn cmd_tables(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn cmd_columns(path: &Path, table: Option<&str>, stats: bool) -> Result<()> {
+fn cmd_columns<R: Read + Seek>(
+    kar: &mut KarArchive<R>,
+    data: ColumnData<'_>,
+    table: Option<&str>,
+    stats: bool,
+) -> Result<()> {
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     if stats {
-        let mut kar = open_kar(path)?;
-        let rows = inspect::column_stats_all(&mut kar, path, table)?;
+        let rows = inspect::column_stats_all(kar, data, table)?;
         write_column_stats(&mut out, &rows)?;
     } else {
-        let kar = open_kar(path)?;
-        let cols = inspect::list_columns(&kar, table)?;
+        let cols = inspect::list_columns(kar, table)?;
         for c in cols {
             writeln!(out, "{c}")?;
         }
@@ -283,19 +419,18 @@ fn write_column_stats<W: Write>(w: &mut W, rows: &[ColumnStats]) -> Result<()> {
     Ok(())
 }
 
-fn cmd_meta(
-    path: &Path,
+fn cmd_meta<R: Read + Seek>(
+    kar: &mut KarArchive<R>,
     table: Option<&str>,
     sub_path: Option<&str>,
     depth: Option<usize>,
     db: bool,
 ) -> Result<()> {
-    let mut kar = open_kar(path)?;
     let nodes = if db {
-        inspect::read_db_metadata(&mut kar)
+        inspect::read_db_metadata(kar)
             .ok_or_else(|| anyhow::anyhow!("no database-level md/cur in archive"))?
     } else {
-        inspect::read_table_metadata(&mut kar, table).ok_or_else(|| {
+        inspect::read_table_metadata(kar, table).ok_or_else(|| {
             anyhow::anyhow!(
                 "no table metadata for {} in archive",
                 table.unwrap_or("SEQUENCE/first table")
@@ -331,10 +466,9 @@ fn cmd_meta(
     Ok(())
 }
 
-fn cmd_schema(path: &Path) -> Result<()> {
-    let mut kar = open_kar(path)?;
-    let nodes = inspect::read_table_metadata(&mut kar, None)
-        .or_else(|| inspect::read_db_metadata(&mut kar))
+fn cmd_schema<R: Read + Seek>(kar: &mut KarArchive<R>) -> Result<()> {
+    let nodes = inspect::read_table_metadata(kar, None)
+        .or_else(|| inspect::read_db_metadata(kar))
         .ok_or_else(|| anyhow::anyhow!("no metadata (md/cur) found in archive"))?;
     let text = metadata::schema_text(&nodes)
         .ok_or_else(|| anyhow::anyhow!("no schema node found in metadata"))?;
@@ -347,9 +481,13 @@ fn cmd_schema(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn cmd_id_range(path: &Path, table: Option<&str>, column: Option<&str>) -> Result<()> {
-    let mut kar = open_kar(path)?;
-    let (first, count) = inspect::id_range(&mut kar, path, table, column)?;
+fn cmd_id_range<R: Read + Seek>(
+    kar: &mut KarArchive<R>,
+    data: ColumnData<'_>,
+    table: Option<&str>,
+    column: Option<&str>,
+) -> Result<()> {
+    let (first, count) = inspect::id_range(kar, data, table, column)?;
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     writeln!(
@@ -360,8 +498,11 @@ fn cmd_id_range(path: &Path, table: Option<&str>, column: Option<&str>) -> Resul
     Ok(())
 }
 
-fn cmd_dump(
-    path: &Path,
+#[allow(clippy::too_many_arguments)]
+fn cmd_dump<R: Read + Seek>(
+    kar: &mut KarArchive<R>,
+    data: ColumnData<'_>,
+    where_: &str,
     table: Option<&str>,
     columns: Vec<String>,
     exclude: Vec<String>,
@@ -369,11 +510,17 @@ fn cmd_dump(
     format: DumpFormat,
     raw: bool,
 ) -> Result<()> {
-    let mut kar = open_kar(path)?;
     let rows = match rows {
         Some(s) => RowRanges::parse(s).context("parsing --rows / -R argument")?,
         None => RowRanges::default(),
     };
+    if matches!(data, ColumnData::Ranged) && rows.is_empty() {
+        eprintln!(
+            "{} dumping every row of a remote archive transfers each selected \
+             column in full; pass -R to fetch a range instead",
+            style::header("note:")
+        );
+    }
     let spec = DumpSpec {
         columns,
         exclude,
@@ -381,13 +528,13 @@ fn cmd_dump(
         format: format.into(),
         raw,
     };
-    let mut runner = dump::DumpRunner::new(&mut kar, path, table, spec)
-        .with_context(|| format!("preparing vdb dump for {}", path.display()))?;
+    let mut runner = dump::DumpRunner::new(kar, data, table, spec)
+        .with_context(|| format!("preparing vdb dump for {where_}"))?;
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     runner
         .run(&mut out)
-        .with_context(|| format!("dumping rows from {}", path.display()))?;
+        .with_context(|| format!("dumping rows from {where_}"))?;
     Ok(())
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -267,13 +267,35 @@ sracha validate [OPTIONS] <INPUT>...
 
 ## sracha vdb
 
-Inspect the VDB structure of a local `.sra` file. Pure-Rust
-replacement for `vdb-dump` — no network, no C FFI, no subprocess to
-sra-tools.
+Inspect the VDB structure of an `.sra` archive. Pure-Rust replacement for
+`vdb-dump` — no C FFI, no subprocess to sra-tools.
 
 ```
-sracha vdb <SUBCOMMAND> <FILE> [OPTIONS]
+sracha vdb <SUBCOMMAND> <SOURCE> [OPTIONS]
 ```
+
+`<SOURCE>` is a local `.sra` path, an `https://` URL, or a run accession.
+Accessions and URLs are read **in place over HTTP range requests** — the
+archive is never downloaded. The table of contents is a file prefix and the
+column indexes are kilobytes, so inspecting a multi-gigabyte run transfers a
+few hundred KiB:
+
+```bash
+# ~1 s and ~256 KiB transferred against a 4.2 GB archive
+sracha vdb info SRR18959644
+
+# spot-check read structure without downloading anything
+sracha vdb dump SRR18959644 -C READ_LEN,READ_TYPE -R 1,22228622
+```
+
+Pass `-v` to see how much was transferred. Only inspection works remotely;
+`sracha fastq` needs a local file, since decoding touches essentially every
+byte and would transfer the whole archive anyway.
+
+!!! note "Row ranges matter for remote `dump`"
+
+    `dump` fetches only the blobs covering `-R`. Without `-R` it reads every
+    selected column in full, which over the network means downloading them.
 
 ### sracha vdb info
 
@@ -281,7 +303,7 @@ Print summary metadata: schema, platform, table row counts, load
 timestamp, and formatter / loader / update software events.
 
 ```
-sracha vdb info <FILE> [--json]
+sracha vdb info <SOURCE> [--json]
 ```
 
 | Option | Default | Description |
@@ -294,7 +316,7 @@ List tables in the archive. Only meaningful for Database archives
 (cSRA / aligned); flat Tables print a note.
 
 ```
-sracha vdb tables <FILE>
+sracha vdb tables <SOURCE>
 ```
 
 ### sracha vdb columns
@@ -302,7 +324,7 @@ sracha vdb tables <FILE>
 List columns in a table.
 
 ```
-sracha vdb columns <FILE> [-T TABLE] [-s]
+sracha vdb columns <SOURCE> [-T TABLE] [-s]
 ```
 
 | Option | Default | Description |
@@ -315,7 +337,7 @@ sracha vdb columns <FILE> [-T TABLE] [-s]
 Dump the metadata tree (schema / stats / LOAD / SOFTWARE nodes).
 
 ```
-sracha vdb meta <FILE> [-T TABLE] [-P PATH] [-d DEPTH] [--db]
+sracha vdb meta <SOURCE> [-T TABLE] [-P PATH] [-d DEPTH] [--db]
 ```
 
 | Option | Default | Description |
@@ -330,7 +352,7 @@ sracha vdb meta <FILE> [-T TABLE] [-P PATH] [-d DEPTH] [--db]
 Print the embedded schema text.
 
 ```
-sracha vdb schema <FILE>
+sracha vdb schema <SOURCE>
 ```
 
 ### sracha vdb id-range
@@ -338,13 +360,31 @@ sracha vdb schema <FILE>
 Print the first row id and row count for a table/column.
 
 ```
-sracha vdb id-range <FILE> [-T TABLE] [-C COLUMN]
+sracha vdb id-range <SOURCE> [-T TABLE] [-C COLUMN]
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `-T, --table <NAME>` | `SEQUENCE` (or first) | Table to inspect |
 | `-C, --column <NAME>` | first alphabetically | Column to read |
+
+### sracha vdb dump
+
+Dump row-level data for the chosen columns. Values are typed by a
+name-based heuristic (READ as bases, READ_LEN as an array, and so on);
+unrecognized columns render as hex.
+
+```
+sracha vdb dump <SOURCE> [-T TABLE] [-C COLUMNS] [-x COLUMNS] [-R ROWS] [-f FORMAT]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-T, --table <NAME>` | `SEQUENCE` (or first) | Table to dump from |
+| `-C, --columns <LIST>` | all known columns | Comma-separated columns to include |
+| `-x, --exclude <LIST>` | | Columns to drop, applied after `-C` |
+| `-R, --rows <RANGES>` | all rows | Comma-separated, 1-indexed, inclusive: `5`, `5-20`, `100-`, `-50`, `1-10,200` |
+| `-f, --format <FMT>` | `default` | `default`, `csv`, `tab`, or `json` (NDJSON) |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Fast SRA downloader and FASTQ converter, written in pure Rust.
 - **Stdout streaming** -- pipe interleaved FASTQ to downstream tools with `-Z`
 - **Resumable downloads** -- automatically resumes interrupted transfers
 - **File validation** -- verify SRA file integrity with `sracha validate`
-- **VDB introspection** -- `sracha vdb` inspects local `.sra` files (tables, columns, metadata, schema) as a pure-Rust replacement for `vdb-dump`
+- **VDB introspection** -- `sracha vdb` inspects `.sra` archives (tables, columns, metadata, schema) as a pure-Rust replacement for `vdb-dump`, either from a local file or straight from an accession over HTTP range requests, no download needed
 
 ## How it works
 


### PR DESCRIPTION
Closes #78.

`sracha vdb` subcommands now accept an accession or `https://` URL as well as a local path. Remote sources are read in place over HTTP range requests instead of being downloaded.

## Measured against SRR18959644 (4.2 GB)

| command | wall | transferred |
|---|---|---|
| `vdb info SRR18959644` | 1.15 s | 256 KiB |
| `vdb id-range SRR18959644` | ~1 s | 64 KiB |
| `vdb dump -C READ_LEN,READ_TYPE -R 1,22228622` | 5.0 s | 192 KiB |

The dump is the issue's motivating query. Output matches `vdb-dump` exactly (`READ_LEN=[150, 0]`/`[0, 150]`, `READ_TYPE=[1, 0]`/`[0, 1]` against `SRA_READ_TYPE_BIOLOGICAL, SRA_READ_TYPE_TECHNICAL`), and beats it on wall clock (7.2 s) even from a debug build.

## sracha-vdb

No new dependencies — the crate still has no network deps.

- `KarArchive::read_file_range` reads a sub-range of an archive entry through the generic reader.
- `ColumnReader::open_windowed(archive, col_path, ColumnData, &RowWindow)` — `ColumnData` picks local mmap vs. reader-backed fetch, `RowWindow` says which rows' blobs are needed (`None`, `First`, `Rows(RowRanges)`, `All`). `ColumnReader::open` still exists and delegates, so the local mmap path is byte-for-byte unchanged.
- `DataSource::Windows` holds the sparse byte ranges fetched up front. Blobs less than 1 MiB apart coalesce into one request, so `-R 1,22228622` costs one fetch per cluster rather than a request storm. Reading a row outside the window reports that it was not fetched rather than returning wrong bytes.
- `inspect`/`dump` take `ColumnData` instead of `&Path` and choose their own window: `id-range` fetches no blob data at all, `columns -s` fetches only each column's first blob, `dump` fetches what `-R` covers.

## sracha-core

New `remote::HttpRangeReader` — blocking `Read + Seek` with a 64 KiB block cache, read-ahead so a multi-block `read_exact` is one request, bounded cache, and retries with backoff. Non-206 responses are rejected so a server ignoring `Range` can't silently corrupt a splice.

Blocking is deliberate: `KarArchive` is generic over `Read + Seek` and these paths are latency-bound, so an async variant would force a parallel set of entry points for nothing. It runs under `spawn_blocking` and owns a private runtime via `reqwest::blocking`.

`TransferStats` counts bytes and requests; `-v` prints the total.

## Out of scope

Remote decode. `sracha fastq` still needs a local file — streaming decode touches essentially every byte, so it would transfer the whole archive anyway, slower and with more failure modes.

## Tests

- Hermetic windowing tests in `kdb.rs` over a synthetic four-blob archive with a byte-counting reader: index-only opens read no blob bytes, a row range fetches exactly its blobs, scattered rows coalesce to one window, out-of-window rows error, and windowed reads agree with the local mmap path.
- `HttpRangeReader` unit tests against a loopback HTTP server (block accounting, cache hits, multi-block reads, EOF clamping).
- End-to-end `#[ignore]`d tests serving the real SRR28588231 fixture over loopback: remote `info`/`id-range`/`dump` match the local answers exactly, and transfer stays a small fraction of archive size — the regression guard the issue asked for.

Full suite: 651 unit tests pass, plus the vdb and remote integration tests. `cargo fmt --check` and `clippy -D warnings` clean.