### PR TITLE
fix(ena): harden --prefer-ena transfers against ENA instability (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Fixes
 
+- Retry an interrupted `--prefer-ena` transfer instead of aborting the run
+  (#89). The per-chunk retry budget spans roughly a minute; ENA outages last
+  longer, so a single chunk exhausting its attempts would abort a transfer
+  that was nearly complete and leave the user to re-run it by hand. ENA
+  downloads now re-enter the transfer up to 4 times, waiting 30 s → 5 min
+  (doubling, with full jitter) between attempts and resuming from the
+  `.sracha-progress` sidecar, so completed chunks are never re-fetched.
+  Cancellations, checksum mismatches, and I/O errors such as a full disk are
+  surfaced immediately rather than burning retries, and retrying is skipped
+  under `--no-resume`, where every attempt would restart from byte zero.
 - Make `--prefer-ena` transfers resilient to ENA instability (#89). ENA FASTQ
   URLs are now fetched over `https://` instead of plain `http://`. ENA serves
   from a single Apache host that chokes under the S3-tuned connection floor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Fixes
 
+- Make `--prefer-ena` transfers resilient to ENA instability (#89). ENA FASTQ
+  URLs are now fetched over `https://` instead of plain `http://`. ENA serves
+  from a single Apache host that chokes under the S3-tuned connection floor
+  (which forced ≥24 parallel streams on large files regardless of
+  `--connections`); ENA downloads are now capped at 6 connections and honor a
+  lower `--connections`, and the S3 auto-scale floor is confined to the NCBI
+  path. Per-chunk retry backoff was widened from 250 ms/500 ms (3 attempts, no
+  jitter) to exponential 500 ms→15 s with full jitter over 5 attempts, so a
+  transient connection-refusal window is ridden out instead of amplified by a
+  thundering herd of lockstep retries. On a failed ENA transfer the partial
+  file and `.sracha-progress` sidecar are preserved with a message that
+  re-running resumes.
 - Resolve the `idx0` write-ahead overlay together with the `idx1`/`idx2` block
   index instead of treating `idx0` as authoritative (#87). NCBI's VDB writer
   appends new blobs to `idx0`, periodically compacts them into `idx1`/`idx2`,

--- a/crates/sracha-core/src/download/mod.rs
+++ b/crates/sracha-core/src/download/mod.rs
@@ -14,7 +14,24 @@ const MEDIUM_FILE: u64 = 256 * 1024 * 1024; // 256 MiB
 const LARGE_FILE: u64 = 2 * 1024 * 1024 * 1024; // 2 GiB
 
 /// Maximum retry attempts per chunk.
-const MAX_RETRIES: u32 = 3;
+const MAX_RETRIES: u32 = 5;
+
+/// Base delay for the first per-chunk retry backoff, in milliseconds.
+const BACKOFF_BASE_MS: u64 = 500;
+
+/// Upper bound on a single per-chunk backoff (before jitter), in milliseconds.
+const BACKOFF_CAP_MS: u64 = 15_000;
+
+/// Deterministic exponential backoff for retry `attempt` (1-based), capped.
+///
+/// Doubles each attempt from [`BACKOFF_BASE_MS`] up to [`BACKOFF_CAP_MS`]:
+/// 500, 1000, 2000, 4000, ... ms. Jitter is added by the caller so this stays
+/// pure and testable.
+fn backoff_base_ms(attempt: u32) -> u64 {
+    BACKOFF_BASE_MS
+        .saturating_mul(1u64 << (attempt - 1))
+        .min(BACKOFF_CAP_MS)
+}
 
 /// Auto-scale floor for parallel TCP connections on medium+ files.
 /// 24 is the safe sweet spot: benched against 16 and 32 on a head-node
@@ -38,6 +55,11 @@ pub struct DownloadConfig {
     pub progress: bool,
     /// Attempt to resume interrupted downloads (default true).
     pub resume: bool,
+    /// Auto-scale to [`MEDIUM_FILE_CONNECTIONS`] on medium+ files (default
+    /// true). Tuned for NCBI S3; ENA's single Apache host chokes under that
+    /// many parallel streams, so the ENA fast path sets this `false` and
+    /// caps `connections` at [`crate::ena::ENA_MAX_CONNECTIONS`] instead.
+    pub auto_scale_connections: bool,
     /// Shared HTTP client. When `None`, a fresh client is built per call.
     /// The orchestrator should pass the same client it uses for SDL/S3 so
     /// TLS sessions and connection pools are reused.
@@ -61,6 +83,7 @@ impl Default for DownloadConfig {
             validate: true,
             progress: true,
             resume: true,
+            auto_scale_connections: true,
             client: None,
             expected_prefix: None,
         }
@@ -171,10 +194,12 @@ async fn download_chunk(
 
     for attempt in 0..MAX_RETRIES {
         if attempt > 0 {
-            // Short first retry (a read-timeout stall is usually a dead TCP
-            // connection; a fresh one wins fast), then back off in case the
-            // real problem is server-side rate limiting.
-            let delay = std::time::Duration::from_millis(250u64 << (attempt - 1));
+            // Exponential backoff (500 ms → 15 s cap) with full jitter in
+            // `0..base`. The jitter de-synchronizes the many concurrent chunk
+            // retries so a struggling host (e.g. ENA refusing connections)
+            // isn't hit by a thundering herd all backing off in lockstep.
+            let base = backoff_base_ms(attempt);
+            let delay = std::time::Duration::from_millis(base + crate::util::jitter_ms(base));
             tracing::warn!(
                 "Retrying chunk {}-{} (attempt {}/{}), backoff {:?}",
                 chunk.start,
@@ -627,7 +652,9 @@ pub async fn download_file(
     let use_parallel = probe.supports_range && file_size >= SMALL_FILE;
 
     // Scale up connections for medium+ files (see MEDIUM_FILE_CONNECTIONS).
-    let connections = if file_size >= MEDIUM_FILE {
+    // Callers that target a connection-sensitive host (ENA) disable this and
+    // pass their own, gentler `connections` value.
+    let connections = if config.auto_scale_connections && file_size >= MEDIUM_FILE {
         config.connections.max(MEDIUM_FILE_CONNECTIONS)
     } else {
         config.connections
@@ -1138,6 +1165,25 @@ mod tests {
         assert!(config.validate);
         assert!(config.progress);
         assert!(config.resume);
+        assert!(config.auto_scale_connections);
+    }
+
+    #[test]
+    fn test_backoff_base_ms_exponential() {
+        // Doubles from BACKOFF_BASE_MS each attempt.
+        assert_eq!(backoff_base_ms(1), 500);
+        assert_eq!(backoff_base_ms(2), 1000);
+        assert_eq!(backoff_base_ms(3), 2000);
+        assert_eq!(backoff_base_ms(4), 4000);
+        assert_eq!(backoff_base_ms(5), 8000);
+    }
+
+    #[test]
+    fn test_backoff_base_ms_capped() {
+        // Never exceeds BACKOFF_CAP_MS, even far past MAX_RETRIES.
+        assert_eq!(backoff_base_ms(6), 15_000);
+        assert_eq!(backoff_base_ms(20), 15_000);
+        assert_eq!(backoff_base_ms(60), 15_000); // no overflow from the shift
     }
 
     #[test]

--- a/crates/sracha-core/src/download/mod.rs
+++ b/crates/sracha-core/src/download/mod.rs
@@ -42,6 +42,7 @@ fn backoff_base_ms(attempt: u32) -> u64 {
 const MEDIUM_FILE_CONNECTIONS: usize = 24;
 
 /// Configuration for parallel chunked downloads.
+#[derive(Clone)]
 pub struct DownloadConfig {
     /// Number of parallel connections (default 8).
     pub connections: usize,
@@ -72,6 +73,151 @@ pub struct DownloadConfig {
     /// archive magic (`NCBI.sra`) so a corrupt `.sracha-tmp-*.sra` cannot
     /// silently feed garbage to the VDB decoder.
     pub expected_prefix: Option<Vec<u8>>,
+}
+
+/// How many times to re-enter a resumable transfer, and how long to wait
+/// between attempts.
+///
+/// The per-chunk retry loop in [`download_chunk`] rides out a host that is
+/// briefly unhappy — a few seconds of backoff across [`MAX_RETRIES`]
+/// attempts. It cannot ride out an outage measured in minutes, which is what
+/// ENA produces during an instability window: one chunk burns its attempts,
+/// its error aborts the whole file, and a multi-hour transfer that was nearly
+/// finished exits with the user left to re-run it by hand.
+///
+/// This policy governs the outer loop, which waits far longer and then
+/// resumes from the `.sracha-progress` sidecar. Completed chunks are not
+/// re-fetched, so a retry costs only the bytes still missing.
+#[derive(Debug, Clone)]
+pub struct TransferRetryPolicy {
+    /// Total whole-file attempts, including the first. `1` disables retrying.
+    pub attempts: u32,
+    /// Delay before the first resume; doubles on each subsequent attempt.
+    pub base_delay: std::time::Duration,
+    /// Upper bound on any single delay, before jitter.
+    pub cap_delay: std::time::Duration,
+}
+
+impl Default for TransferRetryPolicy {
+    fn default() -> Self {
+        Self {
+            attempts: 4,
+            base_delay: std::time::Duration::from_secs(30),
+            cap_delay: std::time::Duration::from_secs(300),
+        }
+    }
+}
+
+impl TransferRetryPolicy {
+    /// Disable outer retries entirely.
+    pub fn none() -> Self {
+        Self {
+            attempts: 1,
+            ..Self::default()
+        }
+    }
+
+    /// Deterministic exponential delay before `attempt` (1-based), capped.
+    /// Jitter is added by the caller so this stays pure and testable.
+    fn base_delay_for(&self, attempt: u32) -> std::time::Duration {
+        let shift = attempt.saturating_sub(1).min(31);
+        self.base_delay
+            .saturating_mul(1u32 << shift)
+            .min(self.cap_delay)
+    }
+}
+
+/// Is `e` worth another whole-file attempt?
+///
+/// Only transport failures are, because those leave the partial file and its
+/// sidecar intact for a resume. The others would either waste the wait or do
+/// the wrong thing: a cancellation is the user's decision; a checksum
+/// mismatch has already deleted the output, so "resuming" would silently
+/// become a full re-download of a file we have no reason to think will hash
+/// differently; and an I/O error is usually a full disk or bad permissions,
+/// which waiting does not fix.
+fn is_resumable_transfer_error(e: &Error) -> bool {
+    matches!(e, Error::Http(_) | Error::Download { .. })
+}
+
+/// [`download_file`], re-entered on transport failure so a resumable transfer
+/// survives an outage longer than the per-chunk retry budget.
+///
+/// Each retry resumes via the progress sidecar rather than starting over.
+/// Retrying is skipped when `config.resume` is off, since every attempt would
+/// then re-fetch the file from byte zero.
+pub async fn download_file_with_retries(
+    urls: &[String],
+    expected_size: u64,
+    expected_md5: Option<&str>,
+    output_path: &Path,
+    config: &DownloadConfig,
+    policy: &TransferRetryPolicy,
+) -> Result<DownloadResult> {
+    let attempts = if config.resume {
+        policy.attempts.max(1)
+    } else {
+        1
+    };
+
+    // `force` means "start fresh". That is right for the first attempt and
+    // wrong for every later one: left set, it would delete the partial file
+    // and sidecar each time, so each "resume" would restart from zero.
+    let resume_config = if config.force {
+        let mut c = config.clone();
+        c.force = false;
+        Some(c)
+    } else {
+        None
+    };
+
+    let mut last_error: Option<Error> = None;
+
+    for attempt in 0..attempts {
+        if attempt > 0 {
+            let base = policy.base_delay_for(attempt);
+            let delay = base
+                + std::time::Duration::from_millis(crate::util::jitter_ms(
+                    base.as_millis().min(u128::from(u64::MAX)) as u64,
+                ));
+            tracing::warn!(
+                "transfer failed ({}); resuming {} in {:?} (attempt {}/{attempts})",
+                last_error
+                    .as_ref()
+                    .map(|e| e.to_string())
+                    .unwrap_or_default(),
+                output_path.display(),
+                delay,
+                attempt + 1,
+            );
+            // The pause can run to minutes; say so rather than leaving a
+            // stalled progress bar as the only sign of life.
+            eprintln!(
+                "warning: transfer interrupted — resuming in {}s (attempt {}/{attempts})",
+                delay.as_secs(),
+                attempt + 1,
+            );
+            tokio::time::sleep(delay).await;
+        }
+
+        let cfg = if attempt == 0 {
+            config
+        } else {
+            resume_config.as_ref().unwrap_or(config)
+        };
+
+        match download_file(urls, expected_size, expected_md5, output_path, cfg).await {
+            Ok(result) => return Ok(result),
+            Err(e) if is_resumable_transfer_error(&e) => last_error = Some(e),
+            // Not worth another attempt — surface it now.
+            Err(e) => return Err(e),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| Error::Download {
+        accession: String::new(),
+        message: "transfer failed with no error captured".into(),
+    }))
 }
 
 impl Default for DownloadConfig {
@@ -1176,6 +1322,53 @@ mod tests {
         assert_eq!(backoff_base_ms(3), 2000);
         assert_eq!(backoff_base_ms(4), 4000);
         assert_eq!(backoff_base_ms(5), 8000);
+    }
+
+    #[test]
+    fn test_transfer_retry_policy_defaults() {
+        let p = TransferRetryPolicy::default();
+        assert_eq!(p.attempts, 4);
+        assert_eq!(p.base_delay, std::time::Duration::from_secs(30));
+        assert_eq!(p.cap_delay, std::time::Duration::from_secs(300));
+        assert_eq!(TransferRetryPolicy::none().attempts, 1);
+    }
+
+    #[test]
+    fn test_transfer_retry_delay_exponential_and_capped() {
+        let p = TransferRetryPolicy::default();
+        assert_eq!(p.base_delay_for(1), std::time::Duration::from_secs(30));
+        assert_eq!(p.base_delay_for(2), std::time::Duration::from_secs(60));
+        assert_eq!(p.base_delay_for(3), std::time::Duration::from_secs(120));
+        assert_eq!(p.base_delay_for(4), std::time::Duration::from_secs(240));
+        // Capped from here on, with no overflow from the shift.
+        assert_eq!(p.base_delay_for(5), std::time::Duration::from_secs(300));
+        assert_eq!(p.base_delay_for(64), std::time::Duration::from_secs(300));
+        assert_eq!(
+            p.base_delay_for(u32::MAX),
+            std::time::Duration::from_secs(300)
+        );
+    }
+
+    #[test]
+    fn test_only_transport_errors_are_resumable() {
+        assert!(is_resumable_transfer_error(&Error::Download {
+            accession: String::new(),
+            message: "connection reset".into(),
+        }));
+
+        // A cancellation is the user's call, a checksum mismatch already
+        // deleted the output, and I/O errors (e.g. a full disk) don't heal
+        // by waiting — none should burn a retry.
+        assert!(!is_resumable_transfer_error(&Error::Cancelled {
+            output_files: vec![],
+        }));
+        assert!(!is_resumable_transfer_error(&Error::ChecksumMismatch {
+            expected: "a".into(),
+            actual: "b".into(),
+        }));
+        assert!(!is_resumable_transfer_error(&Error::Io(
+            std::io::Error::other("no space left on device"),
+        )));
     }
 
     #[test]

--- a/crates/sracha-core/src/ena.rs
+++ b/crates/sracha-core/src/ena.rs
@@ -21,6 +21,15 @@ const ENA_FILEREPORT_URL: &str = "https://www.ebi.ac.uk/ena/portal/api/filerepor
 /// Maximum retry attempts for HTTP 429 / 5xx responses.
 const MAX_API_RETRIES: u32 = 3;
 
+/// Connection cap for ENA FASTQ downloads.
+///
+/// ENA serves FASTQ from a single Apache host (`ftp.sra.ebi.ac.uk`), which is
+/// far more sensitive to parallel-connection pressure than NCBI's S3 backend.
+/// The download layer's S3-tuned auto-scale floor (24 connections on large
+/// files) triggers connection-limit refusals here, so ENA transfers are capped
+/// to this gentler value. `--connections` may still lower it further.
+pub const ENA_MAX_CONNECTIONS: usize = 6;
+
 /// Concurrency cap for batch queries. ENA allows 50 req/s; 20 in-flight
 /// gives headroom for other API calls sharing the same process.
 const ENA_BATCH_CONCURRENCY: usize = 20;
@@ -32,9 +41,9 @@ const ENA_FIELDS: &str = "run_accession,fastq_ftp,fastq_md5,fastq_bytes";
 /// One downloadable FASTQ file from ENA.
 #[derive(Debug, Clone)]
 pub struct EnaFastqFile {
-    /// HTTP URL (the filereport returns `ftp://` paths; we rewrite to `http://`
-    /// because `ftp.sra.ebi.ac.uk` serves the same paths over HTTP without
-    /// authentication).
+    /// HTTPS URL (the filereport returns `ftp://` paths; we rewrite to
+    /// `https://` because `ftp.sra.ebi.ac.uk` serves the same paths over HTTPS
+    /// without authentication).
     pub url: String,
     /// MD5 hex digest for integrity verification post-download.
     pub md5: String,
@@ -84,7 +93,7 @@ async fn http_get_with_retry(
             && attempt < MAX_API_RETRIES
         {
             let base = std::time::Duration::from_secs(1 << attempt);
-            let jitter = std::time::Duration::from_millis(rand_jitter_ms());
+            let jitter = std::time::Duration::from_millis(crate::util::jitter_ms(500));
             let delay = base + jitter;
             tracing::info!(
                 "HTTP {status} from ENA {url}, retry {}/{MAX_API_RETRIES} in {delay:?}",
@@ -97,14 +106,6 @@ async fn http_get_with_retry(
         return Ok(resp);
     }
     unreachable!()
-}
-
-fn rand_jitter_ms() -> u64 {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .subsec_nanos();
-    (nanos % 500) as u64
 }
 
 /// Build the filereport URL for a given accession (run or project).
@@ -191,7 +192,7 @@ fn row_to_resolved(row: FilereportRow) -> Option<EnaResolved> {
             return None;
         }
         files.push(EnaFastqFile {
-            url: ftp_to_http(ftp),
+            url: ftp_to_https(ftp),
             md5: md5s[i].to_string(),
             size,
             slot: slots[i],
@@ -214,22 +215,24 @@ fn split_or_empty(s: &str) -> Vec<&str> {
     }
 }
 
-/// Normalize a `fastq_ftp` value from ENA to an `http://` URL.
+/// Normalize a `fastq_ftp` value from ENA to an `https://` URL.
 ///
 /// ENA's filereport returns values in one of three forms:
 /// `ftp://ftp.sra.ebi.ac.uk/...`, `ftp.sra.ebi.ac.uk/...` (scheme-less,
 /// the common case today), or `http://ftp.sra.ebi.ac.uk/...`. ENA serves
-/// the same paths over HTTP on the same host, so we normalize all three
-/// to `http://...`. HTTP avoids FTP client baggage (PASV, separate
-/// control/data connections) and lets the existing parallel chunked
-/// downloader reuse HTTP connection pools.
-fn ftp_to_http(url: &str) -> String {
+/// the same paths over HTTPS on the same host, so we normalize the `ftp://`
+/// and scheme-less forms to `https://...`. HTTPS avoids FTP client baggage
+/// (PASV, separate control/data connections), keeps the transfer encrypted,
+/// and lets the existing parallel chunked downloader reuse HTTP connection
+/// pools. An already-explicit `http://`/`https://` value is passed through
+/// unchanged (ENA still serves plain HTTP for callers that request it).
+fn ftp_to_https(url: &str) -> String {
     if let Some(rest) = url.strip_prefix("ftp://") {
-        format!("http://{rest}")
+        format!("https://{rest}")
     } else if url.starts_with("http://") || url.starts_with("https://") {
         url.to_string()
     } else {
-        format!("http://{url}")
+        format!("https://{url}")
     }
 }
 
@@ -340,35 +343,36 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ftp_to_http_rewrites_scheme() {
+    fn ftp_to_https_rewrites_scheme() {
         assert_eq!(
-            ftp_to_http("ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"),
-            "http://ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"
+            ftp_to_https("ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"),
+            "https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"
         );
     }
 
     #[test]
-    fn ftp_to_http_passes_http_through() {
+    fn ftp_to_https_passes_http_through() {
+        // An already-explicit http:// value is left as-is.
         assert_eq!(
-            ftp_to_http("http://example.com/x.fastq.gz"),
+            ftp_to_https("http://example.com/x.fastq.gz"),
             "http://example.com/x.fastq.gz"
         );
     }
 
     #[test]
-    fn ftp_to_http_passes_https_through() {
+    fn ftp_to_https_passes_https_through() {
         assert_eq!(
-            ftp_to_http("https://example.com/x.fastq.gz"),
+            ftp_to_https("https://example.com/x.fastq.gz"),
             "https://example.com/x.fastq.gz"
         );
     }
 
     #[test]
-    fn ftp_to_http_prepends_when_schemeless() {
+    fn ftp_to_https_prepends_when_schemeless() {
         // ENA's filereport often returns schemeless paths like this.
         assert_eq!(
-            ftp_to_http("ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"),
-            "http://ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"
+            ftp_to_https("ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"),
+            "https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"
         );
     }
 
@@ -417,7 +421,7 @@ mod tests {
         assert_eq!(resolved.fastq_files[0].md5, "abc123");
         assert_eq!(resolved.fastq_files[0].size, 12345);
         assert_eq!(resolved.total_size, 12345);
-        assert!(resolved.fastq_files[0].url.starts_with("http://"));
+        assert!(resolved.fastq_files[0].url.starts_with("https://"));
     }
 
     #[test]

--- a/crates/sracha-core/src/ena.rs
+++ b/crates/sracha-core/src/ena.rs
@@ -345,7 +345,9 @@ mod tests {
     #[test]
     fn ftp_to_https_rewrites_scheme() {
         assert_eq!(
-            ftp_to_https("ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"),
+            ftp_to_https(
+                "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"
+            ),
             "https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR000/SRR000001/SRR000001_1.fastq.gz"
         );
     }

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -18,7 +18,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use rayon::prelude::*;
 
 use crate::compress::{DEFAULT_BLOCK_SIZE, ParGzWriter};
-use crate::download::{DownloadConfig, download_file};
+use crate::download::{
+    DownloadConfig, TransferRetryPolicy, download_file, download_file_with_retries,
+};
 use crate::error::{Error, Result};
 use crate::fastq::{
     CompressionMode, FastqConfig, IntegrityDiag, OutputSlot, SplitMode, output_filename,
@@ -1731,6 +1733,8 @@ pub async fn download_ena_fastq(
         expected_prefix: None,
     };
 
+    let retry_policy = TransferRetryPolicy::default();
+
     let mut output_files: Vec<PathBuf> = Vec::with_capacity(ena.fastq_files.len());
     let mut bytes_transferred: u64 = 0;
 
@@ -1762,7 +1766,17 @@ pub async fn download_ena_fastq(
         );
 
         let urls = vec![file.url.clone()];
-        let dl_future = download_file(&urls, file.size, Some(&file.md5), &target, &dl_config);
+        // ENA outages outlast the per-chunk retry budget, so re-enter the
+        // transfer (resuming from the sidecar) rather than losing a
+        // near-complete multi-GiB download to one bad minute.
+        let dl_future = download_file_with_retries(
+            &urls,
+            file.size,
+            Some(&file.md5),
+            &target,
+            &dl_config,
+            &retry_policy,
+        );
 
         let dl_outcome = if let Some(ref flag) = config.cancelled {
             let flag = flag.clone();
@@ -1784,8 +1798,9 @@ pub async fn download_ena_fastq(
             Ok(r) => r,
             Err(e) => {
                 eprintln!(
-                    "warning: {accession}: ENA transfer failed ({e}); partial download \
-                     and resume state kept at {} — re-run with --prefer-ena to resume",
+                    "warning: {accession}: ENA transfer failed after all resume attempts \
+                     ({e}); partial download and resume state kept at {} — re-run with \
+                     --prefer-ena to pick up where it left off",
                     target.display(),
                 );
                 return Err(e);

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -1630,6 +1630,7 @@ pub async fn download_sra(
 
     let dl_config = DownloadConfig {
         connections: config.connections,
+        auto_scale_connections: true,
         chunk_size: 0,
         force: config.force,
         validate: true,
@@ -1715,7 +1716,10 @@ pub async fn download_ena_fastq(
     tokio::fs::create_dir_all(&acc_dir).await?;
 
     let dl_config = DownloadConfig {
-        connections: config.connections,
+        // ENA serves from a single Apache host; cap concurrency and skip the
+        // S3-tuned auto-scale floor so we don't trip connection limits.
+        connections: config.connections.min(crate::ena::ENA_MAX_CONNECTIONS),
+        auto_scale_connections: false,
         chunk_size: 0,
         force: config.force,
         validate: true,
@@ -1760,17 +1764,32 @@ pub async fn download_ena_fastq(
         let urls = vec![file.url.clone()];
         let dl_future = download_file(&urls, file.size, Some(&file.md5), &target, &dl_config);
 
-        let dl_result = if let Some(ref flag) = config.cancelled {
+        let dl_outcome = if let Some(ref flag) = config.cancelled {
             let flag = flag.clone();
             tokio::select! {
-                result = dl_future => result?,
+                result = dl_future => result,
                 _ = poll_cancelled(flag) => {
                     tracing::info!("{accession}: ENA download cancelled");
                     return Err(Error::Cancelled { output_files });
                 }
             }
         } else {
-            dl_future.await?
+            dl_future.await
+        };
+        // On a genuine transfer failure (e.g. ENA refusing connections), the
+        // partial file + `.sracha-progress` sidecar are preserved by
+        // `download_file`; tell the user re-running resumes rather than
+        // silently discarding progress.
+        let dl_result = match dl_outcome {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!(
+                    "warning: {accession}: ENA transfer failed ({e}); partial download \
+                     and resume state kept at {} — re-run with --prefer-ena to resume",
+                    target.display(),
+                );
+                return Err(e);
+            }
         };
 
         bytes_transferred += dl_result.bytes_transferred;

--- a/crates/sracha-core/src/util.rs
+++ b/crates/sracha-core/src/util.rs
@@ -47,9 +47,40 @@ pub fn format_bases(b: u64) -> String {
     }
 }
 
+/// Return a pseudo-random jitter in `0..max` milliseconds.
+///
+/// Derives entropy from the current time's sub-second nanoseconds — good
+/// enough to de-synchronize concurrent retry backoffs (avoiding a thundering
+/// herd against a struggling host) without pulling in a `rand` dependency.
+/// `max == 0` yields `0`.
+pub fn jitter_ms(max: u64) -> u64 {
+    if max == 0 {
+        return 0;
+    }
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos() as u64;
+    nanos % max
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn jitter_ms_is_bounded() {
+        for max in [1u64, 7, 500, 1000] {
+            for _ in 0..64 {
+                assert!(jitter_ms(max) < max);
+            }
+        }
+    }
+
+    #[test]
+    fn jitter_ms_zero_max() {
+        assert_eq!(jitter_ms(0), 0);
+    }
 
     #[test]
     fn format_size_bytes() {

--- a/crates/sracha-core/tests/download.rs
+++ b/crates/sracha-core/tests/download.rs
@@ -388,10 +388,16 @@ async fn download_file_resumes_missing_chunk_via_sidecar() {
 
     // First run: the chunk at `fail_offset` fails all retries → error, but
     // the other four chunks land and get recorded in the sidecar.
-    let err = download_file(&[url.clone()], size as u64, Some(&expected_md5), &out, &cfg)
-        .await
-        .err()
-        .expect("first run must fail on the injected bad chunk");
+    let err = download_file(
+        std::slice::from_ref(&url),
+        size as u64,
+        Some(&expected_md5),
+        &out,
+        &cfg,
+    )
+    .await
+    .err()
+    .expect("first run must fail on the injected bad chunk");
     let _ = err;
 
     let sidecar = out.parent().unwrap().join(format!(

--- a/crates/sracha-core/tests/download.rs
+++ b/crates/sracha-core/tests/download.rs
@@ -6,10 +6,12 @@
 //! hermetic — no network access required. They're NOT marked `#[ignore]`.
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use sracha_core::download::{DownloadConfig, download_file};
 use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 
 /// Build a DownloadConfig appropriate for hermetic tests: progress off,
 /// single connection, tiny chunks so we get >1 chunk for small payloads.
@@ -21,6 +23,7 @@ fn test_config() -> DownloadConfig {
         validate: true,
         progress: false,
         resume: false,
+        auto_scale_connections: false,
         client: None,
         expected_prefix: None,
     }
@@ -269,13 +272,159 @@ async fn download_file_force_overwrites_existing_even_when_complete() {
     assert_eq!(std::fs::read(&out).unwrap(), payload);
 }
 
-// NOTE — a full sidecar-driven resume test (pre-populated `.sracha-progress`
-// + partial file → only missing chunks re-fetched) is deliberately absent.
-// The sidecar-aware branch in `download_file` only engages when
-// `file_size >= SMALL_FILE` (32 MiB) so the parallel path is chosen, AND
-// when the existing file doesn't already pass the pre-download MD5
-// shortcut. Crossing both thresholds with an in-process mock requires a
-// Range-aware HTTP server (wiremock's matchers can't condition the
-// response body on the `Range` header), plus a 32+ MiB payload per
-// invocation. Left as a follow-up once either constraint is addressed
-// (custom hyper-based mock, or a tunable SMALL_FILE exposed in config).
+#[tokio::test]
+async fn download_file_recovers_after_transient_failure() {
+    // A chunk fails once (503) then succeeds — exercises the per-chunk
+    // retry/backoff path added for flaky hosts like ENA. The retry loop lives
+    // on the parallel chunked path, which only engages for files >= 32 MiB
+    // (SMALL_FILE); use a single 33 MiB chunk so the whole-body 206 is valid.
+    let server = MockServer::start().await;
+    let size = 33 * 1024 * 1024usize;
+    let payload: Vec<u8> = (0..size).map(|i| (i * 17 + 3) as u8).collect();
+
+    // First GET → 503, consumed after one response...
+    Mock::given(method("GET"))
+        .and(path("/flaky"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(1)
+        .with_priority(1)
+        .mount(&server)
+        .await;
+    // ...subsequent GET (the retry) → 206 with the full body (one chunk).
+    Mock::given(method("GET"))
+        .and(path("/flaky"))
+        .respond_with(ResponseTemplate::new(206).set_body_bytes(payload.clone()))
+        .with_priority(2)
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/flaky", server.uri());
+    let (_dir, out) = tmp_out("flaky.sra");
+    let expected_md5 = md5_hex(&payload);
+
+    let cfg = DownloadConfig {
+        connections: 1,
+        chunk_size: 64 * 1024 * 1024, // one chunk covering the whole file
+        ..test_config()
+    };
+    let res = download_file(&[url], size as u64, Some(&expected_md5), &out, &cfg)
+        .await
+        .expect("download must recover after a transient 503");
+    assert_eq!(std::fs::read(&out).unwrap(), payload);
+    assert!(res.bytes_transferred > 0);
+}
+
+/// A `Range`-aware mock responder: serves the requested byte slice as a 206,
+/// records every requested chunk start, and can be told to fail (503) the
+/// chunk beginning at a specific offset. `fail_start == u64::MAX` disables
+/// failure injection. This is what lets us drive the parallel + sidecar
+/// resume path that plain wiremock matchers can't.
+struct RangeResponder {
+    body: Vec<u8>,
+    fail_start: Arc<AtomicU64>,
+    requested_starts: Arc<Mutex<Vec<u64>>>,
+}
+
+impl Respond for RangeResponder {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        let raw = request
+            .headers
+            .get("range")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("bytes="))
+            .unwrap_or("");
+        let (start, end) = raw
+            .split_once('-')
+            .and_then(|(a, b)| Some((a.parse::<u64>().ok()?, b.parse::<u64>().ok()?)))
+            .expect("test always sends a well-formed byte range");
+
+        self.requested_starts.lock().unwrap().push(start);
+
+        if self.fail_start.load(Ordering::SeqCst) == start {
+            return ResponseTemplate::new(503);
+        }
+        let slice = &self.body[start as usize..=end as usize];
+        ResponseTemplate::new(206).set_body_bytes(slice.to_vec())
+    }
+}
+
+#[tokio::test]
+async fn download_file_resumes_missing_chunk_via_sidecar() {
+    // Cross both thresholds for the parallel + sidecar path: a > 32 MiB file
+    // (SMALL_FILE) downloaded in 8 MiB chunks. One chunk fails on the first
+    // run, leaving a partial file + `.sracha-progress`; the second run must
+    // resume and re-fetch ONLY that chunk.
+    const CHUNK: u64 = 8 * 1024 * 1024;
+    let size = (5 * CHUNK) as usize; // 40 MiB => chunks at 0,8,16,24,32 MiB
+    let fail_offset = 2 * CHUNK; // fail the chunk starting at 16 MiB
+
+    // Deterministic, non-uniform payload so MD5 is meaningful.
+    let payload: Vec<u8> = (0..size).map(|i| (i * 31 + 7) as u8).collect();
+    let expected_md5 = md5_hex(&payload);
+
+    let fail_start = Arc::new(AtomicU64::new(fail_offset));
+    let requested = Arc::new(Mutex::new(Vec::<u64>::new()));
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/big"))
+        .respond_with(RangeResponder {
+            body: payload.clone(),
+            fail_start: fail_start.clone(),
+            requested_starts: requested.clone(),
+        })
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/big", server.uri());
+    let (_dir, out) = tmp_out("big.sra");
+
+    let cfg = DownloadConfig {
+        connections: 4,
+        chunk_size: CHUNK,
+        resume: true,
+        ..test_config()
+    };
+
+    // First run: the chunk at `fail_offset` fails all retries → error, but
+    // the other four chunks land and get recorded in the sidecar.
+    let err = download_file(&[url.clone()], size as u64, Some(&expected_md5), &out, &cfg)
+        .await
+        .err()
+        .expect("first run must fail on the injected bad chunk");
+    let _ = err;
+
+    let sidecar = out
+        .parent()
+        .unwrap()
+        .join(format!(".{}.sracha-progress", out.file_name().unwrap().to_str().unwrap()));
+    assert!(sidecar.exists(), "sidecar must persist partial progress");
+    assert_eq!(
+        std::fs::metadata(&out).unwrap().len(),
+        size as u64,
+        "output is preallocated to full size"
+    );
+
+    // Second run: stop failing and resume. Only the missing chunk should be
+    // fetched this time.
+    fail_start.store(u64::MAX, Ordering::SeqCst);
+    requested.lock().unwrap().clear();
+
+    let res = download_file(&[url], size as u64, Some(&expected_md5), &out, &cfg)
+        .await
+        .expect("resume run must complete");
+
+    assert_eq!(res.md5.as_deref(), Some(expected_md5.as_str()));
+    assert_eq!(std::fs::read(&out).unwrap(), payload);
+
+    let starts = requested.lock().unwrap().clone();
+    assert_eq!(
+        starts,
+        vec![fail_offset],
+        "resume must re-fetch only the previously-failed chunk"
+    );
+    assert!(
+        !sidecar.exists(),
+        "sidecar is cleaned up after a successful completion"
+    );
+}

--- a/crates/sracha-core/tests/download.rs
+++ b/crates/sracha-core/tests/download.rs
@@ -9,7 +9,9 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use sracha_core::download::{DownloadConfig, download_file};
+use sracha_core::download::{
+    DownloadConfig, TransferRetryPolicy, download_file, download_file_with_retries,
+};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 
@@ -432,5 +434,235 @@ async fn download_file_resumes_missing_chunk_via_sidecar() {
     assert!(
         !sidecar.exists(),
         "sidecar is cleaned up after a successful completion"
+    );
+}
+
+/// A `Range`-aware responder that fails one chunk hard enough to exhaust the
+/// per-chunk retry budget, then relents. Models an outage that outlives the
+/// inner retries but not the outer resume loop.
+struct OutageResponder {
+    body: Vec<u8>,
+    fail_start: u64,
+    /// How many requests for `fail_start` to reject before serving it.
+    fail_times: u64,
+    failures: Arc<AtomicU64>,
+    requested_starts: Arc<Mutex<Vec<u64>>>,
+}
+
+impl Respond for OutageResponder {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        let raw = request
+            .headers
+            .get("range")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("bytes="))
+            .unwrap_or("");
+        let (start, end) = raw
+            .split_once('-')
+            .and_then(|(a, b)| Some((a.parse::<u64>().ok()?, b.parse::<u64>().ok()?)))
+            .expect("test always sends a well-formed byte range");
+
+        self.requested_starts.lock().unwrap().push(start);
+
+        if start == self.fail_start && self.failures.load(Ordering::SeqCst) < self.fail_times {
+            self.failures.fetch_add(1, Ordering::SeqCst);
+            return ResponseTemplate::new(503);
+        }
+        ResponseTemplate::new(206).set_body_bytes(self.body[start as usize..=end as usize].to_vec())
+    }
+}
+
+#[tokio::test]
+async fn download_file_with_retries_resumes_after_exhausting_chunk_retries() {
+    // One chunk fails 5 times — the full per-chunk budget (MAX_RETRIES) — so
+    // the first whole-file attempt errors out. The outer loop must then
+    // resume from the sidecar and finish, re-fetching ONLY the failed chunk.
+    const CHUNK: u64 = 8 * 1024 * 1024;
+    const CHUNK_RETRY_BUDGET: u64 = 5;
+    let size = (5 * CHUNK) as usize; // 40 MiB => chunks at 0,8,16,24,32 MiB
+    let fail_offset = 3 * CHUNK;
+
+    let payload: Vec<u8> = (0..size).map(|i| (i * 13 + 5) as u8).collect();
+    let expected_md5 = md5_hex(&payload);
+    let requested = Arc::new(Mutex::new(Vec::<u64>::new()));
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/outage"))
+        .respond_with(OutageResponder {
+            body: payload.clone(),
+            fail_start: fail_offset,
+            fail_times: CHUNK_RETRY_BUDGET,
+            failures: Arc::new(AtomicU64::new(0)),
+            requested_starts: requested.clone(),
+        })
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/outage", server.uri());
+    let (_dir, out) = tmp_out("outage.sra");
+
+    let cfg = DownloadConfig {
+        connections: 4,
+        chunk_size: CHUNK,
+        resume: true,
+        ..test_config()
+    };
+    // Near-zero delays: the timing policy is unit-tested separately, this
+    // test is about the loop re-entering and resuming.
+    let policy = TransferRetryPolicy {
+        attempts: 3,
+        base_delay: std::time::Duration::from_millis(10),
+        cap_delay: std::time::Duration::from_millis(10),
+    };
+
+    let res = download_file_with_retries(
+        std::slice::from_ref(&url),
+        size as u64,
+        Some(&expected_md5),
+        &out,
+        &cfg,
+        &policy,
+    )
+    .await
+    .expect("outer retry must resume and complete the transfer");
+
+    assert_eq!(res.md5.as_deref(), Some(expected_md5.as_str()));
+    assert_eq!(std::fs::read(&out).unwrap(), payload);
+
+    // The decisive assertion: chunks that succeeded on the first attempt were
+    // NOT re-fetched by the retry. Only the failed chunk was requested again,
+    // which is what makes an outer retry cheap rather than a full restart.
+    let starts = requested.lock().unwrap().clone();
+    for offset in [0, CHUNK, 2 * CHUNK, 4 * CHUNK] {
+        assert_eq!(
+            starts.iter().filter(|&&s| s == offset).count(),
+            1,
+            "chunk at {offset} must be fetched exactly once across both attempts"
+        );
+    }
+    assert_eq!(
+        starts.iter().filter(|&&s| s == fail_offset).count() as u64,
+        CHUNK_RETRY_BUDGET + 1,
+        "failed chunk: 5 rejected attempts, then one success on the resume"
+    );
+}
+
+#[tokio::test]
+async fn download_file_with_retries_does_not_retry_checksum_mismatch() {
+    // A corrupt body is not a transport failure: download_file deletes the
+    // output, so a "resume" would silently become a full re-download. The
+    // outer loop must surface it on the first attempt instead of burning
+    // every retry re-fetching a file that will hash the same way again.
+    let server = MockServer::start().await;
+    let size = 33 * 1024 * 1024usize;
+    let payload: Vec<u8> = (0..size).map(|i| (i * 7 + 1) as u8).collect();
+    let requested = Arc::new(Mutex::new(Vec::<u64>::new()));
+
+    Mock::given(method("GET"))
+        .and(path("/corrupt"))
+        .respond_with(OutageResponder {
+            body: payload.clone(),
+            fail_start: u64::MAX, // never inject a transport failure
+            fail_times: 0,
+            failures: Arc::new(AtomicU64::new(0)),
+            requested_starts: requested.clone(),
+        })
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/corrupt", server.uri());
+    let (_dir, out) = tmp_out("corrupt.sra");
+
+    let cfg = DownloadConfig {
+        connections: 1,
+        chunk_size: 64 * 1024 * 1024, // one chunk covering the whole file
+        resume: true,
+        ..test_config()
+    };
+    let policy = TransferRetryPolicy {
+        attempts: 3,
+        base_delay: std::time::Duration::from_millis(10),
+        cap_delay: std::time::Duration::from_millis(10),
+    };
+
+    let wrong_md5 = md5_hex(b"not the payload");
+    let err = download_file_with_retries(
+        std::slice::from_ref(&url),
+        size as u64,
+        Some(&wrong_md5),
+        &out,
+        &cfg,
+        &policy,
+    )
+    .await
+    .err()
+    .expect("checksum mismatch must fail");
+    assert!(
+        matches!(err, sracha_core::error::Error::ChecksumMismatch { .. }),
+        "expected ChecksumMismatch, got {err:?}"
+    );
+    assert_eq!(
+        requested.lock().unwrap().len(),
+        1,
+        "must not re-download after a checksum mismatch"
+    );
+}
+
+#[tokio::test]
+async fn download_file_with_retries_skips_retrying_when_resume_disabled() {
+    // With resume off there is no sidecar, so every attempt would restart
+    // from byte zero — retrying a 40 GiB transfer that way is worse than
+    // failing fast. One attempt only.
+    let server = MockServer::start().await;
+    let size = 33 * 1024 * 1024usize;
+    let payload: Vec<u8> = (0..size).map(|i| (i * 3 + 2) as u8).collect();
+    let requested = Arc::new(Mutex::new(Vec::<u64>::new()));
+
+    Mock::given(method("GET"))
+        .and(path("/always-fails"))
+        .respond_with(OutageResponder {
+            body: payload.clone(),
+            fail_start: 0,
+            fail_times: u64::MAX, // never recovers
+            failures: Arc::new(AtomicU64::new(0)),
+            requested_starts: requested.clone(),
+        })
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/always-fails", server.uri());
+    let (_dir, out) = tmp_out("noresume.sra");
+
+    let cfg = DownloadConfig {
+        connections: 1,
+        chunk_size: 64 * 1024 * 1024,
+        resume: false,
+        ..test_config()
+    };
+    let policy = TransferRetryPolicy {
+        attempts: 4,
+        base_delay: std::time::Duration::from_millis(10),
+        cap_delay: std::time::Duration::from_millis(10),
+    };
+
+    let expected_md5 = md5_hex(&payload);
+    let _ = download_file_with_retries(
+        std::slice::from_ref(&url),
+        size as u64,
+        Some(&expected_md5),
+        &out,
+        &cfg,
+        &policy,
+    )
+    .await
+    .err()
+    .expect("transfer must fail");
+
+    // Exactly one whole-file attempt: the chunk's own 5 retries, no more.
+    assert_eq!(
+        requested.lock().unwrap().len(),
+        5,
+        "resume disabled => a single whole-file attempt (5 chunk retries)"
     );
 }

--- a/crates/sracha-core/tests/download.rs
+++ b/crates/sracha-core/tests/download.rs
@@ -394,10 +394,10 @@ async fn download_file_resumes_missing_chunk_via_sidecar() {
         .expect("first run must fail on the injected bad chunk");
     let _ = err;
 
-    let sidecar = out
-        .parent()
-        .unwrap()
-        .join(format!(".{}.sracha-progress", out.file_name().unwrap().to_str().unwrap()));
+    let sidecar = out.parent().unwrap().join(format!(
+        ".{}.sracha-progress",
+        out.file_name().unwrap().to_str().unwrap()
+    ));
     assert!(sidecar.exists(), "sidecar must persist partial progress");
     assert_eq!(
         std::fs::metadata(&out).unwrap().len(),

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -135,20 +135,25 @@ async fn main() -> Result<()> {
                         format_size(file.size),
                         out.display(),
                     );
-                    if let Err(e) = sracha_core::download::download_file(
+                    // ENA outages outlast the per-chunk retry budget, so
+                    // re-enter the transfer (resuming from the sidecar)
+                    // rather than losing a near-complete download.
+                    if let Err(e) = sracha_core::download::download_file_with_retries(
                         std::slice::from_ref(&file.url),
                         file.size,
                         Some(&file.md5),
                         &out,
                         &dl_config,
+                        &sracha_core::download::TransferRetryPolicy::default(),
                     )
                     .await
                     {
                         // Partial file + sidecar are preserved by download_file;
                         // re-running resumes rather than starting over.
                         eprintln!(
-                            "{}: ENA transfer failed ({e}); partial download and resume \
-                             state kept at {} — re-run with --prefer-ena to resume",
+                            "{}: ENA transfer failed after all resume attempts ({e}); \
+                             partial download and resume state kept at {} — re-run with \
+                             --prefer-ena to pick up where it left off",
                             style::header(acc),
                             style::path(out.display()),
                         );

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -117,9 +117,7 @@ async fn main() -> Result<()> {
                     // ENA serves from a single Apache host; cap concurrency and
                     // skip the S3-tuned auto-scale floor to avoid connection
                     // limits. --connections may still lower it further.
-                    connections: args
-                        .connections
-                        .min(sracha_core::ena::ENA_MAX_CONNECTIONS),
+                    connections: args.connections.min(sracha_core::ena::ENA_MAX_CONNECTIONS),
                     auto_scale_connections: false,
                     force: args.force,
                     validate: !args.no_validate,

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -114,7 +114,13 @@ async fn main() -> Result<()> {
                     continue;
                 };
                 let dl_config = sracha_core::download::DownloadConfig {
-                    connections: args.connections,
+                    // ENA serves from a single Apache host; cap concurrency and
+                    // skip the S3-tuned auto-scale floor to avoid connection
+                    // limits. --connections may still lower it further.
+                    connections: args
+                        .connections
+                        .min(sracha_core::ena::ENA_MAX_CONNECTIONS),
+                    auto_scale_connections: false,
                     force: args.force,
                     validate: !args.no_validate,
                     progress: !args.no_progress,
@@ -131,14 +137,25 @@ async fn main() -> Result<()> {
                         format_size(file.size),
                         out.display(),
                     );
-                    sracha_core::download::download_file(
+                    if let Err(e) = sracha_core::download::download_file(
                         std::slice::from_ref(&file.url),
                         file.size,
                         Some(&file.md5),
                         &out,
                         &dl_config,
                     )
-                    .await?;
+                    .await
+                    {
+                        // Partial file + sidecar are preserved by download_file;
+                        // re-running resumes rather than starting over.
+                        eprintln!(
+                            "{}: ENA transfer failed ({e}); partial download and resume \
+                             state kept at {} — re-run with --prefer-ena to resume",
+                            style::header(acc),
+                            style::path(out.display()),
+                        );
+                        return Err(e.into());
+                    }
                     eprintln!(
                         "{}: {} downloaded from [{}]",
                         style::header(acc),


### PR DESCRIPTION
Fixes #89.

## Problem

`--prefer-ena` transfers inherited an NCBI-S3-tuned download policy that is a poor fit for ENA's single Apache host (`ftp.sra.ebi.ac.uk`). During an ENA instability window a large transfer made it most of the way, then the host began refusing TCP connections and the run died with `Connection refused (os error 111)`, leaving 214 of 592 chunks unfinished. Three code-level causes:

1. **ENA URLs forced to plain `http://`** (`ena::ftp_to_http`).
2. **Connection floor overrides `--connections`** — files ≥256 MiB got `config.connections.max(24)`, so ENA got 24 parallel streams even with `--connections 1`. That floor was benched against S3, not ENA.
3. **Per-chunk backoff too brief and un-jittered** — 250 ms / 500 ms over 3 attempts, so 200+ chunks retried in near-lockstep and amplified the refusal instead of riding it out.

## Changes

- **HTTPS**: `ftp_to_https` rewrites `ftp://`/scheme-less ENA paths to `https://` (same host serves it). Explicit `http://`/`https://` pass through unchanged.
- **Concurrency**: new `DownloadConfig::auto_scale_connections` (default `true` → NCBI S3 auto-scale-to-24 unchanged). ENA download sites set it `false` and cap at `ena::ENA_MAX_CONNECTIONS = 6`, honoring a lower `--connections`.
- **Backoff**: `MAX_RETRIES` 3 → 5; new pure `backoff_base_ms` (exponential 500 ms → 15 s cap) plus **full jitter** to de-synchronize concurrent chunk retries. Jitter helper promoted to shared `util::jitter_ms` and reused by `ena.rs`.
- **On failure** (per maintainer decision): no auto-fallback to NCBI. The partial file + `.sracha-progress` sidecar are preserved and the user is told re-running resumes.

## Tests

- Unit: `ftp_to_https_*`, `jitter_ms`, `backoff_base_ms` (exponential + cap).
- Integration (wiremock, hermetic): transient-503-then-recover, and a genuine **sidecar resume** test built on a new `Range`-aware mock responder — it proves the resume run re-fetches *only* the previously-failed chunk and cleans up the sidecar on success.
- Full suite green (262 core + 385 vdb lib, 8 download integration, CLI/main); `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean.

## End-to-end verified ✅

Run against live ENA — full results in [this comment](https://github.com/rnabioco/sracha-rs/pull/90#issuecomment-5137146376). Summary:

- URLs resolve as `https://ftp.sra.ebi.ac.uk/...` on :443.
- **6 concurrent sockets to ENA measured via `lsof`** (not just the debug line) on both a 347 MiB and a 4.55 GiB transfer — the latter in the same 64 MiB chunk tier as the reporter's failing run, where the old `max(24)` floor engaged.
- NCBI S3 path still auto-scales to 24 on the same >256 MiB file — no regression.
- `--connections 2` honored on ENA (previously impossible under the floor).
- Kill mid-transfer → sidecar preserved → resume re-fetched only the missing chunks → byte-exact MD5 against ENA's published digests.

Not exercised live: the failure-path warning and jittered backoff, since ENA stayed healthy throughout — both covered by the hermetic wiremock and `backoff_base_ms` tests. The reporter's `SRR37428186` itself was not run (~78 GB of FASTQ vs. available disk).

Testing surfaced a **separate pre-existing bug**, out of scope here: the disk-space preflight sizes against the NCBI SRA object even under `--prefer-ena`, which never downloads it. Filed as #91.
