### PR TITLE
fix(pipeline): prefer static VDB READ_LEN metadata over the EUtils average (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Read lengths now come from the archive's own static `READ_LEN` metadata in
+  preference to the NCBI EUtils average (#84). RunInfo carries only
+  `avgLength` and a SINGLE/PAIRED flag, so it can never describe more than two
+  reads and always split the spot evenly — scrambling any run whose reads
+  differ in length. SRR9827735 (10x, 26/55/8) was cut into 44/45; it now
+  matches fasterq-dump byte for byte. A probe of 120 public runs put this at
+  roughly 25% of 10x-style runs. When no static structure exists and the
+  EUtils average is used, sracha now warns instead of guessing silently.
+
 ## 0.4.0 (2026-07-25)
 
 ### Upgrade note

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -225,6 +225,37 @@ pub fn is_unsupported_platform(platform: &str) -> bool {
     UNSUPPORTED_PLATFORMS.contains(&platform)
 }
 
+/// Where [`resolve_fallback_read_lengths`] got its answer, for logging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReadLenSource {
+    /// The archive's own static `col/READ_LEN/row` metadata node.
+    VdbMetadata,
+    /// Derived from the EUtils RunInfo `avgLength` and library layout.
+    EutilsAverage,
+}
+
+/// Pick per-read lengths for an archive with no physical `READ_LEN` column.
+///
+/// The archive's own static read structure wins over the EUtils RunInfo
+/// average. RunInfo carries only `avgLength` plus a SINGLE/PAIRED layout, so
+/// it can never describe more than two reads and always splits the spot
+/// evenly. That silently scrambles any run whose reads differ in length —
+/// 10x-style barcode/UMI + cDNA + sample index layouts get cut at the wrong
+/// offsets rather than at the submitted boundaries (issue #84). Where both
+/// sources exist they agree on the total spot length, so preferring the
+/// metadata only refines where the split points fall.
+fn resolve_fallback_read_lengths(
+    metadata_lengths: Option<Vec<u32>>,
+    api_lengths: Option<&[u32]>,
+) -> Option<(Vec<u32>, ReadLenSource)> {
+    if let Some(lens) = metadata_lengths.filter(|v| !v.is_empty()) {
+        return Some((lens, ReadLenSource::VdbMetadata));
+    }
+    api_lengths
+        .filter(|v| !v.is_empty())
+        .map(|v| (v.to_vec(), ReadLenSource::EutilsAverage))
+}
+
 /// Map a raw `sracha_vdb::Error::BlobIntegrity` from `decode_blob` into the
 /// user-facing [`Error::IntegrityFailure`], attaching the accession and the
 /// shared [`crate::error::BLOB_INTEGRITY_GUIDANCE`] text. Passes other errors
@@ -552,16 +583,32 @@ fn decode_and_write(
         tracing::debug!("fixed_spot_len={fsl} (from blob 0)");
     }
 
-    // Fallback per-read lengths (from NCBI EUtils API or VDB metadata).
+    // Fallback per-read lengths (from VDB metadata or the NCBI EUtils API).
     // Only used when READ_LEN column is absent. Cloned once here so rayon
     // closures can borrow it without moving the config.
     let fallback_read_lengths: Option<Vec<u32>> = if !has_read_len {
-        config
-            .run_info
-            .as_ref()
-            .map(|ri| ri.avg_read_len.clone())
-            .filter(|v| !v.is_empty())
-            .or_else(|| cursor.metadata_read_lengths())
+        let picked = resolve_fallback_read_lengths(
+            cursor.metadata_read_lengths(),
+            config
+                .run_info
+                .as_ref()
+                .map(|ri| ri.avg_read_len.as_slice()),
+        );
+        match &picked {
+            Some((lens, ReadLenSource::VdbMetadata)) => tracing::debug!(
+                "{accession}: no physical READ_LEN; per-read lengths {lens:?} \
+                 from static VDB metadata",
+            ),
+            Some((lens, ReadLenSource::EutilsAverage)) => tracing::warn!(
+                "{accession}: no physical READ_LEN column and no static read \
+                 structure in the archive metadata; splitting each spot as \
+                 {lens:?} from the NCBI EUtils average. This is a guess — if \
+                 the run's reads differ in length the split points will be \
+                 wrong.",
+            ),
+            None => {}
+        }
+        picked.map(|(lens, _)| lens)
     } else {
         None
     };
@@ -2102,6 +2149,38 @@ mod tests {
     use super::*;
     use crate::sdl::{ResolvedFile, ResolvedMirror};
     use crate::vdb::blob;
+
+    #[test]
+    fn fallback_read_lengths_prefer_vdb_metadata() {
+        // SRR9827735 (issue #84): the archive's static metadata says
+        // 26/55/8, while EUtils only knows avgLength=89 + PAIRED and so
+        // proposes an even 44/45 split. The archive must win, or the FASTQ
+        // is silently cut at the wrong offsets.
+        let picked = resolve_fallback_read_lengths(Some(vec![26, 55, 8]), Some(&[44, 45]));
+        assert_eq!(
+            picked,
+            Some((vec![26, 55, 8], ReadLenSource::VdbMetadata)),
+            "static VDB metadata must outrank the EUtils average"
+        );
+    }
+
+    #[test]
+    fn fallback_read_lengths_use_eutils_when_metadata_absent() {
+        let picked = resolve_fallback_read_lengths(None, Some(&[151, 151]));
+        assert_eq!(picked, Some((vec![151, 151], ReadLenSource::EutilsAverage)));
+    }
+
+    #[test]
+    fn fallback_read_lengths_skip_empty_sources() {
+        // avgLength=0 runs yield an empty RunInfo vector; an archive with no
+        // static read structure yields None. Neither should be picked.
+        assert_eq!(
+            resolve_fallback_read_lengths(Some(vec![]), Some(&[75])),
+            Some((vec![75], ReadLenSource::EutilsAverage))
+        );
+        assert_eq!(resolve_fallback_read_lengths(None, Some(&[])), None);
+        assert_eq!(resolve_fallback_read_lengths(None, None), None);
+    }
 
     fn make_resolved(mirrors: Vec<ResolvedMirror>) -> ResolvedAccession {
         ResolvedAccession {

--- a/crates/sracha-vdb/src/metadata.rs
+++ b/crates/sracha-vdb/src/metadata.rs
@@ -100,25 +100,39 @@ pub fn parse_read_structure(tree_data: &[u8]) -> Result<Vec<ReadDescriptor>, Str
 /// Read per-read descriptors from `col/{READ_TYPE,READ_LEN}/row` static
 /// columns. `READ_TYPE/row` stores one `u8` per read (low bit: 1 =
 /// biological, 0 = technical); `READ_LEN/row` stores one little-endian
-/// `u32` per read. `nreads` comes from `READ_TYPE/row` because it is
-/// exactly one byte per read. When `READ_LEN/row` is absent or
-/// mis-sized we emit `read_len=0` so callers fall back to `spot_len /
-/// nreads`.
+/// `u32` per read.
+///
+/// `nreads` comes from `READ_TYPE/row` when present, since it is exactly one
+/// byte per read; failing that, from `READ_LEN/row`'s length in `u32`s, so an
+/// archive carrying only the lengths still yields a usable structure (reads
+/// then default to biological). When `READ_LEN/row` is absent or mis-sized we
+/// emit `read_len=0` so callers fall back to `spot_len / nreads`.
 fn read_static_col_read_structure(nodes: &[MetaNode]) -> Option<Vec<ReadDescriptor>> {
     let col = nodes.iter().find(|n| n.name == "col")?;
-    let read_type = find_meta_node(&col.children, "READ_TYPE/row")?;
-    let nreads = read_type.value.len();
-    if nreads == 0 {
-        return None;
-    }
+    let types_bytes = find_meta_node(&col.children, "READ_TYPE/row")
+        .map(|n| n.value.as_slice())
+        .unwrap_or(&[]);
     let lens_bytes = find_meta_node(&col.children, "READ_LEN/row")
         .map(|n| n.value.as_slice())
         .unwrap_or(&[]);
+
+    let nreads = if !types_bytes.is_empty() {
+        types_bytes.len()
+    } else if !lens_bytes.is_empty() && lens_bytes.len().is_multiple_of(4) {
+        lens_bytes.len() / 4
+    } else {
+        return None;
+    };
+
+    let have_types = types_bytes.len() == nreads;
     let have_lens = lens_bytes.len() == 4 * nreads;
 
     let mut descs = Vec::with_capacity(nreads);
     for i in 0..nreads {
-        let rtype = if read_type.value[i] & 1 != 0 {
+        // Without a READ_TYPE node every read is assumed biological — the
+        // same default the pipeline applies when the physical column is
+        // missing too.
+        let rtype = if !have_types || types_bytes[i] & 1 != 0 {
             b'B'
         } else {
             b'T'
@@ -1129,6 +1143,45 @@ pub(crate) mod tests {
         assert_eq!(descs.len(), 2);
         assert!(descs.iter().all(|d| d.read_type == b'B'));
         assert!(descs.iter().all(|d| d.read_len == 0));
+    }
+
+    #[test]
+    fn read_structure_static_cols_missing_types_keeps_lens() {
+        // No READ_TYPE/row — nreads comes from READ_LEN/row instead, so the
+        // concrete lengths survive rather than being dropped for a
+        // platform-inferred guess.
+        let mut lens_bytes = Vec::new();
+        for l in [26u32, 55, 8] {
+            lens_bytes.extend_from_slice(&l.to_le_bytes());
+        }
+        let row_len = build_meta_node("row", &lens_bytes, None);
+        let read_len = build_meta_node_with_children("READ_LEN", b"", &[&row_len], None);
+        let col = build_meta_node_with_children("col", b"", &[&read_len], None);
+        let tree = build_pbstree(&[&col]);
+
+        let descs = parse_read_structure(&tree).unwrap();
+        assert_eq!(descs.len(), 3);
+        assert_eq!(
+            descs.iter().map(|d| d.read_len).collect::<Vec<_>>(),
+            vec![26, 55, 8]
+        );
+        assert!(descs.iter().all(|d| d.read_type == b'B'));
+    }
+
+    #[test]
+    fn read_structure_static_cols_three_reads_tbt() {
+        // SRR9827735's real layout: 10x barcode+UMI / cDNA / sample index,
+        // stored only as static metadata (issue #84).
+        let tree = static_col_tree(3, &[0, 1, 0], &[26, 55, 8]);
+        let descs = parse_read_structure(&tree).unwrap();
+        assert_eq!(descs.len(), 3);
+        assert_eq!(
+            descs
+                .iter()
+                .map(|d| (d.read_type, d.read_len))
+                .collect::<Vec<_>>(),
+            vec![(b'T', 26), (b'B', 55), (b'T', 8)]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #84.

## Root cause

Not a VDB decode bug — `sracha-vdb` already parses the archive's static
`col/READ_LEN/row` metadata correctly. The pipeline was throwing that answer
away.

When the SEQUENCE table has no physical `READ_LEN` column, `decode_sra` used
`RunInfo::avg_read_len` first and only consulted the archive's own static
metadata if that was empty. EUtils RunInfo carries just `avgLength` plus a
SINGLE/PAIRED layout, so it can never express more than two reads and always
splits the spot evenly. Any run whose reads differ in length was cut at the
wrong offsets and emitted as well-formed but scrambled FASTQ, with no warning.

SRR9827735 (10x, submitted as 26 bp barcode+UMI / 55 bp cDNA / 8 bp index)
reports `avgLength=89` + `PAIRED`, producing the reported 44/45 split. The
static metadata carries the true 26/55/8.

Git history shows the ordering was accidental: the EUtils path landed first in
f7e9740, and e0abd92 bolted the VDB-metadata path on as an `.or_else()` rather
than promoting it.

## The fix

`fallback_read_lengths` now prefers the archive's static metadata, with EUtils
as last resort. The choice is factored into `resolve_fallback_read_lengths`
so it is unit-testable without network.

Safety check before flipping: across all 89 sampled archives lacking a
physical `READ_LEN`, the static metadata's summed spot length matched EUtils
`avgLength` **exactly, every time**. The metadata only refines where the split
points fall; it never contradicts the total. So this cannot regress a run that
works today.

Two supporting changes:

- `read_static_col_read_structure` derives `nreads` from `READ_LEN/row` when
  `READ_TYPE/row` is absent, instead of discarding usable lengths and falling
  through to a platform-inferred guess.
- Taking the EUtils path now emits a `tracing::warn!`. The default log level is
  `warn`, so the guess is visible rather than silent.

## How common is this?

I probed 120 public runs over HTTP range reads, comparing each archive's true
static layout against what sracha computes today.

Missing physical `READ_LEN` is the normal case, not an edge case: 36/40 in a
10x-targeted sample, 25/40 and 28/40 in broad Illumina RNA-seq samples. Of
those, output is scrambled in:

| sample | scrambled |
|---|---|
| 10x-targeted | 10/40 (25%) |
| broad Illumina RNA-seq | 0-1 per 40 (~0-2%) |

Failures are concentrated in barcoded/single-cell layouts (`T8+B150+B150`,
`T8+B26+B98`, `B26+B96`, one `T8+T8+B151+B151`). Symmetric paired and
single-read runs come out right by luck, because an even split happens to be
correct.

The era framing in the issue is a red herring — `SRR11806406` (`T28+B91+T8`,
10x v3) is from 2020. It is also the worst failure shape for that audience:
well-formed FASTQ that CellRanger or STARsolo will ingest and produce garbage
from.

## Verification

Before/after on the same archive, `SRR11806406`:

| | files | read lengths |
|---|---|---|
| main | 2 | 63 / 64 |
| this PR | 3 | 28 / 91 / 8 |
| fasterq-dump | 3 | 28 / 91 / 8 |

63/64 is exactly the predicted `avgLength=127 / 2` split.

Compared against fasterq-dump on seven accessions — file count, per-file read
lengths, and md5 of the sequence lines. All byte-identical:

| accession | layout | result |
|---|---|---|
| SRR9827735 | T26+B55+T8 | 3 files, 26/55/8, seq match |
| SRR11806406 | T28+B91+T8 | 3 files, 28/91/8, seq match |
| SRR10596347 | T8+T26+B98 | 3 files, 8/26/98, seq match |
| SRR10204151 | B25+B25 (control) | 2 files, 25/25, seq match |
| SRR10050274 | B50+T0 (control) | 1 file, 50, seq match |
| SRR5417270 | B76+T0 (control) | 1 file, 76, seq match |
| SRR5299560 | B98 (control) | 1 file, 98, seq match |

672 unit tests pass (5 new), 35 integration tests pass, clippy clean.

Note on `SRR5299560`: fasterq-dump names single-read output `<acc>.fastq`
while sracha writes `<acc>_1.fastq.gz`. Content is identical. Pre-existing
naming difference, unrelated to this PR, but possibly worth its own issue.
