### PR TITLE
fix(ena): retry interrupted ENA transfers with sidecar resume (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Fixes
 
+- Retry an interrupted `--prefer-ena` transfer instead of aborting the run
+  (#89). The per-chunk retry budget spans roughly a minute; ENA outages last
+  longer, so a single chunk exhausting its attempts would abort a transfer
+  that was nearly complete and leave the user to re-run it by hand. ENA
+  downloads now re-enter the transfer up to 4 times, waiting 30 s → 5 min
+  (doubling, with full jitter) between attempts and resuming from the
+  `.sracha-progress` sidecar, so completed chunks are never re-fetched.
+  Cancellations, checksum mismatches, and I/O errors such as a full disk are
+  surfaced immediately rather than burning retries, and retrying is skipped
+  under `--no-resume`, where every attempt would restart from byte zero.
 - Make `--prefer-ena` transfers resilient to ENA instability (#89). ENA FASTQ
   URLs are now fetched over `https://` instead of plain `http://`. ENA serves
   from a single Apache host that chokes under the S3-tuned connection floor

--- a/crates/sracha-core/src/download/mod.rs
+++ b/crates/sracha-core/src/download/mod.rs
@@ -42,6 +42,7 @@ fn backoff_base_ms(attempt: u32) -> u64 {
 const MEDIUM_FILE_CONNECTIONS: usize = 24;
 
 /// Configuration for parallel chunked downloads.
+#[derive(Clone)]
 pub struct DownloadConfig {
     /// Number of parallel connections (default 8).
     pub connections: usize,
@@ -72,6 +73,151 @@ pub struct DownloadConfig {
     /// archive magic (`NCBI.sra`) so a corrupt `.sracha-tmp-*.sra` cannot
     /// silently feed garbage to the VDB decoder.
     pub expected_prefix: Option<Vec<u8>>,
+}
+
+/// How many times to re-enter a resumable transfer, and how long to wait
+/// between attempts.
+///
+/// The per-chunk retry loop in [`download_chunk`] rides out a host that is
+/// briefly unhappy — a few seconds of backoff across [`MAX_RETRIES`]
+/// attempts. It cannot ride out an outage measured in minutes, which is what
+/// ENA produces during an instability window: one chunk burns its attempts,
+/// its error aborts the whole file, and a multi-hour transfer that was nearly
+/// finished exits with the user left to re-run it by hand.
+///
+/// This policy governs the outer loop, which waits far longer and then
+/// resumes from the `.sracha-progress` sidecar. Completed chunks are not
+/// re-fetched, so a retry costs only the bytes still missing.
+#[derive(Debug, Clone)]
+pub struct TransferRetryPolicy {
+    /// Total whole-file attempts, including the first. `1` disables retrying.
+    pub attempts: u32,
+    /// Delay before the first resume; doubles on each subsequent attempt.
+    pub base_delay: std::time::Duration,
+    /// Upper bound on any single delay, before jitter.
+    pub cap_delay: std::time::Duration,
+}
+
+impl Default for TransferRetryPolicy {
+    fn default() -> Self {
+        Self {
+            attempts: 4,
+            base_delay: std::time::Duration::from_secs(30),
+            cap_delay: std::time::Duration::from_secs(300),
+        }
+    }
+}
+
+impl TransferRetryPolicy {
+    /// Disable outer retries entirely.
+    pub fn none() -> Self {
+        Self {
+            attempts: 1,
+            ..Self::default()
+        }
+    }
+
+    /// Deterministic exponential delay before `attempt` (1-based), capped.
+    /// Jitter is added by the caller so this stays pure and testable.
+    fn base_delay_for(&self, attempt: u32) -> std::time::Duration {
+        let shift = attempt.saturating_sub(1).min(31);
+        self.base_delay
+            .saturating_mul(1u32 << shift)
+            .min(self.cap_delay)
+    }
+}
+
+/// Is `e` worth another whole-file attempt?
+///
+/// Only transport failures are, because those leave the partial file and its
+/// sidecar intact for a resume. The others would either waste the wait or do
+/// the wrong thing: a cancellation is the user's decision; a checksum
+/// mismatch has already deleted the output, so "resuming" would silently
+/// become a full re-download of a file we have no reason to think will hash
+/// differently; and an I/O error is usually a full disk or bad permissions,
+/// which waiting does not fix.
+fn is_resumable_transfer_error(e: &Error) -> bool {
+    matches!(e, Error::Http(_) | Error::Download { .. })
+}
+
+/// [`download_file`], re-entered on transport failure so a resumable transfer
+/// survives an outage longer than the per-chunk retry budget.
+///
+/// Each retry resumes via the progress sidecar rather than starting over.
+/// Retrying is skipped when `config.resume` is off, since every attempt would
+/// then re-fetch the file from byte zero.
+pub async fn download_file_with_retries(
+    urls: &[String],
+    expected_size: u64,
+    expected_md5: Option<&str>,
+    output_path: &Path,
+    config: &DownloadConfig,
+    policy: &TransferRetryPolicy,
+) -> Result<DownloadResult> {
+    let attempts = if config.resume {
+        policy.attempts.max(1)
+    } else {
+        1
+    };
+
+    // `force` means "start fresh". That is right for the first attempt and
+    // wrong for every later one: left set, it would delete the partial file
+    // and sidecar each time, so each "resume" would restart from zero.
+    let resume_config = if config.force {
+        let mut c = config.clone();
+        c.force = false;
+        Some(c)
+    } else {
+        None
+    };
+
+    let mut last_error: Option<Error> = None;
+
+    for attempt in 0..attempts {
+        if attempt > 0 {
+            let base = policy.base_delay_for(attempt);
+            let delay = base
+                + std::time::Duration::from_millis(crate::util::jitter_ms(
+                    base.as_millis().min(u128::from(u64::MAX)) as u64,
+                ));
+            tracing::warn!(
+                "transfer failed ({}); resuming {} in {:?} (attempt {}/{attempts})",
+                last_error
+                    .as_ref()
+                    .map(|e| e.to_string())
+                    .unwrap_or_default(),
+                output_path.display(),
+                delay,
+                attempt + 1,
+            );
+            // The pause can run to minutes; say so rather than leaving a
+            // stalled progress bar as the only sign of life.
+            eprintln!(
+                "warning: transfer interrupted — resuming in {}s (attempt {}/{attempts})",
+                delay.as_secs(),
+                attempt + 1,
+            );
+            tokio::time::sleep(delay).await;
+        }
+
+        let cfg = if attempt == 0 {
+            config
+        } else {
+            resume_config.as_ref().unwrap_or(config)
+        };
+
+        match download_file(urls, expected_size, expected_md5, output_path, cfg).await {
+            Ok(result) => return Ok(result),
+            Err(e) if is_resumable_transfer_error(&e) => last_error = Some(e),
+            // Not worth another attempt — surface it now.
+            Err(e) => return Err(e),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| Error::Download {
+        accession: String::new(),
+        message: "transfer failed with no error captured".into(),
+    }))
 }
 
 impl Default for DownloadConfig {
@@ -1176,6 +1322,53 @@ mod tests {
         assert_eq!(backoff_base_ms(3), 2000);
         assert_eq!(backoff_base_ms(4), 4000);
         assert_eq!(backoff_base_ms(5), 8000);
+    }
+
+    #[test]
+    fn test_transfer_retry_policy_defaults() {
+        let p = TransferRetryPolicy::default();
+        assert_eq!(p.attempts, 4);
+        assert_eq!(p.base_delay, std::time::Duration::from_secs(30));
+        assert_eq!(p.cap_delay, std::time::Duration::from_secs(300));
+        assert_eq!(TransferRetryPolicy::none().attempts, 1);
+    }
+
+    #[test]
+    fn test_transfer_retry_delay_exponential_and_capped() {
+        let p = TransferRetryPolicy::default();
+        assert_eq!(p.base_delay_for(1), std::time::Duration::from_secs(30));
+        assert_eq!(p.base_delay_for(2), std::time::Duration::from_secs(60));
+        assert_eq!(p.base_delay_for(3), std::time::Duration::from_secs(120));
+        assert_eq!(p.base_delay_for(4), std::time::Duration::from_secs(240));
+        // Capped from here on, with no overflow from the shift.
+        assert_eq!(p.base_delay_for(5), std::time::Duration::from_secs(300));
+        assert_eq!(p.base_delay_for(64), std::time::Duration::from_secs(300));
+        assert_eq!(
+            p.base_delay_for(u32::MAX),
+            std::time::Duration::from_secs(300)
+        );
+    }
+
+    #[test]
+    fn test_only_transport_errors_are_resumable() {
+        assert!(is_resumable_transfer_error(&Error::Download {
+            accession: String::new(),
+            message: "connection reset".into(),
+        }));
+
+        // A cancellation is the user's call, a checksum mismatch already
+        // deleted the output, and I/O errors (e.g. a full disk) don't heal
+        // by waiting — none should burn a retry.
+        assert!(!is_resumable_transfer_error(&Error::Cancelled {
+            output_files: vec![],
+        }));
+        assert!(!is_resumable_transfer_error(&Error::ChecksumMismatch {
+            expected: "a".into(),
+            actual: "b".into(),
+        }));
+        assert!(!is_resumable_transfer_error(&Error::Io(
+            std::io::Error::other("no space left on device"),
+        )));
     }
 
     #[test]

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -18,7 +18,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use rayon::prelude::*;
 
 use crate::compress::{DEFAULT_BLOCK_SIZE, ParGzWriter};
-use crate::download::{DownloadConfig, download_file};
+use crate::download::{
+    DownloadConfig, TransferRetryPolicy, download_file, download_file_with_retries,
+};
 use crate::error::{Error, Result};
 use crate::fastq::{
     CompressionMode, FastqConfig, IntegrityDiag, OutputSlot, SplitMode, output_filename,
@@ -1731,6 +1733,8 @@ pub async fn download_ena_fastq(
         expected_prefix: None,
     };
 
+    let retry_policy = TransferRetryPolicy::default();
+
     let mut output_files: Vec<PathBuf> = Vec::with_capacity(ena.fastq_files.len());
     let mut bytes_transferred: u64 = 0;
 
@@ -1762,7 +1766,17 @@ pub async fn download_ena_fastq(
         );
 
         let urls = vec![file.url.clone()];
-        let dl_future = download_file(&urls, file.size, Some(&file.md5), &target, &dl_config);
+        // ENA outages outlast the per-chunk retry budget, so re-enter the
+        // transfer (resuming from the sidecar) rather than losing a
+        // near-complete multi-GiB download to one bad minute.
+        let dl_future = download_file_with_retries(
+            &urls,
+            file.size,
+            Some(&file.md5),
+            &target,
+            &dl_config,
+            &retry_policy,
+        );
 
         let dl_outcome = if let Some(ref flag) = config.cancelled {
             let flag = flag.clone();
@@ -1784,8 +1798,9 @@ pub async fn download_ena_fastq(
             Ok(r) => r,
             Err(e) => {
                 eprintln!(
-                    "warning: {accession}: ENA transfer failed ({e}); partial download \
-                     and resume state kept at {} — re-run with --prefer-ena to resume",
+                    "warning: {accession}: ENA transfer failed after all resume attempts \
+                     ({e}); partial download and resume state kept at {} — re-run with \
+                     --prefer-ena to pick up where it left off",
                     target.display(),
                 );
                 return Err(e);

--- a/crates/sracha-core/tests/download.rs
+++ b/crates/sracha-core/tests/download.rs
@@ -9,7 +9,9 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use sracha_core::download::{DownloadConfig, download_file};
+use sracha_core::download::{
+    DownloadConfig, TransferRetryPolicy, download_file, download_file_with_retries,
+};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 
@@ -432,5 +434,235 @@ async fn download_file_resumes_missing_chunk_via_sidecar() {
     assert!(
         !sidecar.exists(),
         "sidecar is cleaned up after a successful completion"
+    );
+}
+
+/// A `Range`-aware responder that fails one chunk hard enough to exhaust the
+/// per-chunk retry budget, then relents. Models an outage that outlives the
+/// inner retries but not the outer resume loop.
+struct OutageResponder {
+    body: Vec<u8>,
+    fail_start: u64,
+    /// How many requests for `fail_start` to reject before serving it.
+    fail_times: u64,
+    failures: Arc<AtomicU64>,
+    requested_starts: Arc<Mutex<Vec<u64>>>,
+}
+
+impl Respond for OutageResponder {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        let raw = request
+            .headers
+            .get("range")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("bytes="))
+            .unwrap_or("");
+        let (start, end) = raw
+            .split_once('-')
+            .and_then(|(a, b)| Some((a.parse::<u64>().ok()?, b.parse::<u64>().ok()?)))
+            .expect("test always sends a well-formed byte range");
+
+        self.requested_starts.lock().unwrap().push(start);
+
+        if start == self.fail_start && self.failures.load(Ordering::SeqCst) < self.fail_times {
+            self.failures.fetch_add(1, Ordering::SeqCst);
+            return ResponseTemplate::new(503);
+        }
+        ResponseTemplate::new(206).set_body_bytes(self.body[start as usize..=end as usize].to_vec())
+    }
+}
+
+#[tokio::test]
+async fn download_file_with_retries_resumes_after_exhausting_chunk_retries() {
+    // One chunk fails 5 times — the full per-chunk budget (MAX_RETRIES) — so
+    // the first whole-file attempt errors out. The outer loop must then
+    // resume from the sidecar and finish, re-fetching ONLY the failed chunk.
+    const CHUNK: u64 = 8 * 1024 * 1024;
+    const CHUNK_RETRY_BUDGET: u64 = 5;
+    let size = (5 * CHUNK) as usize; // 40 MiB => chunks at 0,8,16,24,32 MiB
+    let fail_offset = 3 * CHUNK;
+
+    let payload: Vec<u8> = (0..size).map(|i| (i * 13 + 5) as u8).collect();
+    let expected_md5 = md5_hex(&payload);
+    let requested = Arc::new(Mutex::new(Vec::<u64>::new()));
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/outage"))
+        .respond_with(OutageResponder {
+            body: payload.clone(),
+            fail_start: fail_offset,
+            fail_times: CHUNK_RETRY_BUDGET,
+            failures: Arc::new(AtomicU64::new(0)),
+            requested_starts: requested.clone(),
+        })
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/outage", server.uri());
+    let (_dir, out) = tmp_out("outage.sra");
+
+    let cfg = DownloadConfig {
+        connections: 4,
+        chunk_size: CHUNK,
+        resume: true,
+        ..test_config()
+    };
+    // Near-zero delays: the timing policy is unit-tested separately, this
+    // test is about the loop re-entering and resuming.
+    let policy = TransferRetryPolicy {
+        attempts: 3,
+        base_delay: std::time::Duration::from_millis(10),
+        cap_delay: std::time::Duration::from_millis(10),
+    };
+
+    let res = download_file_with_retries(
+        std::slice::from_ref(&url),
+        size as u64,
+        Some(&expected_md5),
+        &out,
+        &cfg,
+        &policy,
+    )
+    .await
+    .expect("outer retry must resume and complete the transfer");
+
+    assert_eq!(res.md5.as_deref(), Some(expected_md5.as_str()));
+    assert_eq!(std::fs::read(&out).unwrap(), payload);
+
+    // The decisive assertion: chunks that succeeded on the first attempt were
+    // NOT re-fetched by the retry. Only the failed chunk was requested again,
+    // which is what makes an outer retry cheap rather than a full restart.
+    let starts = requested.lock().unwrap().clone();
+    for offset in [0, CHUNK, 2 * CHUNK, 4 * CHUNK] {
+        assert_eq!(
+            starts.iter().filter(|&&s| s == offset).count(),
+            1,
+            "chunk at {offset} must be fetched exactly once across both attempts"
+        );
+    }
+    assert_eq!(
+        starts.iter().filter(|&&s| s == fail_offset).count() as u64,
+        CHUNK_RETRY_BUDGET + 1,
+        "failed chunk: 5 rejected attempts, then one success on the resume"
+    );
+}
+
+#[tokio::test]
+async fn download_file_with_retries_does_not_retry_checksum_mismatch() {
+    // A corrupt body is not a transport failure: download_file deletes the
+    // output, so a "resume" would silently become a full re-download. The
+    // outer loop must surface it on the first attempt instead of burning
+    // every retry re-fetching a file that will hash the same way again.
+    let server = MockServer::start().await;
+    let size = 33 * 1024 * 1024usize;
+    let payload: Vec<u8> = (0..size).map(|i| (i * 7 + 1) as u8).collect();
+    let requested = Arc::new(Mutex::new(Vec::<u64>::new()));
+
+    Mock::given(method("GET"))
+        .and(path("/corrupt"))
+        .respond_with(OutageResponder {
+            body: payload.clone(),
+            fail_start: u64::MAX, // never inject a transport failure
+            fail_times: 0,
+            failures: Arc::new(AtomicU64::new(0)),
+            requested_starts: requested.clone(),
+        })
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/corrupt", server.uri());
+    let (_dir, out) = tmp_out("corrupt.sra");
+
+    let cfg = DownloadConfig {
+        connections: 1,
+        chunk_size: 64 * 1024 * 1024, // one chunk covering the whole file
+        resume: true,
+        ..test_config()
+    };
+    let policy = TransferRetryPolicy {
+        attempts: 3,
+        base_delay: std::time::Duration::from_millis(10),
+        cap_delay: std::time::Duration::from_millis(10),
+    };
+
+    let wrong_md5 = md5_hex(b"not the payload");
+    let err = download_file_with_retries(
+        std::slice::from_ref(&url),
+        size as u64,
+        Some(&wrong_md5),
+        &out,
+        &cfg,
+        &policy,
+    )
+    .await
+    .err()
+    .expect("checksum mismatch must fail");
+    assert!(
+        matches!(err, sracha_core::error::Error::ChecksumMismatch { .. }),
+        "expected ChecksumMismatch, got {err:?}"
+    );
+    assert_eq!(
+        requested.lock().unwrap().len(),
+        1,
+        "must not re-download after a checksum mismatch"
+    );
+}
+
+#[tokio::test]
+async fn download_file_with_retries_skips_retrying_when_resume_disabled() {
+    // With resume off there is no sidecar, so every attempt would restart
+    // from byte zero — retrying a 40 GiB transfer that way is worse than
+    // failing fast. One attempt only.
+    let server = MockServer::start().await;
+    let size = 33 * 1024 * 1024usize;
+    let payload: Vec<u8> = (0..size).map(|i| (i * 3 + 2) as u8).collect();
+    let requested = Arc::new(Mutex::new(Vec::<u64>::new()));
+
+    Mock::given(method("GET"))
+        .and(path("/always-fails"))
+        .respond_with(OutageResponder {
+            body: payload.clone(),
+            fail_start: 0,
+            fail_times: u64::MAX, // never recovers
+            failures: Arc::new(AtomicU64::new(0)),
+            requested_starts: requested.clone(),
+        })
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/always-fails", server.uri());
+    let (_dir, out) = tmp_out("noresume.sra");
+
+    let cfg = DownloadConfig {
+        connections: 1,
+        chunk_size: 64 * 1024 * 1024,
+        resume: false,
+        ..test_config()
+    };
+    let policy = TransferRetryPolicy {
+        attempts: 4,
+        base_delay: std::time::Duration::from_millis(10),
+        cap_delay: std::time::Duration::from_millis(10),
+    };
+
+    let expected_md5 = md5_hex(&payload);
+    let _ = download_file_with_retries(
+        std::slice::from_ref(&url),
+        size as u64,
+        Some(&expected_md5),
+        &out,
+        &cfg,
+        &policy,
+    )
+    .await
+    .err()
+    .expect("transfer must fail");
+
+    // Exactly one whole-file attempt: the chunk's own 5 retries, no more.
+    assert_eq!(
+        requested.lock().unwrap().len(),
+        5,
+        "resume disabled => a single whole-file attempt (5 chunk retries)"
     );
 }

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -135,20 +135,25 @@ async fn main() -> Result<()> {
                         format_size(file.size),
                         out.display(),
                     );
-                    if let Err(e) = sracha_core::download::download_file(
+                    // ENA outages outlast the per-chunk retry budget, so
+                    // re-enter the transfer (resuming from the sidecar)
+                    // rather than losing a near-complete download.
+                    if let Err(e) = sracha_core::download::download_file_with_retries(
                         std::slice::from_ref(&file.url),
                         file.size,
                         Some(&file.md5),
                         &out,
                         &dl_config,
+                        &sracha_core::download::TransferRetryPolicy::default(),
                     )
                     .await
                     {
                         // Partial file + sidecar are preserved by download_file;
                         // re-running resumes rather than starting over.
                         eprintln!(
-                            "{}: ENA transfer failed ({e}); partial download and resume \
-                             state kept at {} — re-run with --prefer-ena to resume",
+                            "{}: ENA transfer failed after all resume attempts ({e}); \
+                             partial download and resume state kept at {} — re-run with \
+                             --prefer-ena to pick up where it left off",
                             style::header(acc),
                             style::path(out.display()),
                         );


### PR DESCRIPTION
Follow-up to #90, which this stacks on (base is `fix/ena-transfer-robustness-89`, not `main`). Addresses the failure @nrminor hit testing `feeaa95` — see https://github.com/rnabioco/sracha-rs/pull/90#issuecomment-5137146376.

## Problem

#90 fixed the connection storm, and their retest confirms it: the transfer ran 34 minutes at 15.59 MiB/s with no refusal cascade. But it still died, this time on a **timeout**, near the end of a ~37 GiB file.

The per-chunk retry budget is the limit. Five attempts, each able to burn the 10 s `connect_timeout`, separated by 7.5–15 s of jittered backoff — roughly **30–65 seconds** of tolerance. ENA's bad windows outlast that. Once one chunk exhausted its attempts, its error set `first_error` and aborted the whole file, so a nearly-complete multi-hour transfer exited and left the user to re-run it by hand.

The bytes were never lost — the sidecar preserved them, and their log shows resume carrying ~6 GiB forward from an earlier attempt. The run just didn't take advantage of that on its own.

## Change

New `download_file_with_retries` wraps `download_file` and re-enters it on transport failure: up to 4 attempts, waiting 30 s → 5 min (doubling, full jitter). Each retry resumes from the `.sracha-progress` sidecar, so completed chunks are never re-fetched and a retry costs only the bytes still missing.

Timing lives in a `TransferRetryPolicy` struct rather than constants, which is what makes the loop testable without real 30-second sleeps.

Three cases deliberately **don't** retry, because each would either waste the wait or do the wrong thing:

- **Cancellation** — the user's decision.
- **Checksum mismatch** — `download_file` has already deleted the output, so "resuming" would silently become a full re-download of a file we have no reason to think will hash differently.
- **I/O errors** — usually a full disk or bad permissions, which waiting does not fix.

Retrying is also skipped under `--no-resume` (every attempt would restart from byte zero), and `force` is cleared after the first attempt so a retry resumes instead of wiping the partial file each time.

Wired into both ENA download sites — the pipeline used by `get`, and the CLI `fetch` branch. **The NCBI S3 path is unchanged.**

## Tests

- Unit: `TransferRetryPolicy` defaults, exponential-and-capped delay (including no shift overflow at `u32::MAX`), and the retryable-error classification.
- Integration (wiremock, hermetic) — `download_file_with_retries_resumes_after_exhausting_chunk_retries` is the one that matters. It fails a chunk exactly 5 times, the full per-chunk budget, so the first whole-file attempt genuinely aborts; it then asserts the retry re-fetched **only** that chunk while every other chunk was requested exactly once. That's the property that makes an outer retry cheap rather than a restart.
- Two more pin down the negative paths by counting requests: no retry after a checksum mismatch, and a single attempt under `--no-resume`.
- 690 tests pass; `cargo clippy --all-targets -D warnings` and `cargo fmt --check` clean.
- Live smoke test against ENA through the new call site: MD5s exact, gzip valid, no retry warnings on a healthy transfer.

## Not addressed here

**The progress bar still overstates progress during a degraded transfer.** `pb.inc()` fires per body piece as data arrives, and a retry re-fetches its chunk from byte zero with no decrement, so retried bytes are counted twice. This is why their run displayed `30.99 GiB/30.99 GiB  eta 0s` while chunks were still outstanding — the "nearly complete" reading was an artifact, not a near-miss. Worth fixing in `try_download_chunk` (track completed chunks rather than bytes received), and arguably belongs here since both land in front of the same user. Happy to add it if you'd rather not split it.

The 30 s → 5 min schedule is a judgment call, not measured against a real outage. @nrminor's trace logs should show how long the bad windows actually last; if they exceed ~10 minutes, `attempts` is the knob.
