### PR TITLE
fix(cli): size disk preflight by what is actually downloaded (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Fixes
 
+- Size the disk-space preflight by what will actually be downloaded (#91).
+  The check summed the NCBI `.sra` object size even under `--prefer-ena`,
+  where that object is never fetched — so it measured a file that would not
+  exist. It could refuse a transfer that would have fit, and pass one that
+  then ran out of disk partway (for SRR37428186 the `.sra` is 58.2 GiB while
+  the ENA FASTQs total 72.9 GiB). ENA-served runs are now sized by their
+  filereport totals, and `sracha fetch --prefer-ena` gets a preflight at all —
+  its ENA downloads previously bypassed the check entirely.
 - Stop the download progress bar from overstating progress when chunks retry
   (#89). Bytes were credited as they arrived, but a retried chunk re-fetches
   from byte zero, so every retry counted its bytes again — a stalled 37 GiB

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -108,6 +108,17 @@ async fn main() -> Result<()> {
 
             tokio::fs::create_dir_all(&args.output_dir).await?;
 
+            // Preflight the ENA set. These runs are downloaded below and then
+            // filtered out of `ncbi_accessions`, so without this they would
+            // reach the disk check that runs later — a full-ENA fetch would
+            // get no preflight at all. The NCBI check further down re-stats
+            // the filesystem, by which point these files are on disk, so the
+            // two checks compose rather than double-count.
+            let ena_bytes: u64 = ena_results.iter().flatten().map(|e| e.total_size).sum();
+            if ena_bytes > 0 {
+                check_disk_space(ena_bytes, &args.output_dir)?;
+            }
+
             // Handle ENA hits first (pure HTTP, no SDL involvement).
             for (i, acc) in run_accessions.iter().enumerate() {
                 let Some(ena) = &ena_results[i] else {
@@ -199,7 +210,10 @@ async fn main() -> Result<()> {
                 style::count(resolved_all.len()),
             ));
             check_download_confirmation(&resolved_all, args.yes, has_projects)?;
-            check_disk_space(&resolved_all, &args.output_dir)?;
+            // Only NCBI-served runs reach here; the ENA set was checked and
+            // downloaded above, so `available_space` already reflects it.
+            let sra_bytes: u64 = resolved_all.iter().map(|r| r.sra_file.size).sum();
+            check_disk_space(sra_bytes, &args.output_dir)?;
 
             for resolved in &resolved_all {
                 let acc = &resolved.accession;
@@ -481,20 +495,13 @@ async fn main() -> Result<()> {
                 return Ok(());
             }
 
-            check_download_confirmation(&resolved_all, args.yes, has_projects)?;
-            check_disk_space(&resolved_all, &args.output_dir)?;
-
-            let format_label = if args.fasta { "FASTA" } else { "FASTQ" };
-            tracing::info!(
-                "get {} run accession(s) -> {format_label}",
-                resolved_all.len()
-            );
-
-            let progress = !args.no_progress && !args.stdout;
-
             // If ENA is in play, resolve filereport metadata for every run up
             // front. Accessions ENA can't serve (empty/None) silently fall back
             // to the NCBI pipeline per-accession below.
+            //
+            // Resolved *before* the preflight below so the disk check can size
+            // the transfer by what will actually be written: under
+            // `--prefer-ena` the `.sra` object is never downloaded.
             let ena_results: Vec<Option<sracha_core::ena::EnaResolved>> = if ena_compatible {
                 let sp = progress::Spinner::start(format!(
                     "Querying ENA filereport for {} accession(s)",
@@ -512,6 +519,20 @@ async fn main() -> Result<()> {
             } else {
                 vec![None; resolved_all.len()]
             };
+
+            check_download_confirmation(&resolved_all, args.yes, has_projects)?;
+            check_disk_space(
+                expected_download_bytes(&resolved_all, &ena_results),
+                &args.output_dir,
+            )?;
+
+            let format_label = if args.fasta { "FASTA" } else { "FASTQ" };
+            tracing::info!(
+                "get {} run accession(s) -> {format_label}",
+                resolved_all.len()
+            );
+
+            let progress = !args.no_progress && !args.stdout;
 
             // Check platform — reject legacy platforms with complex read structures.
             // Only applies to accessions that will go through VDB decode; ENA
@@ -1927,13 +1948,39 @@ fn check_download_confirmation(
     Ok(())
 }
 
-/// Check that the target directory has enough free disk space for the download.
+/// Total bytes the run set will actually write into the output directory.
+///
+/// Sizing by `sra_file.size` alone is wrong under `--prefer-ena`: those runs
+/// are served as ENA FASTQ files and the NCBI `.sra` object is never fetched,
+/// so the check would measure a file that will not exist. That misses in both
+/// directions — refusing a transfer that would have fit, and passing one that
+/// runs out of disk partway (for SRR37428186 the `.sra` is 58.2 GiB while the
+/// ENA FASTQs total 72.9 GiB).
+///
+/// `ena_results` is positionally aligned with `resolved`; `None` means ENA
+/// can't serve that run and the NCBI path will be used.
+fn expected_download_bytes(
+    resolved: &[ResolvedAccession],
+    ena_results: &[Option<sracha_core::ena::EnaResolved>],
+) -> u64 {
+    resolved
+        .iter()
+        .enumerate()
+        .map(|(i, r)| match ena_results.get(i).and_then(|e| e.as_ref()) {
+            Some(ena) => ena.total_size,
+            None => r.sra_file.size,
+        })
+        .sum()
+}
+
+/// Check that the target directory has enough free disk space for
+/// `required_bytes`.
 ///
 /// Uses `statvfs` to query available space. Falls back silently if the check
 /// fails (e.g. the directory doesn't exist yet or the filesystem doesn't
 /// support `statvfs`).
-fn check_disk_space(resolved: &[ResolvedAccession], output_dir: &Path) -> Result<()> {
-    let total_size: u64 = resolved.iter().map(|r| r.sra_file.size).sum();
+fn check_disk_space(required_bytes: u64, output_dir: &Path) -> Result<()> {
+    let total_size = required_bytes;
 
     // Find the nearest existing ancestor to stat (output_dir may not exist yet).
     let stat_path = {
@@ -2127,19 +2174,80 @@ mod tests {
 
     #[test]
     fn disk_space_ok_when_sufficient() {
-        let resolved = vec![make_resolved_acc("SRR1", 1024)];
         let dir = tempfile::tempdir().unwrap();
         // Real directory — should have some space available.
-        assert!(check_disk_space(&resolved, dir.path()).is_ok());
+        assert!(check_disk_space(1024, dir.path()).is_ok());
     }
 
     #[test]
     fn disk_space_walks_to_existing_ancestor() {
-        let resolved = vec![make_resolved_acc("SRR1", 1024)];
         let dir = tempfile::tempdir().unwrap();
         let deep_path = dir.path().join("a/b/c/d/e");
         // The directory doesn't exist, but check_disk_space should walk up.
-        assert!(check_disk_space(&resolved, &deep_path).is_ok());
+        assert!(check_disk_space(1024, &deep_path).is_ok());
+    }
+
+    #[test]
+    fn disk_space_rejects_impossible_request() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(check_disk_space(u64::MAX, dir.path()).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // expected_download_bytes (regression: issue #91)
+    // -----------------------------------------------------------------------
+
+    fn make_ena_resolved(accession: &str, total_size: u64) -> sracha_core::ena::EnaResolved {
+        sracha_core::ena::EnaResolved {
+            accession: accession.into(),
+            fastq_files: vec![],
+            total_size,
+        }
+    }
+
+    #[test]
+    fn expected_bytes_uses_sra_size_without_ena() {
+        let resolved = vec![
+            make_resolved_acc("SRR1", 1024),
+            make_resolved_acc("SRR2", 512),
+        ];
+        assert_eq!(expected_download_bytes(&resolved, &[None, None]), 1536);
+    }
+
+    #[test]
+    fn expected_bytes_uses_ena_size_for_ena_served_runs() {
+        // The whole point of #91: an ENA-served run must be sized by the
+        // FASTQs that will be written, not the .sra that never will be.
+        let resolved = vec![make_resolved_acc("SRR1", 1024)];
+        let ena = vec![Some(make_ena_resolved("SRR1", 4096))];
+        assert_eq!(expected_download_bytes(&resolved, &ena), 4096);
+    }
+
+    #[test]
+    fn expected_bytes_mixes_ena_and_ncbi_runs() {
+        // A partial ENA hit set: each run sized by whichever path serves it.
+        let resolved = vec![
+            make_resolved_acc("SRR1", 1024),
+            make_resolved_acc("SRR2", 2048),
+            make_resolved_acc("SRR3", 4096),
+        ];
+        let ena = vec![
+            Some(make_ena_resolved("SRR1", 10)),
+            None,
+            Some(make_ena_resolved("SRR3", 20)),
+        ];
+        assert_eq!(expected_download_bytes(&resolved, &ena), 10 + 2048 + 20);
+    }
+
+    #[test]
+    fn expected_bytes_falls_back_when_ena_results_are_short() {
+        // Defensive: a mis-sized ENA vector must not panic or silently drop
+        // runs — anything unpaired falls back to its .sra size.
+        let resolved = vec![
+            make_resolved_acc("SRR1", 1024),
+            make_resolved_acc("SRR2", 512),
+        ];
+        assert_eq!(expected_download_bytes(&resolved, &[]), 1536);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #91. Stacks on #93 (base is `fix/progress-bar-retry-double-count`, which itself stacks on #90).

## Problem

`check_disk_space` summed `sra_file.size` unconditionally, so under `--prefer-ena` it sized the preflight against the NCBI `.sra` object — a file that path never downloads. It measured something that will not exist.

That misses in **both** directions:

- **Over-strict** — refuses a transfer that would have fit, whenever a run's `.sra` is larger than its ENA FASTQs.
- **Under-strict** — passes, then runs out of disk partway. For `SRR37428186` the `.sra` is 58.19 GiB while the two ENA FASTQs total 72.90 GiB, so on a volume with 60–72 GiB free the check waved it through and the transfer died mid-flight. That's a ~35-minute wait to discover a problem the preflight exists to catch.

There was also a second hole: in `fetch`, ENA hits are downloaded and *then* filtered out of `ncbi_accessions` before the check runs, so **a full-ENA `fetch` got no preflight at all.**

## Change

- **`get`** — ENA filereport resolution moves above the preflight so each run can be sized by whichever path will serve it. New `expected_download_bytes` picks `EnaResolved::total_size` for ENA hits and `sra_file.size` otherwise.
- **`fetch`** — the ENA set is now checked before its download loop. The NCBI check further down re-stats the filesystem, by which point those files are on disk, so the two checks compose rather than double-count.
- `check_disk_space` takes a byte count instead of reaching into `sra_file`, which is what let both call sites express their own sizing.

## Verification

The command from the issue, on a volume with 42 GiB free:

```
# before
Error: not enough disk space: download requires 58.19 GiB but only 43.08 GiB available

# after
Error: not enough disk space: download requires 72.90 GiB but only 42.44 GiB available
```

72.90 GiB is the real ENA total. The refusal is now correct rather than coincidental, and the under-estimate case is closed.

Also re-ran a live `--prefer-ena` download end to end (`SRR28588231`): MD5s exact, no regression on the happy path.

## Tests

- `expected_download_bytes`: ENA-served runs sized by filereport totals, NCBI runs by `.sra` size, a mixed hit set, and a defensively-short ENA vector that must fall back rather than panic or drop runs.
- `check_disk_space` gains a rejection case; the two existing tests move to the byte-count signature.
- 698 tests pass; `cargo clippy --all-targets -D warnings` and `cargo fmt --check` clean.

## Not addressed

Two things I found while in here, both pre-existing and out of scope:

- `check_download_confirmation` (the >100 GiB prompt) has the same blind spot — it sums `sra_file.size` too. Making it ENA-aware means touching the `InfoEntry` table it renders, which felt like a separate change. Worth noting the threshold can currently be evaluated against the wrong number.
- On the plain NCBI `get` path the estimate is low in a different way: the temp `.sracha-tmp-<acc>.sra` sits in the output directory while FASTQ is written beside it, so peak usage is roughly SRA + FASTQ while the check counts only the SRA.

Happy to take either as a follow-up.
