### PR TITLE
fix(vdb): dispatch page map row mapping on the declared version (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Decode version-2 (random-access) page maps as per-row element offsets
+  instead of repeat counts (#101). A page map's `data_offset[]` and
+  `data_run[]` share one slot in the on-disk format, and sracha kept both in
+  an untyped `Vec<u32>`, so a version-2 blob's offsets were walked as run
+  lengths — `sracha fastq` failed on SRR35917722 with "variable data
+  truncated", and `sracha vdb dump` failed on any archive with deduplicated
+  rows because it never expanded them at all. `PageMap` now carries a typed
+  `RowMapping`, and every consumer resolves rows through a single
+  offset-and-length walk that mirrors ncbi-vdb's `PageMapFindRow`.
+
 ## 0.4.2 (2026-07-31)
 
 ### Fixes

--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -87,15 +87,6 @@ impl FlatBytes {
         self.offsets.push(self.bytes.len() as u32);
     }
 
-    /// Append the same chunk `repeat` times — used by NAME_FMT's run-length
-    /// variant where identical templates back many consecutive rows.
-    fn push_repeated(&mut self, row: &[u8], repeat: usize) {
-        for _ in 0..repeat {
-            self.bytes.extend_from_slice(row);
-            self.offsets.push(self.bytes.len() as u32);
-        }
-    }
-
     #[inline]
     fn get(&self, i: usize) -> Option<&[u8]> {
         if i + 1 < self.offsets.len() {
@@ -120,8 +111,8 @@ pub(crate) use crate::vdb::blob_codecs::{
 
 /// Materialize the READ_TYPE rows covering one READ blob, one row per spot.
 ///
-/// VDB stores only the distinct READ_TYPE rows; the page map's `data_runs[i]`
-/// says how many consecutive spots share record `i`. A run whose read types
+/// VDB stores only the distinct READ_TYPE rows; the page map says how many
+/// consecutive spots share each record. A run whose read types
 /// never change collapses to a single record — SRR18959644's first record
 /// covers 22,227,968 spots — and a blob straddling a change in read types
 /// holds two. Indexing the unexpanded buffer per spot therefore reads the
@@ -132,7 +123,7 @@ pub(crate) use crate::vdb::blob_codecs::{
 /// those long runs, so only the `[skip_rows, skip_rows + take_rows)` window
 /// this blob needs is built. The result is indexed from row 0.
 ///
-/// Blobs with no page map (or no `data_runs`) already carry one row per spot
+/// Blobs with no page map (or an identity mapping) already carry one row per spot
 /// and are sliced directly.
 fn read_type_rows_for_blob(
     data: &[u8],
@@ -153,8 +144,7 @@ fn read_type_rows_for_blob(
         return Vec::new();
     }
 
-    let runs = page_map.map(|pm| pm.data_runs.as_slice()).unwrap_or(&[]);
-    if runs.is_empty() {
+    let Some(pm) = page_map.filter(|pm| !pm.mapping.is_identity()) else {
         // One row per spot already. A blob holding a single row against many
         // spots is a constant column stored without runs; repeat it.
         if data.len() == row_len {
@@ -163,23 +153,22 @@ fn read_type_rows_for_blob(
         let start = (skip_rows * row_len).min(data.len());
         let end = (start + take_rows * row_len).min(data.len());
         return data[start..end].to_vec();
-    }
+    };
 
+    // Only the requested window is materialized: one READ_TYPE record can
+    // cover millions of spots, so expanding the whole blob would cost tens of
+    // MiB per READ blob.
+    let Ok(extents) = pm.row_extents_range(skip_rows, take_rows) else {
+        return Vec::new();
+    };
     let mut out = Vec::with_capacity(take_rows * row_len);
-    let mut row = 0usize; // first logical row of the current record
-    for (i, record) in data.chunks_exact(row_len).enumerate() {
-        let repeat = runs.get(i).copied().unwrap_or(1) as usize;
-        let end = row + repeat;
-        // Overlap of this record's row span with the requested window.
-        let from = row.max(skip_rows);
-        let to = end.min(skip_rows + take_rows);
-        for _ in from..to {
-            out.extend_from_slice(record);
-        }
-        row = end;
-        if row >= skip_rows + take_rows {
+    for extent in &extents {
+        let start = extent.offset as usize;
+        let end = start + extent.len as usize;
+        if end > data.len() {
             break;
         }
+        out.extend_from_slice(&data[start..end]);
     }
     out
 }
@@ -416,7 +405,7 @@ fn apply_altread_merge(
     // emit potentially-wrong FASTQ.
     if let Some(pm) = alt_page_map.as_ref()
         && pm.lengths.len() > 1
-        && pm.data_runs.is_empty()
+        && pm.mapping.is_identity()
         && altread_data.iter().any(|&b| b != 0)
     {
         return Err(sracha_vdb::Error::UnsupportedFormat {
@@ -450,69 +439,26 @@ fn apply_altread_merge(
     let row_bases = actual_bases / raw.read_id_range.max(1) as usize;
     let per_row_lens = alt_page_map.as_ref().and_then(|alt_pm| {
         let read_pm = read_page_map?;
-        (alt_pm.total_rows() == read_pm.total_rows()).then(|| {
-            // Expand READ's per-data-record lengths via READ's own
-            // data_runs to get one entry per logical row — matches
-            // the row-by-row layout of `read_data` after the
-            // `expand_variable_data_runs` step above.
-            let rec_lens = read_pm.data_record_lengths();
-            let mut lens = Vec::with_capacity(read_pm.total_rows() as usize);
-            if read_pm.data_runs.is_empty() {
-                lens.extend_from_slice(&rec_lens);
-            } else {
-                for (i, &len) in rec_lens.iter().enumerate() {
-                    let repeat = read_pm.data_runs.get(i).copied().unwrap_or(1) as usize;
-                    for _ in 0..repeat {
-                        lens.push(len);
-                    }
-                }
-            }
-            lens
-        })
+        // `leng_runs` already carries one length per logical row, matching the
+        // row-by-row layout of `read_data` after the expansion above.
+        (alt_pm.total_rows() == read_pm.total_rows()).then(|| read_pm.logical_row_lengths())
     });
-    // Variant-2 random-access page maps repurpose `data_runs` as
-    // `data_offset[row_count]`: each row's trimmed bytes are sliced
-    // out of `altread_data` at `data_offsets[row]` for `lengths[run]`
-    // bytes (multiple rows can share the same offset → write-time
-    // dedup, so the data buffer can be far smaller than
-    // `sum(lengths × leng_runs)`). DRR024182 blob 162 hits this:
-    // 8192 rows / 77 unique lengths / 1981 stored bytes / only 17
-    // unique offsets (6481 rows share offset=0). Detect by the data
-    // shape (`data_runs.len() == total_rows && lengths.len() > 1`)
-    // and route to the offset-aware reconstruction; everything else
-    // continues through the run-length variable padder.
-    let is_variant2_ra = alt_page_map
-        .as_ref()
-        .is_some_and(|pm| pm.lengths.len() > 1 && pm.data_runs.len() as u64 == pm.total_rows());
+    // Random-access page maps (version 2) give each row its own element
+    // offset into `altread_data`, and several rows can share one offset —
+    // write-time dedup, so the stored buffer is far smaller than
+    // `sum(lengths × leng_runs)`. DRR024182 blob 162 hits this: 8192 rows /
+    // 77 unique lengths / 1981 stored bytes / only 17 unique offsets (6481
+    // rows share offset 0). `pad_trimmed_rows_*` resolve every mapping
+    // through `PageMap::row_extents`, so no special case is needed here.
     let padded_ok = alt_page_map.as_ref().and_then(|pm| {
         if altread_data.is_empty() {
             return None;
         }
-        // Variant-2 RA needs to walk every row by `data_offset[row]`
-        // and copy `lengths[run]` bytes; neither `pad_trimmed_rows_*`
-        // can do that. When the READ blob aligns 1:1 with ALTREAD,
-        // pad each row to its READ-derived logical width; otherwise
-        // (e.g. DRR035866-style 2:1 ALTREAD blob) pad to the uniform
-        // `row_bases` width across every ALTREAD row, then the merge
-        // step slices the relevant `row_offset * row_bases` portion.
-        if is_variant2_ra && row_bases > 0 {
-            let alt_total_rows = pm.total_rows() as usize;
-            let row_logical_lens: Vec<u32> = match per_row_lens.as_ref() {
-                Some(lens) => lens.clone(),
-                None => vec![row_bases as u32; alt_total_rows],
-            };
-            match pm.pad_random_access_rows(
-                &altread_data,
-                &row_logical_lens,
-                crate::vdb::blob::TrimSide::Leading,
-            ) {
-                Ok(v) => return Some(v),
-                Err(e) => {
-                    tracing::debug!("blob {blob_idx}: ALTREAD pad_random_access_rows err: {e}");
-                    return None;
-                }
-            }
-        }
+        // When the READ blob aligns 1:1 with ALTREAD, pad each row to its
+        // READ-derived logical width; otherwise (e.g. DRR035866-style 2:1
+        // ALTREAD blob) pad to the uniform `row_bases` width across every
+        // ALTREAD row, and the merge step slices the relevant
+        // `row_offset * row_bases` portion.
         if let Some(lens) = per_row_lens.as_ref() {
             match pm.pad_trimmed_rows_variable(
                 &altread_data,
@@ -613,22 +559,20 @@ pub(crate) fn decode_blob_to_fastq(
     let mut read_data = crate::vdb::encoding::unpack_2na(&read_decoded.data, actual_bases);
     let read_page_map = read_decoded.page_map;
 
-    // V2 blobs may deduplicate identical rows via the page map's
-    // `data_runs` — e.g., two spots with identical base calls get
-    // written once and replicated on read. Without expansion the
-    // trailing duplicate rows drop out at blob boundaries and every
-    // subsequent spot drifts. Variable per-row lengths (Illumina reads
-    // vary after adapter trim) are the common case, so delegate to
-    // `expand_variable_data_runs` — same approach as the QUALITY path
-    // below. On the unpacked 2na buffer, page_map `lengths` are in
-    // bases per row, matching one byte per base in `read_data`.
+    // Blobs may deduplicate identical rows — two spots with identical base
+    // calls get written once and materialized again on read, either via
+    // repeat counts or via per-row offsets into a vocabulary. Without
+    // expansion the duplicate rows drop out at blob boundaries and every
+    // subsequent spot drifts. On the unpacked 2na buffer the page map's
+    // `lengths` are bases per row, matching one byte per base in `read_data`,
+    // so the element size is 1.
     if let Some(ref pm) = read_page_map
-        && !pm.data_runs.is_empty()
+        && !pm.mapping.is_identity()
     {
-        match pm.expand_variable_data_runs(&read_data) {
+        match pm.expand_rows(&read_data, 1) {
             Ok(expanded) => read_data = expanded,
             Err(e) => {
-                tracing::debug!("blob {blob_idx}: READ expand_variable_data_runs skipped: {e}");
+                tracing::debug!("blob {blob_idx}: READ row expansion skipped: {e}");
             }
         }
     }
@@ -652,9 +596,9 @@ pub(crate) fn decode_blob_to_fastq(
             // data_runs > 1; the decompressed data only contains unique
             // rows and must be expanded to match the total base count.
             if let Some(ref pm) = qpage_map
-                && !pm.data_runs.is_empty()
+                && !pm.mapping.is_identity()
             {
-                qdata = pm.expand_variable_data_runs(&qdata)?;
+                qdata = pm.expand_rows(&qdata, 1)?;
             }
             qdata
         } else {
@@ -1023,84 +967,47 @@ pub(crate) fn decode_blob_to_fastq(
         // two tiles alternate at fine granularity along the spot axis
         // (DRR040793: tile 1101/1102 interleave starting at spot 7637).
         //
-        // Two page_map shapes show up in real archives:
-        //   - data_runs holds run-length REPEAT counts (one per data
-        //     record). data_record_lengths × repeats expands directly
-        //     to per-row strings.
-        //   - data_runs holds per-row BYTE OFFSETS into the data buffer
-        //     (the random_access variant 2 case where ncbi-vdb's serial
-        //     format stores `data_offset[row_count]` after lengths /
-        //     leng_runs and overlays it on the data_run slot). Each row
-        //     pulls its own slice from a deduplicated pool of unique
-        //     templates.
-        let name_fmt_per_row: Option<FlatBytes> = if raw.has_name_fmt
-            && !raw.name_fmt_raw.is_empty()
-        {
-            decode_raw(raw.name_fmt_raw, raw.name_fmt_cs, raw.name_fmt_id_range)
-                .ok()
-                .and_then(|nfd| {
-                    let pm = nfd.page_map.as_ref()?;
-                    let total_rows = pm.total_rows() as usize;
-                    let random_access = pm.data_runs.len() == total_rows && total_rows > 0;
-                    let bytes = decode_zip_encoding(&nfd).ok()?;
-                    let mut rows = FlatBytes::with_capacity(total_rows, bytes.len());
-                    if random_access {
-                        // Per-row byte offsets: each row pulls its own
-                        // slice from `bytes` at offset data_runs[i] of
-                        // length determined by leng_runs expansion.
-                        let mut row_idx = 0usize;
-                        for (length, &run) in pm.lengths.iter().zip(pm.leng_runs.iter()) {
-                            let len = *length as usize;
-                            for _ in 0..run {
-                                if len == 0 {
-                                    rows.push(&[]);
-                                    row_idx += 1;
-                                    continue;
-                                }
-                                let off = pm.data_runs.get(row_idx).copied().unwrap_or(0) as usize;
-                                if off + len > bytes.len() {
-                                    return None;
-                                }
-                                rows.push(&bytes[off..off + len]);
-                                row_idx += 1;
-                            }
+        // Rows are pulled straight from their extents: under repeat counts a
+        // record stored once is emitted for each row it covers, and under a
+        // random-access map each row indexes its own template out of a
+        // deduplicated pool. Both shapes appear in real archives.
+        let name_fmt_per_row: Option<FlatBytes> =
+            if raw.has_name_fmt && !raw.name_fmt_raw.is_empty() {
+                decode_raw(raw.name_fmt_raw, raw.name_fmt_cs, raw.name_fmt_id_range)
+                    .ok()
+                    .and_then(|nfd| {
+                        let pm = nfd.page_map.as_ref()?;
+                        let total_rows = pm.total_rows() as usize;
+                        let bytes = decode_zip_encoding(&nfd).ok()?;
+                        let extents = pm.row_extents().ok()?;
+                        if extents.len() != total_rows {
+                            return None;
                         }
-                    } else {
-                        // Run-length variant: one chunk per data record,
-                        // replicated `data_runs[i]` times (defaults to 1
-                        // when data_runs is empty).
-                        let rec_lens = pm.data_record_lengths();
-                        let mut cursor = 0usize;
-                        for (i, &len) in rec_lens.iter().enumerate() {
-                            let len = len as usize;
-                            let repeat = pm.data_runs.get(i).copied().unwrap_or(1) as usize;
-                            if cursor + len > bytes.len() {
+                        let mut rows = FlatBytes::with_capacity(total_rows, bytes.len());
+                        for extent in &extents {
+                            let start = extent.offset as usize;
+                            let end = start.checked_add(extent.len as usize)?;
+                            if end > bytes.len() {
                                 return None;
                             }
-                            rows.push_repeated(&bytes[cursor..cursor + len], repeat);
-                            cursor += len;
+                            rows.push(&bytes[start..end]);
                         }
-                    }
-                    if blob_idx == 0 {
-                        let nonempty = (0..rows.len())
-                            .filter(|&i| rows.get(i).is_some_and(|r| !r.is_empty()))
-                            .count();
-                        tracing::debug!(
-                            "NAME_FMT blob 0: {} rows ({}), {} non-empty overrides",
-                            rows.len(),
-                            if random_access {
-                                "random-access"
-                            } else {
-                                "run-length"
-                            },
-                            nonempty,
-                        );
-                    }
-                    Some(rows)
-                })
-        } else {
-            None
-        };
+                        if blob_idx == 0 {
+                            let nonempty = (0..rows.len())
+                                .filter(|&i| rows.get(i).is_some_and(|r| !r.is_empty()))
+                                .count();
+                            tracing::debug!(
+                                "NAME_FMT blob 0: {} rows ({:?}), {} non-empty overrides",
+                                rows.len(),
+                                std::mem::discriminant(&pm.mapping),
+                                nonempty,
+                            );
+                        }
+                        Some(rows)
+                    })
+            } else {
+                None
+            };
 
         if has_templates && !x_vals.is_empty() && !y_vals.is_empty() {
             // Average template length ~30 chars + ~20 chars of expanded
@@ -1568,12 +1475,18 @@ mod tests {
     // `[technical, biological]`, leaving nothing to emit.
     // -----------------------------------------------------------------------
 
-    fn page_map(lengths: Vec<u32>, leng_runs: Vec<u32>, data_runs: Vec<u32>) -> PageMap {
+    fn page_map(lengths: Vec<u32>, leng_runs: Vec<u32>, repeats: Vec<u32>) -> PageMap {
+        let data_recs = repeats.len() as u64;
+        let mapping = if repeats.is_empty() {
+            crate::vdb::blob::RowMapping::Identity
+        } else {
+            crate::vdb::blob::RowMapping::RepeatCounts(repeats)
+        };
         PageMap {
-            data_recs: data_runs.len() as u64,
+            data_recs,
             lengths,
             leng_runs,
-            data_runs,
+            mapping,
         }
     }
 
@@ -1617,7 +1530,7 @@ mod tests {
         assert_eq!(read_type_rows_for_blob(&data, None, 2, 0, 2), data.to_vec());
         assert_eq!(read_type_rows_for_blob(&data, None, 2, 1, 1), vec![0, 1]);
 
-        // A page map with no data_runs already holds one row per spot.
+        // An identity page map already holds one row per spot.
         let pm = page_map(vec![2], vec![2], vec![]);
         assert_eq!(
             read_type_rows_for_blob(&data, Some(&pm), 2, 0, 2),

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -2426,32 +2426,32 @@ mod tests {
     }
 
     #[test]
-    fn expand_empty_data_runs_returns_input() {
+    fn expand_identity_mapping_returns_input() {
         let data = vec![1, 0, 0, 0, 2, 0, 0, 0];
         let pm = blob::PageMap {
             data_recs: 2,
             lengths: vec![1],
             leng_runs: vec![2],
-            data_runs: vec![],
+            mapping: blob::RowMapping::Identity,
         };
         let result = expand_via_page_map(data.clone(), &Some(pm)).unwrap();
         assert_eq!(result, data);
     }
 
     #[test]
-    fn expand_data_runs_direct_offset() {
+    fn expand_random_access_offsets() {
         // 3 unique u32 values: [10, 20, 30]
         let data = vec![
             10, 0, 0, 0, // entry 0
             20, 0, 0, 0, // entry 1
             30, 0, 0, 0, // entry 2
         ];
-        // 4 rows, each referencing an entry by offset index
+        // 4 rows, each naming the element its data starts at
         let pm = blob::PageMap {
-            data_recs: 3,
+            data_recs: 4,
             lengths: vec![1],
             leng_runs: vec![4],
-            data_runs: vec![0, 2, 1, 0], // rows → entries: 0,2,1,0
+            mapping: blob::RowMapping::RandomAccessOffsets(vec![0, 2, 1, 0]),
         };
         let result = expand_via_page_map(data, &Some(pm)).unwrap();
         assert_eq!(
@@ -2466,14 +2466,14 @@ mod tests {
     }
 
     #[test]
-    fn expand_data_runs_direct_offset_rejects_oob() {
+    fn expand_random_access_offsets_reject_oob() {
         // Only 2 entries in data (8 bytes = 2 u32s), but offset 5 points past.
         let data = vec![10, 0, 0, 0, 20, 0, 0, 0];
         let pm = blob::PageMap {
-            data_recs: 2,
+            data_recs: 3,
             lengths: vec![1],
             leng_runs: vec![3],
-            data_runs: vec![0, 5, 1],
+            mapping: blob::RowMapping::RandomAccessOffsets(vec![0, 5, 1]),
         };
         assert!(expand_via_page_map(data, &Some(pm)).is_err());
     }

--- a/crates/sracha-vdb/src/blob.rs
+++ b/crates/sracha-vdb/src/blob.rs
@@ -183,18 +183,119 @@ pub enum TrimSide {
     Trailing,
 }
 
+/// How a page map maps logical rows onto the blob's element stream.
+///
+/// ncbi-vdb's `PageMap` carries a `random_access` flag plus two arrays that
+/// share one allocation — `data_run` (repeat counts) and `data_offset`
+/// (per-row offsets) — with the flag deciding which one is live
+/// (`libs/kdb/page-map.c`, `PageMapDeserialize_v0`). Modelling that as one
+/// untyped `Vec<u32>` is what produced issue #101: a version-2 blob's
+/// `data_offset[]` was walked as though the entries were repeat counts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RowMapping {
+    /// Every data record covers exactly one logical row — the `data_run[..]
+    /// == 1` case (variants 0 and 2 without random access). Row data is laid
+    /// out contiguously in row order.
+    Identity,
+    /// `repeats[i]` consecutive logical rows all share data record `i`
+    /// (variants 1 and 3). The read cursor advances by one record's element
+    /// count per *record*, not per row, so a record covering many rows is
+    /// stored once.
+    RepeatCounts(Vec<u32>),
+    /// `offsets[r]` is the element offset of logical row `r`'s data within
+    /// the blob's element stream — ncbi-vdb's `data_offset[row_count]`,
+    /// written only by version 2 (`random_access`) and only for variants 0
+    /// and 2.
+    ///
+    /// The values are element offsets (`elem_count_t`), not byte offsets and
+    /// not record indices. They may repeat and may decrease: the writer runs
+    /// a vocabulary encoder (`libs/vdb/blob.c`, `VBlobPageMapOptimize`), so
+    /// distinct rows with identical content point at the same offset and the
+    /// data buffer is usually far smaller than `sum(row lengths)`.
+    RandomAccessOffsets(Vec<u32>),
+}
+
+impl RowMapping {
+    /// Repeat counts, when this map stores them.
+    pub fn repeat_counts(&self) -> Option<&[u32]> {
+        match self {
+            RowMapping::RepeatCounts(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Per-row element offsets, when this map stores them.
+    pub fn row_offsets(&self) -> Option<&[u32]> {
+        match self {
+            RowMapping::RandomAccessOffsets(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub fn is_identity(&self) -> bool {
+        matches!(self, RowMapping::Identity)
+    }
+
+}
+
+/// Maximum logical rows per blob — reject page maps whose `leng_runs` sum to
+/// more than this. Real SRA blobs hold well under it (a few million rows is
+/// typical, hundreds of millions is the high end).
+pub const MAX_LOGICAL_ROWS_PER_BLOB: u64 = 1_000_000_000;
+
+/// Yields one element count per logical row by walking `lengths` / `leng_runs`
+/// without expanding them.
+struct LengthRunCursor<'a> {
+    lengths: &'a [u32],
+    leng_runs: &'a [u32],
+    idx: usize,
+    left_in_run: u32,
+}
+
+impl<'a> LengthRunCursor<'a> {
+    fn new(pm: &'a PageMap) -> Self {
+        Self {
+            lengths: &pm.lengths,
+            leng_runs: &pm.leng_runs,
+            idx: 0,
+            left_in_run: pm.leng_runs.first().copied().unwrap_or(0),
+        }
+    }
+
+    fn next(&mut self) -> Option<u32> {
+        while self.left_in_run == 0 {
+            self.idx += 1;
+            self.left_in_run = *self.leng_runs.get(self.idx)?;
+        }
+        let len = *self.lengths.get(self.idx)?;
+        self.left_in_run -= 1;
+        Some(len)
+    }
+}
+
+/// Where one logical row's data sits in the blob's element stream.
+///
+/// Units are *elements*, matching ncbi-vdb's `PageMapIteratorDataOffset` /
+/// `PageMapIteratorDataLength`: multiply by the column's element size to get
+/// bytes. Two rows may share an offset when the writer deduplicated them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RowExtent {
+    pub offset: u32,
+    pub len: u32,
+}
+
 /// Deserialized page map describing row boundaries within a blob.
 #[derive(Debug, Clone)]
 pub struct PageMap {
-    /// Number of data records (rows) in the blob.
+    /// Number of data records in the blob. Equals the row count for the
+    /// identity and random-access mappings.
     pub data_recs: u64,
     /// Row lengths (one per unique length run).
     pub lengths: Vec<u32>,
     /// Length runs (how many consecutive rows share the same length).
     pub leng_runs: Vec<u32>,
-    /// Data runs (how many rows share the same physical data position).
-    /// Empty for variants where data_run is always 1.
-    pub data_runs: Vec<u32>,
+    /// How logical rows map onto stored data.
+    pub mapping: RowMapping,
 }
 
 impl PageMap {
@@ -206,162 +307,218 @@ impl PageMap {
         self.leng_runs.iter().map(|&r| u64::from(r)).sum()
     }
 
-    /// Expand run-length-encoded data to full row data.
-    ///
-    /// Takes decoded values (one per `data_rec`) and returns expanded values
-    /// (one per logical row). Each data entry `i` covers `data_runs[i]`
-    /// consecutive rows. If `data_runs` is empty, each data entry covers
-    /// exactly one row (no expansion needed).
-    ///
-    /// This is used for columns like READ_LEN where `irzip_decode` produces
-    /// `data_recs` unique values, but the actual row count is larger because
-    /// some values repeat via `data_runs`.
-    pub fn expand_data_runs<T: Clone>(&self, data: &[T]) -> Vec<T> {
-        if self.data_runs.is_empty() {
-            // No run-length encoding — each data entry = one row.
-            return data.to_vec();
-        }
-
-        let total = self.total_rows() as usize;
-        let mut expanded = Vec::with_capacity(total);
-
-        for (i, item) in data.iter().enumerate() {
-            let repeat = self.data_runs.get(i).copied().unwrap_or(1) as usize;
-            for _ in 0..repeat {
-                expanded.push(item.clone());
-            }
-        }
-
-        expanded
+    /// Repeat counts, when the mapping stores them.
+    pub fn repeat_counts(&self) -> Option<&[u32]> {
+        self.mapping.repeat_counts()
     }
 
-    /// Compute per-data-record byte lengths from the page map.
+    /// One element count per logical row, expanded from `lengths` /
+    /// `leng_runs`.
     ///
-    /// The page map stores `lengths` (unique length values) and `leng_runs`
-    /// (how many consecutive rows share each length). This function expands
-    /// to one length per data record (not per logical row — data_runs are
-    /// NOT applied here).
-    pub fn data_record_lengths(&self) -> Vec<u32> {
-        if self.data_runs.is_empty() {
-            // No data_runs: data_recs == total_rows, expand leng_runs directly
-            let mut row_lens = Vec::with_capacity(self.data_recs as usize);
-            for (length, &run) in self.lengths.iter().zip(self.leng_runs.iter()) {
-                for _ in 0..run {
-                    row_lens.push(*length);
+    /// Independent of the mapping: ncbi-vdb keeps the length runs unchanged
+    /// when it converts a page map to random access
+    /// (`PageMapToRandomAccess`), so row lengths always come from here.
+    pub fn logical_row_lengths(&self) -> Vec<u32> {
+        let mut out = Vec::with_capacity(self.total_rows() as usize);
+        for (&len, &run) in self.lengths.iter().zip(self.leng_runs.iter()) {
+            for _ in 0..run {
+                out.push(len);
+            }
+        }
+        out
+    }
+
+    /// Resolve every logical row to its `(offset, len)` in the blob's element
+    /// stream.
+    ///
+    /// This is the single place the three mappings are interpreted; it mirrors
+    /// the reference walk in ncbi-vdb's `PageMapFindRow` (page-map.c:431-461)
+    /// and the `data_offset[row]` lookup in `PageMapIteratorDataOffset`.
+    ///
+    /// Returns fewer than `total_rows()` entries when the map is internally
+    /// inconsistent (runs that don't cover every row); callers that care check
+    /// the length.
+    ///
+    /// Errors when `leng_runs` sums past [`MAX_LOGICAL_ROWS_PER_BLOB`], which
+    /// a crafted page map could otherwise use to force a huge allocation.
+    pub fn row_extents(&self) -> Result<Vec<RowExtent>> {
+        self.row_extents_range(0, self.total_rows() as usize)
+    }
+
+    /// [`row_extents`](Self::row_extents) for the window
+    /// `[skip, skip + take)` only.
+    ///
+    /// The walk still visits every length run and data record — that cost is
+    /// proportional to the *encoded* size, which is small — but it
+    /// materializes only the requested rows. Blobs where one record covers
+    /// millions of rows (SRR18959644's first READ_TYPE record spans
+    /// 22,227,968 spots) make the full expansion far more expensive than the
+    /// caller needs.
+    pub fn row_extents_range(&self, skip: usize, take: usize) -> Result<Vec<RowExtent>> {
+        let total_rows = self.total_rows();
+        if total_rows > MAX_LOGICAL_ROWS_PER_BLOB {
+            return Err(Error::Format(format!(
+                "page_map: logical row count {total_rows} exceeds {MAX_LOGICAL_ROWS_PER_BLOB} cap"
+            )));
+        }
+        let total = total_rows as usize;
+        let end = skip.saturating_add(take).min(total);
+        if skip >= end {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::with_capacity(end - skip);
+
+        // Walks the length runs in lockstep with the row cursor, so a row's
+        // element count is available without expanding `leng_runs`.
+        let mut lens = LengthRunCursor::new(self);
+
+        match &self.mapping {
+            RowMapping::Identity => {
+                let mut offset = 0u32;
+                for row in 0..end {
+                    let Some(len) = lens.next() else { break };
+                    if row >= skip {
+                        out.push(RowExtent { offset, len });
+                    }
+                    offset = offset.saturating_add(len);
                 }
             }
-            return row_lens;
-        }
-
-        // With data_runs: expand leng_runs to get per-logical-row lengths,
-        // then collapse back to per-data-record lengths by skipping repeated rows.
-        let mut logical_lens = Vec::with_capacity(self.total_rows() as usize);
-        for (length, &run) in self.lengths.iter().zip(self.leng_runs.iter()) {
-            for _ in 0..run {
-                logical_lens.push(*length);
+            RowMapping::RepeatCounts(repeats) => {
+                // Each record covers `repeat` rows that share one stored copy;
+                // the cursor advances one row length per *record*.
+                let mut offset = 0u32;
+                let mut row = 0usize;
+                for &repeat in repeats {
+                    if row >= end {
+                        break;
+                    }
+                    let Some(len) = lens.next() else { break };
+                    let rows_here = repeat as usize;
+                    for r in row..(row + rows_here).min(end) {
+                        if r >= skip {
+                            out.push(RowExtent { offset, len });
+                        }
+                    }
+                    // The remaining rows of this record consume the same
+                    // length run without advancing the data cursor.
+                    for _ in 1..rows_here {
+                        lens.next();
+                    }
+                    offset = offset.saturating_add(len);
+                    row += rows_here;
+                }
+            }
+            RowMapping::RandomAccessOffsets(offsets) => {
+                for row in 0..end {
+                    let Some(len) = lens.next() else { break };
+                    if row >= skip {
+                        // A zero-length row can point anywhere; the writer
+                        // emits 0 for those (libs/vdb/blob.c:800-806).
+                        let offset = offsets.get(row).copied().unwrap_or(0);
+                        out.push(RowExtent { offset, len });
+                    }
+                }
             }
         }
 
-        let mut record_lens = Vec::with_capacity(self.data_recs as usize);
-        let mut row = 0usize;
-        for i in 0..self.data_recs as usize {
-            let repeat = self.data_runs.get(i).copied().unwrap_or(1) as usize;
-            if row < logical_lens.len() {
-                record_lens.push(logical_lens[row]);
-            }
-            row += repeat;
-        }
-        record_lens
+        Ok(out)
     }
 
-    /// Expand a per-row-trimmed column (e.g. ALTREAD `trim<0,0>`) to a
-    /// flat `total_rows * row_bytes` buffer, zero-padding the removed
-    /// positions that were trimmed at write time.
+    /// Gather every logical row's data into one flat, row-ordered buffer.
     ///
-    /// `data` is the decompressed payload with one contiguous byte run
-    /// per data record. Records 0..N are then replicated `data_runs[i]`
-    /// times to produce the full row sequence. For every emitted row we
-    /// copy `min(stored, row_bytes)` bytes into the appropriate end of
-    /// the padded row (right-aligned for `TrimSide::Leading`,
-    /// left-aligned for `TrimSide::Trailing`) and leave the other end
-    /// zero.
+    /// `data` is the decompressed payload; `elem_bytes` is the column's true
+    /// element size (1 for byte columns, 4 for u32). Under
+    /// [`RowMapping::RepeatCounts`] a record stored once is emitted once per
+    /// row it covers; under [`RowMapping::RandomAccessOffsets`] each row is
+    /// pulled from its own offset, so deduplicated rows are materialized
+    /// again. The result always holds `sum(logical_row_lengths) * elem_bytes`
+    /// bytes.
     ///
-    /// Fails if a per-record stored length exceeds `row_bytes` (would
-    /// silently drop data) or if data runs short.
+    /// Errors when a row's slice would run past the end of `data`.
+    pub fn expand_rows(&self, data: &[u8], elem_bytes: usize) -> Result<Vec<u8>> {
+        if elem_bytes == 0 {
+            return Err(Error::Format(
+                "page_map: elem_bytes must be non-zero".into(),
+            ));
+        }
+        // Identity rows are already contiguous and in order.
+        if self.mapping.is_identity() {
+            return Ok(data.to_vec());
+        }
+
+        let extents = self.row_extents()?;
+        let total_rows = self.total_rows() as usize;
+        if extents.len() != total_rows {
+            return Err(Error::Format(format!(
+                "page_map: mapping covers {} of {total_rows} rows (inconsistent runs)",
+                extents.len(),
+            )));
+        }
+
+        let out_bytes: usize = extents
+            .iter()
+            .map(|e| e.len as usize * elem_bytes)
+            .try_fold(0usize, |acc, n| acc.checked_add(n))
+            .ok_or_else(|| Error::Format("page_map: expanded size overflows".into()))?;
+        let mut out = Vec::with_capacity(out_bytes);
+
+        for (row, extent) in extents.iter().enumerate() {
+            let start = (extent.offset as usize)
+                .checked_mul(elem_bytes)
+                .ok_or_else(|| Error::Format("page_map: row offset overflows".into()))?;
+            let len = (extent.len as usize)
+                .checked_mul(elem_bytes)
+                .ok_or_else(|| Error::Format("page_map: row length overflows".into()))?;
+            let end = start
+                .checked_add(len)
+                .ok_or_else(|| Error::Format("page_map: row extent overflows".into()))?;
+            if end > data.len() {
+                return Err(Error::Format(format!(
+                    "page_map: row {row} wants data[{start}..{end}] but data has {} bytes",
+                    data.len(),
+                )));
+            }
+            out.extend_from_slice(&data[start..end]);
+        }
+
+        Ok(out)
+    }
+
+    /// Expand a per-row-trimmed column (e.g. ALTREAD `trim<0,0>`) to a flat
+    /// `total_rows * row_bytes` buffer, zero-padding the positions the trim
+    /// removed at write time.
+    ///
+    /// Each row's stored bytes are copied into the appropriate end of its
+    /// slot — right-aligned for [`TrimSide::Leading`], left-aligned for
+    /// [`TrimSide::Trailing`] — and the rest is left zero.
+    ///
+    /// Fails if a stored row is wider than `row_bytes` (which would silently
+    /// drop data) or if a row's bytes run past the end of `data`.
     pub fn pad_trimmed_rows_fixed(
         &self,
         data: &[u8],
         row_bytes: usize,
         side: TrimSide,
     ) -> Result<Vec<u8>> {
-        let total_rows = self.total_rows() as usize;
-        let mut out = vec![0u8; total_rows * row_bytes];
-        let record_lens = self.data_record_lengths();
-
-        let mut in_off = 0usize;
-        let mut out_row = 0usize;
-        for (rec_idx, &rec_len_u32) in record_lens.iter().enumerate() {
-            let rec_len = rec_len_u32 as usize;
-            if rec_len > row_bytes {
-                return Err(Error::Format(format!(
-                    "page_map: record {rec_idx} stored {rec_len} bytes exceeds \
-                     row_bytes={row_bytes}"
-                )));
-            }
-            if in_off + rec_len > data.len() {
-                return Err(Error::Format(format!(
-                    "page_map: record {rec_idx} wants {rec_len} bytes at offset \
-                     {in_off} but data has only {}",
-                    data.len()
-                )));
-            }
-            let rec_data = &data[in_off..in_off + rec_len];
-            let repeat = if self.data_runs.is_empty() {
-                1
-            } else {
-                self.data_runs.get(rec_idx).copied().unwrap_or(1) as usize
-            };
-            for _ in 0..repeat {
-                if out_row >= total_rows {
-                    return Ok(out);
-                }
-                let out_start = out_row * row_bytes;
-                match side {
-                    TrimSide::Leading => {
-                        // stored bytes right-align; leading zeros fill the gap.
-                        let offset = row_bytes - rec_len;
-                        out[out_start + offset..out_start + row_bytes].copy_from_slice(rec_data);
-                    }
-                    TrimSide::Trailing => {
-                        out[out_start..out_start + rec_len].copy_from_slice(rec_data);
-                    }
-                }
-                out_row += 1;
-            }
-            in_off += rec_len;
-        }
-        Ok(out)
+        let row_lens = vec![row_bytes as u32; self.total_rows() as usize];
+        self.pad_trimmed_rows_variable(data, &row_lens, side)
     }
 
     /// Variable-target version of [`pad_trimmed_rows_fixed`].
     ///
     /// Used for columns whose logical rows have non-uniform true widths —
     /// e.g. ALTREAD on Illumina runs after adapter trimming, where each
-    /// spot's base count matches that spot's `READ_LEN` sum. The stored
-    /// bytes are still left- or right-aligned inside each row depending
-    /// on `side`; the difference from the fixed variant is that every
-    /// logical row pads to its own `row_lens[logical_row]` target instead
-    /// of a single shared `row_bytes`.
+    /// spot's base count matches that spot's `READ_LEN` sum. `row_lens` must
+    /// have `self.total_rows()` entries (one per logical row) and gives each
+    /// row's full pre-trim width; the page map's own `lengths` give the
+    /// trimmed width actually stored.
     ///
-    /// `row_lens` must have `self.total_rows()` entries (one per logical
-    /// row, after `data_runs` replication). Returns a buffer of size
-    /// `sum(row_lens)` — a flat concatenation of every logical row's
-    /// padded bytes — so callers merging against another variable-row
-    /// column can just iterate byte-for-byte.
+    /// Returns `sum(row_lens)` bytes — every logical row's padded bytes
+    /// concatenated — so callers merging against another variable-row column
+    /// can iterate byte for byte.
     ///
-    /// Fails if `row_lens` has the wrong length, if a stored record's
-    /// bytes exceed the target for any of its replicated rows, or if
-    /// `data` is shorter than the sum of per-record stored lengths.
+    /// Handles all three mappings, including the random-access one where
+    /// several rows share a stored copy.
     pub fn pad_trimmed_rows_variable(
         &self,
         data: &[u8],
@@ -371,367 +528,57 @@ impl PageMap {
         let total_rows = self.total_rows() as usize;
         if row_lens.len() != total_rows {
             return Err(Error::Format(format!(
-                "page_map: row_lens has {} entries, expected {} (total_rows)",
+                "page_map: row_lens has {} entries, expected {total_rows} (total_rows)",
                 row_lens.len(),
-                total_rows,
             )));
         }
+
+        let extents = self.row_extents()?;
+        if extents.len() != total_rows {
+            return Err(Error::Format(format!(
+                "page_map: mapping covers {} of {total_rows} rows (inconsistent runs)",
+                extents.len(),
+            )));
+        }
+
         let total_bytes: usize = row_lens.iter().map(|&l| l as usize).sum();
         let mut out = vec![0u8; total_bytes];
-        let record_lens = self.data_record_lengths();
-
-        let mut in_off = 0usize;
-        let mut out_off = 0usize;
-        let mut logical_row = 0usize;
-        for (rec_idx, &rec_len_u32) in record_lens.iter().enumerate() {
-            let rec_len = rec_len_u32 as usize;
-            if in_off + rec_len > data.len() {
-                return Err(Error::Format(format!(
-                    "page_map: record {rec_idx} wants {rec_len} bytes at offset \
-                     {in_off} but data has only {}",
-                    data.len()
-                )));
-            }
-            let rec_data = &data[in_off..in_off + rec_len];
-            let repeat = if self.data_runs.is_empty() {
-                1
-            } else {
-                self.data_runs.get(rec_idx).copied().unwrap_or(1) as usize
-            };
-            for _ in 0..repeat {
-                if logical_row >= total_rows {
-                    return Ok(out);
-                }
-                let row_bytes = row_lens[logical_row] as usize;
-                if rec_len > row_bytes {
-                    return Err(Error::Format(format!(
-                        "page_map: record {rec_idx} stored {rec_len} bytes \
-                         exceeds row {logical_row} target {row_bytes}"
-                    )));
-                }
-                match side {
-                    TrimSide::Leading => {
-                        let offset = row_bytes - rec_len;
-                        out[out_off + offset..out_off + row_bytes].copy_from_slice(rec_data);
-                    }
-                    TrimSide::Trailing => {
-                        out[out_off..out_off + rec_len].copy_from_slice(rec_data);
-                    }
-                }
-                out_off += row_bytes;
-                logical_row += 1;
-            }
-            in_off += rec_len;
-        }
-        Ok(out)
-    }
-
-    /// Reconstruct per-row bytes from a variant-2 random-access page map
-    /// (variable row lengths + per-row `data_offset[]`) used by trim-then-zip
-    /// physical columns like `.ALTREAD`.
-    ///
-    /// The on-disk layout in this variant: `lengths[]/leng_runs[]` describes
-    /// each row's *trimmed* byte count (after `trim<0,0>` stripped leading
-    /// zeros at write time), and the field this code calls `data_runs` is
-    /// actually `data_offset[row_count]` — the byte offset of each row's
-    /// trimmed bytes inside the decompressed `data` buffer. Multiple rows
-    /// may share the same offset (write-time deduplication), so the data
-    /// buffer can be much smaller than `sum(lengths × leng_runs)`.
-    ///
-    /// `row_logical_lens[r]` is the row's full pre-trim width (e.g. the
-    /// READ column's per-row base count for ALTREAD). The trimmed bytes are
-    /// placed inside a `row_logical_lens[r]` slot, right-aligned for
-    /// `TrimSide::Leading` (the trim<0,0> case) so the leading zeros that
-    /// were stripped are restored as zero bytes. Returns
-    /// `sum(row_logical_lens)` bytes — one row after another in a single
-    /// flat buffer, ready to merge byte-for-byte against another column.
-    ///
-    /// Errors when `row_logical_lens` length doesn't match `total_rows()`,
-    /// when `data_runs` (= `data_offset[]`) length doesn't match
-    /// `total_rows()` (i.e. this isn't a variant-2 RA page map), when a
-    /// trimmed length exceeds the corresponding logical width (would mean
-    /// the trim wrote more bytes than its input held), or when a row's
-    /// `(offset, trimmed_len)` slice would read past the end of `data`.
-    pub fn pad_random_access_rows(
-        &self,
-        data: &[u8],
-        row_logical_lens: &[u32],
-        side: TrimSide,
-    ) -> Result<Vec<u8>> {
-        let total_rows = self.total_rows() as usize;
-        if row_logical_lens.len() != total_rows {
-            return Err(Error::Format(format!(
-                "page_map: row_logical_lens has {} entries, expected {} (total_rows)",
-                row_logical_lens.len(),
-                total_rows,
-            )));
-        }
-        if self.data_runs.len() != total_rows {
-            return Err(Error::Format(format!(
-                "page_map: pad_random_access_rows requires data_offset[] of length \
-                 {total_rows}, got {} entries",
-                self.data_runs.len(),
-            )));
-        }
-
-        // Expand `lengths`/`leng_runs` to per-row trimmed lengths.
-        let mut row_trimmed_lens = Vec::with_capacity(total_rows);
-        for (length, &run) in self.lengths.iter().zip(self.leng_runs.iter()) {
-            for _ in 0..run {
-                row_trimmed_lens.push(*length);
-            }
-        }
-        if row_trimmed_lens.len() != total_rows {
-            return Err(Error::Format(format!(
-                "page_map: leng_runs sum to {} but total_rows() = {total_rows}",
-                row_trimmed_lens.len(),
-            )));
-        }
-
-        let total_bytes: usize = row_logical_lens.iter().map(|&l| l as usize).sum();
-        let mut out = vec![0u8; total_bytes];
 
         let mut out_off = 0usize;
-        for r in 0..total_rows {
-            let logical = row_logical_lens[r] as usize;
-            let trimmed = row_trimmed_lens[r] as usize;
-            let offset = self.data_runs[r] as usize;
-
-            if trimmed > logical {
+        for (row, extent) in extents.iter().enumerate() {
+            let target = row_lens[row] as usize;
+            let stored = extent.len as usize;
+            if stored > target {
                 return Err(Error::Format(format!(
-                    "page_map: row {r} trimmed_len {trimmed} > logical {logical}"
+                    "page_map: row {row} stored {stored} bytes exceeds target {target}"
                 )));
             }
-            if trimmed > 0 {
-                let end = offset.checked_add(trimmed).ok_or_else(|| {
-                    Error::Format(format!(
-                        "page_map: row {r} offset {offset} + trimmed {trimmed} overflows usize"
-                    ))
+            if stored > 0 {
+                let start = extent.offset as usize;
+                let end = start.checked_add(stored).ok_or_else(|| {
+                    Error::Format(format!("page_map: row {row} extent overflows"))
                 })?;
                 if end > data.len() {
                     return Err(Error::Format(format!(
-                        "page_map: row {r} wants data[{offset}..{end}] but data has only {} bytes",
+                        "page_map: row {row} wants data[{start}..{end}] but data has {} bytes",
                         data.len(),
                     )));
                 }
-                let bytes = &data[offset..end];
+                let bytes = &data[start..end];
                 match side {
                     TrimSide::Leading => {
-                        let pad = logical - trimmed;
-                        out[out_off + pad..out_off + logical].copy_from_slice(bytes);
+                        let pad = target - stored;
+                        out[out_off + pad..out_off + target].copy_from_slice(bytes);
                     }
                     TrimSide::Trailing => {
-                        out[out_off..out_off + trimmed].copy_from_slice(bytes);
+                        out[out_off..out_off + stored].copy_from_slice(bytes);
                     }
                 }
             }
-            out_off += logical;
+            out_off += target;
         }
 
         Ok(out)
-    }
-
-    /// Expand variable-length data via data_runs.
-    ///
-    /// Unlike [`expand_data_runs_bytes`](Self::expand_data_runs_bytes) which
-    /// handles fixed-size elements, this handles variable-length rows (e.g.,
-    /// quality data where each row has a different number of bytes).
-    ///
-    /// Fails if `data` is shorter than the sum of record lengths or if
-    /// `data_runs` has fewer entries than there are records — either signals
-    /// a truncated blob or a corrupt page map that would otherwise drop rows
-    /// silently.
-    pub fn expand_variable_data_runs(&self, data: &[u8]) -> Result<Vec<u8>> {
-        if self.data_runs.is_empty() {
-            return Ok(data.to_vec());
-        }
-
-        let record_lens = self.data_record_lengths();
-
-        if self.data_runs.len() < record_lens.len() {
-            return Err(Error::Format(format!(
-                "page_map: data_runs has {} entries, expected at least {}",
-                self.data_runs.len(),
-                record_lens.len(),
-            )));
-        }
-
-        let total_data: usize = record_lens.iter().map(|&l| l as usize).sum();
-        if data.len() < total_data {
-            return Err(Error::Format(format!(
-                "page_map: variable data truncated — have {} bytes, need {}",
-                data.len(),
-                total_data,
-            )));
-        }
-
-        let expected_out: usize = record_lens
-            .iter()
-            .zip(self.data_runs.iter())
-            .map(|(&len, &rep)| len as usize * rep as usize)
-            .sum();
-        let mut expanded = Vec::with_capacity(expected_out);
-        let mut cursor = 0usize;
-        for (i, &len) in record_lens.iter().enumerate() {
-            let repeat = self.data_runs[i] as usize;
-            let chunk = &data[cursor..cursor + len as usize];
-            for _ in 0..repeat {
-                expanded.extend_from_slice(chunk);
-            }
-            cursor += len as usize;
-        }
-
-        if expanded.len() != expected_out {
-            return Err(Error::Format(format!(
-                "page_map: expanded length {} != expected {}",
-                expanded.len(),
-                expected_out,
-            )));
-        }
-
-        Ok(expanded)
-    }
-
-    /// Expand run-length-encoded byte data to full row data.
-    ///
-    /// Like [`expand_data_runs`](Self::expand_data_runs), but operates on
-    /// fixed-size elements packed into a byte slice. Each element is
-    /// `elem_bytes` wide.
-    ///
-    /// Fails if `data_runs` has fewer entries than the number of elements in
-    /// `data` — missing entries used to default to repeat=1, silently losing
-    /// the intended per-record repeat counts.
-    pub fn expand_data_runs_bytes(&self, data: &[u8], elem_bytes: usize) -> Result<Vec<u8>> {
-        if self.data_runs.is_empty() || elem_bytes == 0 {
-            return Ok(data.to_vec());
-        }
-
-        let n = data.len() / elem_bytes;
-        if self.data_runs.len() < n {
-            return Err(Error::Format(format!(
-                "page_map: data_runs has {} entries, expected at least {} for {} bytes at {} bytes/elem",
-                self.data_runs.len(),
-                n,
-                data.len(),
-                elem_bytes,
-            )));
-        }
-
-        let expected_out: usize = self
-            .data_runs
-            .iter()
-            .take(n)
-            .map(|&r| r as usize * elem_bytes)
-            .sum();
-        let mut expanded = Vec::with_capacity(expected_out);
-
-        for i in 0..n {
-            let repeat = self.data_runs[i] as usize;
-            let start = i * elem_bytes;
-            let end = start + elem_bytes;
-            let chunk = &data[start..end];
-            for _ in 0..repeat {
-                expanded.extend_from_slice(chunk);
-            }
-        }
-
-        Ok(expanded)
-    }
-
-    /// Expand variable-length physical records into per-logical-row data,
-    /// honouring both `data_runs` (record → row replication) and the per-row
-    /// element counts carried by `lengths` / `leng_runs`.
-    ///
-    /// Each physical record occupies a contiguous run of elements in `data`
-    /// whose length is the element count of the first logical row the record
-    /// covers (all rows sharing a physical record have the same length). The
-    /// record is emitted `data_runs[i]` times.
-    ///
-    /// This generalises [`expand_data_runs_bytes`](Self::expand_data_runs_bytes),
-    /// which assumes every record is the same width. Variable-length array
-    /// columns — e.g. READ_START / READ_TYPE / LABEL_LEN / RD_FILTER on PacBio
-    /// SMRT runs, where each spot stores an NREADS-sized array — pack records
-    /// of differing lengths, so the fixed-width walk reads the wrong record
-    /// boundaries (and trips the length check when the record count and the
-    /// data-run count disagree).
-    ///
-    /// `elem_bytes` is the true element size (1 for byte columns, 4 for u32),
-    /// NOT a per-row stride — record widths come from the page map. Falls back
-    /// to passthrough when there are no `data_runs`.
-    pub fn expand_records_to_rows(&self, data: &[u8], elem_bytes: usize) -> Result<Vec<u8>> {
-        if self.data_runs.is_empty() || elem_bytes == 0 {
-            return Ok(data.to_vec());
-        }
-        // Without a length structure we can't recover per-record widths; defer
-        // to the fixed-width walk (each record is one element wide).
-        if self.lengths.is_empty() || self.leng_runs.is_empty() {
-            return self.expand_data_runs_bytes(data, elem_bytes);
-        }
-
-        let mut expanded = Vec::with_capacity(data.len());
-        let mut byte_off = 0usize; // consumed bytes of `data`
-        let mut li = 0usize; // index into lengths/leng_runs
-        let mut rem = self.leng_runs[0] as u64; // rows left in the current leng run
-
-        // Advance the leng-run cursor to the next run that still has rows.
-        let advance = |li: &mut usize, rem: &mut u64| -> Result<()> {
-            while *rem == 0 {
-                *li += 1;
-                match self.leng_runs.get(*li) {
-                    Some(&r) => *rem = r as u64,
-                    None => {
-                        return Err(Error::Format(
-                            "page_map: leng_runs exhausted before data_runs (inconsistent map)"
-                                .into(),
-                        ));
-                    }
-                }
-            }
-            Ok(())
-        };
-
-        for &run in &self.data_runs {
-            advance(&mut li, &mut rem)?;
-            let rec_len =
-                *self.lengths.get(li).ok_or_else(|| {
-                    Error::Format("page_map: lengths shorter than leng_runs".into())
-                })? as usize;
-            let rec_bytes = rec_len.checked_mul(elem_bytes).ok_or_else(|| {
-                Error::Format("page_map: record length × elem_bytes overflows".into())
-            })?;
-            let end = byte_off
-                .checked_add(rec_bytes)
-                .ok_or_else(|| Error::Format("page_map: record offset overflows".into()))?;
-            if end > data.len() {
-                return Err(Error::Format(format!(
-                    "page_map: variable record wants bytes {byte_off}..{end} but data has {}",
-                    data.len(),
-                )));
-            }
-            let chunk = &data[byte_off..end];
-            for _ in 0..run {
-                expanded.extend_from_slice(chunk);
-            }
-            byte_off = end;
-
-            // Consume `run` logical rows from the leng-run stream.
-            let mut to_consume = run as u64;
-            while to_consume > 0 {
-                advance(&mut li, &mut rem)?;
-                let step = to_consume.min(rem);
-                rem -= step;
-                to_consume -= step;
-            }
-        }
-
-        if byte_off != data.len() {
-            return Err(Error::Format(format!(
-                "page_map: variable records consumed {byte_off} of {} data bytes",
-                data.len(),
-            )));
-        }
-
-        Ok(expanded)
     }
 }
 
@@ -778,33 +625,41 @@ fn page_map_deserialize_v0(data: &[u8], row_count: u64) -> Result<PageMap> {
 
     let random_access = (data[0] >> 2) == 2;
 
+    // Random access is only ever written for variants 0 and 2: the encoder
+    // derives variant bit 0 from `data_recs != row_count`, and
+    // `PageMapToRandomAccess` always sets `data_recs = row_count`
+    // (ncbi-vdb page-map.c:729, :1098). Variants 1 and 3 reserve no space for
+    // `data_offset[]`, so a version-2 header on one of them is malformed —
+    // ncbi-vdb would leave `data_offset` NULL and dereference it later.
+    if random_access && (variant == 1 || variant == 3) {
+        return Err(Error::Format(format!(
+            "page_map: version 2 (random access) is not valid with variant {variant} — \
+             only variants 0 and 2 carry data_offset[]"
+        )));
+    }
+
     match variant {
         0 => {
             // Fixed row length.
             let (row_len, sz) = vlen_decode_u64(&data[cur..])?;
             cur += sz;
 
-            if random_access {
-                // Random access: data_offset array maps each row to a data position.
-                // The array has row_count entries, each indicating which data_rec
-                // that row uses. This allows compacting N rows into fewer unique entries.
+            let mapping = if random_access {
+                // `data_offset[row_count]`: one element offset per logical row.
                 let (data_offsets, _) = deserialize_lengths(&data[cur..], row_count as usize)?;
-                // data_recs = max(data_offsets) + 1
-                let max_off = data_offsets.iter().copied().max().unwrap_or(0);
-                Ok(PageMap {
-                    data_recs: (max_off + 1) as u64,
-                    lengths: vec![row_len as u32],
-                    leng_runs: vec![row_count as u32],
-                    data_runs: data_offsets, // repurpose data_runs as data_offsets
-                })
+                RowMapping::RandomAccessOffsets(data_offsets)
             } else {
-                Ok(PageMap {
-                    data_recs: row_count,
-                    lengths: vec![row_len as u32],
-                    leng_runs: vec![row_count as u32],
-                    data_runs: vec![],
-                })
-            }
+                RowMapping::Identity
+            };
+
+            Ok(PageMap {
+                // ncbi-vdb sets data_recs = row_count for this variant whether
+                // or not random access is on (page-map.c:1288).
+                data_recs: row_count,
+                lengths: vec![row_len as u32],
+                leng_runs: vec![row_count as u32],
+                mapping,
+            })
         }
         1 => {
             // Fixed row length, variable data_run.
@@ -820,23 +675,17 @@ fn page_map_deserialize_v0(data: &[u8], row_count: u64) -> Result<PageMap> {
                 data_recs,
                 lengths: vec![row_len as u32],
                 leng_runs: vec![row_count as u32],
-                data_runs,
+                mapping: RowMapping::RepeatCounts(data_runs),
             })
         }
         2 => {
             // Variable row length, data_run = 1.
             //
-            // When random_access is set (page_map version=2), this
-            // variant additionally stores `data_offset[row_count]`
-            // after the lengths/leng_runs pair — a per-row byte offset
-            // into the column's data buffer. ncbi-vdb repurposes the
-            // `data_run` slot to carry these offsets for the random-
-            // access variant. We follow the same convention so
-            // downstream code can detect "data_runs.len() ==
-            // total_rows" and dispatch into the offset-lookup branch
-            // already present in `expand_via_page_map`. Without this,
-            // NAME_FMT blobs on Illumina HiSeq archives (DRR040793
-            // blob 2 et al) lose their per-row template overrides and
+            // When random_access is set (page_map version 2), this variant
+            // additionally stores `data_offset[row_count]` after the
+            // lengths/leng_runs pair — one element offset per logical row.
+            // NAME_FMT blobs on Illumina HiSeq archives (DRR040793 blob 2 et
+            // al) rely on it for their per-row template overrides; without it
             // sracha falls back to the skey range mapping, which can't
             // reproduce the fine-grained tile interleave.
             let (leng_recs, sz) = vlen_decode_u64(&data[cur..])?;
@@ -850,18 +699,18 @@ fn page_map_deserialize_v0(data: &[u8], row_count: u64) -> Result<PageMap> {
             let lengths = combined[..leng_recs as usize].to_vec();
             let leng_runs = combined[leng_recs as usize..].to_vec();
 
-            let data_runs = if random_access {
+            let mapping = if random_access {
                 let (offsets, _) = deserialize_lengths(&data[cur..], row_count as usize)?;
-                offsets
+                RowMapping::RandomAccessOffsets(offsets)
             } else {
-                Vec::new()
+                RowMapping::Identity
             };
 
             Ok(PageMap {
                 data_recs: row_count,
                 lengths,
                 leng_runs,
-                data_runs,
+                mapping,
             })
         }
         3 => {
@@ -883,7 +732,7 @@ fn page_map_deserialize_v0(data: &[u8], row_count: u64) -> Result<PageMap> {
                 data_recs,
                 lengths,
                 leng_runs,
-                data_runs,
+                mapping: RowMapping::RepeatCounts(data_runs),
             })
         }
         _ => Err(Error::Format(format!(
@@ -2601,7 +2450,7 @@ mod tests {
         assert_eq!(pm.data_recs, 100);
         assert_eq!(pm.lengths, vec![10]);
         assert_eq!(pm.leng_runs, vec![100]);
-        assert!(pm.data_runs.is_empty());
+        assert_eq!(pm.mapping, RowMapping::Identity);
     }
 
     #[test]
@@ -2613,7 +2462,7 @@ mod tests {
         assert_eq!(pm.data_recs, 3);
         assert_eq!(pm.lengths, vec![5]);
         assert_eq!(pm.leng_runs, vec![6]);
-        assert_eq!(pm.data_runs, vec![2, 3, 1]);
+        assert_eq!(pm.mapping, RowMapping::RepeatCounts(vec![2, 3, 1]));
     }
 
     #[test]
@@ -2626,7 +2475,7 @@ mod tests {
         assert_eq!(pm.data_recs, 8);
         assert_eq!(pm.lengths, vec![10, 20]);
         assert_eq!(pm.leng_runs, vec![5, 3]);
-        assert!(pm.data_runs.is_empty());
+        assert_eq!(pm.mapping, RowMapping::Identity);
     }
 
     #[test]
@@ -2640,7 +2489,7 @@ mod tests {
         assert_eq!(pm.data_recs, 3);
         assert_eq!(pm.lengths, vec![10, 20]);
         assert_eq!(pm.leng_runs, vec![5, 3]);
-        assert_eq!(pm.data_runs, vec![1, 1, 1]);
+        assert_eq!(pm.mapping, RowMapping::RepeatCounts(vec![1, 1, 1]));
     }
 
     // -----------------------------------------------------------------------
@@ -2996,7 +2845,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // PageMap expand_data_runs tests
+    // PageMap expand_rows tests
     // -----------------------------------------------------------------------
 
     #[test]
@@ -3005,7 +2854,7 @@ mod tests {
             data_recs: 100,
             lengths: vec![10],
             leng_runs: vec![100],
-            data_runs: vec![],
+            mapping: RowMapping::Identity,
         };
         assert_eq!(pm.total_rows(), 100);
     }
@@ -3016,54 +2865,52 @@ mod tests {
             data_recs: 3,
             lengths: vec![5],
             leng_runs: vec![2048],
-            data_runs: vec![1000, 500, 548],
+            mapping: RowMapping::RepeatCounts(vec![1000, 500, 548]),
         };
         assert_eq!(pm.total_rows(), 2048);
     }
 
-    #[test]
-    fn page_map_expand_data_runs_empty_runs() {
-        // No data_runs means each entry covers 1 row (no expansion).
-        let pm = PageMap {
-            data_recs: 3,
-            lengths: vec![10],
-            leng_runs: vec![3],
-            data_runs: vec![],
-        };
-        let data = vec![10u32, 20, 30];
-        let expanded = pm.expand_data_runs(&data);
-        assert_eq!(expanded, vec![10, 20, 30]);
-    }
+    // The old `page_map_expand_data_runs_empty_runs` test (generic
+    // `expand_data_runs` over `&[u32]`, empty runs) is folded into
+    // `page_map_expand_rows_identity_is_passthrough` below: with the typed
+    // mapping, "no data runs" is exactly `RowMapping::Identity`.
 
     #[test]
-    fn page_map_expand_data_runs_with_repeats() {
-        // data_runs = [2, 3, 1] means:
-        //   entry 0 covers 2 rows, entry 1 covers 3 rows, entry 2 covers 1 row
+    fn page_map_expand_rows_repeat_counts_u32() {
+        // RepeatCounts [2, 3, 1]: record 0 covers 2 rows, record 1 covers 3
+        // rows, record 2 covers 1 row. One u32 element per row.
         let pm = PageMap {
             data_recs: 3,
-            lengths: vec![5],
+            lengths: vec![1],
             leng_runs: vec![6],
-            data_runs: vec![2, 3, 1],
+            mapping: RowMapping::RepeatCounts(vec![2, 3, 1]),
         };
-        let data = vec![100u32, 200, 300];
-        let expanded = pm.expand_data_runs(&data);
-        assert_eq!(expanded, vec![100, 100, 200, 200, 200, 300]);
+        let mut data = Vec::new();
+        for v in [100u32, 200, 300] {
+            data.extend_from_slice(&v.to_le_bytes());
+        }
+        let expanded = pm.expand_rows(&data, 4).unwrap();
+        let vals: Vec<u32> = expanded
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        assert_eq!(vals, vec![100, 100, 200, 200, 200, 300]);
     }
 
     #[test]
-    fn page_map_expand_data_runs_bytes_u32() {
+    fn page_map_expand_rows_repeat_counts_bytes_u32() {
         let pm = PageMap {
             data_recs: 2,
-            lengths: vec![4],
+            lengths: vec![1], // one u32 element per row
             leng_runs: vec![5],
-            data_runs: vec![3, 2],
+            mapping: RowMapping::RepeatCounts(vec![3, 2]),
         };
         // Two u32 LE values: 42 and 99
         let mut data = Vec::new();
         data.extend_from_slice(&42u32.to_le_bytes());
         data.extend_from_slice(&99u32.to_le_bytes());
 
-        let expanded = pm.expand_data_runs_bytes(&data, 4).unwrap();
+        let expanded = pm.expand_rows(&data, 4).unwrap();
         assert_eq!(expanded.len(), 5 * 4); // 5 rows * 4 bytes each
 
         let vals: Vec<u32> = expanded
@@ -3074,51 +2921,55 @@ mod tests {
     }
 
     #[test]
-    fn page_map_expand_data_runs_bytes_empty_runs() {
+    fn page_map_expand_rows_identity_is_passthrough() {
+        // Identity: every record is one row and rows are already contiguous
+        // and in order, so expansion is a copy.
         let pm = PageMap {
             data_recs: 2,
-            lengths: vec![4],
+            lengths: vec![1],
             leng_runs: vec![2],
-            data_runs: vec![],
+            mapping: RowMapping::Identity,
         };
         let data = vec![1, 2, 3, 4, 5, 6, 7, 8];
-        let expanded = pm.expand_data_runs_bytes(&data, 4).unwrap();
+        let expanded = pm.expand_rows(&data, 4).unwrap();
         assert_eq!(expanded, data);
     }
 
     #[test]
-    fn page_map_expand_records_to_rows_uniform_matches_fixed() {
-        // For uniform-length records, expand_records_to_rows must reproduce the
-        // fixed-width expand_data_runs_bytes result exactly.
+    fn page_map_expand_rows_random_access_offsets() {
+        // RandomAccessOffsets: offsets are ELEMENT offsets, may repeat, and
+        // need not increase. Rows 0 and 2 share record 0's copy; row 1 points
+        // past it. This is the shape a version-2 page map writes after
+        // VBlobPageMapOptimize dedups identical rows.
         let pm = PageMap {
-            data_recs: 2,
-            lengths: vec![1], // one u32 per row, constant
-            leng_runs: vec![5],
-            data_runs: vec![3, 2],
+            data_recs: 3,
+            lengths: vec![1],
+            leng_runs: vec![3],
+            mapping: RowMapping::RandomAccessOffsets(vec![0, 1, 0]),
         };
         let mut data = Vec::new();
-        data.extend_from_slice(&42u32.to_le_bytes());
-        data.extend_from_slice(&99u32.to_le_bytes());
-
-        let variable = pm.expand_records_to_rows(&data, 4).unwrap();
-        let fixed = pm.expand_data_runs_bytes(&data, 4).unwrap();
-        assert_eq!(variable, fixed);
-
-        let vals: Vec<u32> = variable
+        for v in [42u32, 99] {
+            data.extend_from_slice(&v.to_le_bytes());
+        }
+        let expanded = pm.expand_rows(&data, 4).unwrap();
+        let vals: Vec<u32> = expanded
             .chunks_exact(4)
             .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect();
-        assert_eq!(vals, vec![42, 42, 42, 99, 99]);
+        assert_eq!(vals, vec![42, 99, 42]);
     }
 
+    // `page_map_expand_records_to_rows_uniform_matches_fixed` compared the
+    // fixed-width and variable-width walks against each other; both are now
+    // the single `expand_rows` path, so the uniform-record case is covered by
+    // `page_map_expand_rows_repeat_counts_bytes_u32` above.
+
     #[test]
-    fn page_map_expand_records_to_rows_variable_lengths() {
+    fn page_map_expand_rows_variable_lengths() {
         // Variable-length array column (e.g. READ_START on PacBio SMRT): records
         // have differing element counts, given by the lengths/leng_runs runs,
-        // and each record is replicated data_runs[i] times. The fixed-width walk
-        // mis-reads record boundaries and rejects this shape — the variable walk
-        // must reconstruct it. Mirrors the real DRR032988 first-blob layout where
-        // data runs align with leng runs.
+        // and each record is replicated repeat_counts[i] times. Mirrors the real
+        // DRR032988 first-blob layout where data runs align with leng runs.
         //
         //   3 records: lengths 1, 3, 1 (sum = 5 u32s of source data)
         //   record 0 (len 1) -> repeated 2 rows
@@ -3128,7 +2979,7 @@ mod tests {
             data_recs: 3,
             lengths: vec![1, 3, 1],
             leng_runs: vec![2, 1, 2],
-            data_runs: vec![2, 1, 2],
+            mapping: RowMapping::RepeatCounts(vec![2, 1, 2]),
         };
         // Source u32 stream: rec0=[10], rec1=[20,21,22], rec2=[30]  (5 u32s)
         let src: Vec<u32> = vec![10, 20, 21, 22, 30];
@@ -3137,10 +2988,7 @@ mod tests {
             data.extend_from_slice(&v.to_le_bytes());
         }
 
-        // The fixed-width walk can't handle this (would want >= 5 data_runs).
-        assert!(pm.expand_data_runs_bytes(&data, 4).is_err());
-
-        let expanded = pm.expand_records_to_rows(&data, 4).unwrap();
+        let expanded = pm.expand_rows(&data, 4).unwrap();
         let vals: Vec<u32> = expanded
             .chunks_exact(4)
             .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
@@ -3150,68 +2998,67 @@ mod tests {
     }
 
     #[test]
-    fn page_map_expand_records_to_rows_byte_column() {
+    fn page_map_expand_rows_byte_column() {
         // Same shape, 1-byte elements (e.g. READ_TYPE).
         let pm = PageMap {
             data_recs: 3,
             lengths: vec![1, 3, 1],
             leng_runs: vec![2, 1, 2],
-            data_runs: vec![2, 1, 2],
+            mapping: RowMapping::RepeatCounts(vec![2, 1, 2]),
         };
         let data = vec![1u8, 0, 1, 0, 1]; // rec0=[1] rec1=[0,1,0] rec2=[1]
-        let expanded = pm.expand_records_to_rows(&data, 1).unwrap();
+        let expanded = pm.expand_rows(&data, 1).unwrap();
         assert_eq!(expanded, vec![1, 1, 0, 1, 0, 1, 1]);
     }
 
     #[test]
-    fn page_map_expand_records_to_rows_rejects_truncated() {
-        // Source shorter than the records demand -> error, not silent garbage.
+    fn page_map_expand_rows_rejects_truncated() {
+        // Source shorter than the rows demand -> error, not silent garbage.
         let pm = PageMap {
             data_recs: 2,
             lengths: vec![1, 3],
             leng_runs: vec![1, 1],
-            data_runs: vec![1, 1],
+            mapping: RowMapping::RepeatCounts(vec![1, 1]),
         };
         let data = vec![0u8; 4]; // only 1 u32, needs 1 + 3 = 4 u32s
-        assert!(pm.expand_records_to_rows(&data, 4).is_err());
+        assert!(pm.expand_rows(&data, 4).is_err());
     }
 
     #[test]
-    fn page_map_expand_data_runs_bytes_rejects_short_data_runs() {
-        // data has 3 elements (12 bytes / 4), but data_runs only has 2.
+    fn page_map_expand_rows_rejects_incomplete_mapping() {
+        // The repeat counts cover 2 + 3 = 5 rows but leng_runs claims 6, so the
+        // map is internally inconsistent — refuse rather than emit a short
+        // buffer that callers would silently mis-slice.
         let pm = PageMap {
             data_recs: 2,
-            lengths: vec![4],
-            leng_runs: vec![5],
-            data_runs: vec![2, 3],
+            lengths: vec![1],
+            leng_runs: vec![6],
+            mapping: RowMapping::RepeatCounts(vec![2, 3]),
         };
-        let data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        assert!(pm.expand_data_runs_bytes(&data, 4).is_err());
+        let data = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
+        assert!(pm.expand_rows(&data, 4).is_err());
     }
 
     #[test]
-    fn page_map_expand_data_runs_bytes_row_length_gt_1() {
+    fn page_map_expand_rows_row_length_gt_1() {
         // Regression for iter-1 validation: columns with row_length > 1 crashed
-        // sracha with `data_runs has N entries, expected at least 2N for 4N
-        // bytes at 4 bytes/elem`. Callers must pass entry_bytes
-        // (= row_length × elem_bytes), not elem_bytes, so the "number of rows"
-        // check matches the per-row data_runs count.
+        // sracha with `data runs has N entries, expected at least 2N for 4N
+        // bytes at 4 bytes/elem`. Row width now comes from the page map's own
+        // `lengths`, so callers pass elem_bytes and the walk derives the rest.
         let pm = PageMap {
             data_recs: 3,
             lengths: vec![2], // two u32s per row
             leng_runs: vec![6],
-            data_runs: vec![2, 1, 3],
+            mapping: RowMapping::RepeatCounts(vec![2, 1, 3]),
         };
-        // Three rows, two u32 LE each = 24 bytes.
+        // Three records, two u32 LE each = 24 bytes.
         let mut data = Vec::new();
         for v in [10u32, 11, 20, 21, 30, 31] {
             data.extend_from_slice(&v.to_le_bytes());
         }
-        let row_length = pm.lengths[0] as usize;
-        let entry_bytes = row_length * 4;
 
-        let expanded = pm.expand_data_runs_bytes(&data, entry_bytes).unwrap();
-        // 2 + 1 + 3 = 6 logical rows, each 8 bytes.
+        let expanded = pm.expand_rows(&data, 4).unwrap();
+        // 2 + 1 + 3 = 6 logical rows, each 2 u32s.
         assert_eq!(expanded.len(), 6 * 8);
         let vals: Vec<u32> = expanded
             .chunks_exact(4)
@@ -3219,22 +3066,36 @@ mod tests {
             .collect();
         assert_eq!(vals, vec![10, 11, 10, 11, 20, 21, 30, 31, 30, 31, 30, 31]);
 
-        // And confirm the old mis-invocation (passing elem_bytes=4) still
-        // fails, so we don't silently regress.
-        assert!(pm.expand_data_runs_bytes(&data, 4).is_err());
+        // The units flipped relative to the old API: passing entry_bytes
+        // (row_length × elem_bytes) now double-counts the row width and runs
+        // off the end of the data. Kept so a caller can't regress to it
+        // silently.
+        let entry_bytes = pm.lengths[0] as usize * 4;
+        assert!(pm.expand_rows(&data, entry_bytes).is_err());
     }
 
     #[test]
-    fn page_map_expand_variable_data_runs_rejects_truncated_data() {
-        // record_lens will be [4], needs 4 bytes; give it only 2.
+    fn page_map_expand_rows_rejects_truncated_data() {
+        // Row length is 4 elements, so row 0 needs 4 bytes; give it only 2.
         let pm = PageMap {
             data_recs: 1,
             lengths: vec![4],
             leng_runs: vec![3],
-            data_runs: vec![3],
+            mapping: RowMapping::RepeatCounts(vec![3]),
         };
         let data = vec![1u8, 2];
-        assert!(pm.expand_variable_data_runs(&data).is_err());
+        assert!(pm.expand_rows(&data, 1).is_err());
+    }
+
+    #[test]
+    fn page_map_expand_rows_rejects_zero_elem_bytes() {
+        let pm = PageMap {
+            data_recs: 1,
+            lengths: vec![1],
+            leng_runs: vec![1],
+            mapping: RowMapping::RepeatCounts(vec![1]),
+        };
+        assert!(pm.expand_rows(&[0u8; 4], 0).is_err());
     }
 
     // -----------------------------------------------------------------------
@@ -3244,13 +3105,13 @@ mod tests {
     #[test]
     fn pad_trimmed_rows_leading_right_aligns_and_replicates() {
         // Mirrors ALTREAD `trim<0,0>`: each record's stored bytes land at
-        // the END of a fixed-width row, and `data_runs` copies those bytes
-        // into multiple consecutive rows.
+        // the END of a fixed-width row, and the repeat counts copy those
+        // bytes into multiple consecutive rows.
         let pm = PageMap {
             data_recs: 2,
             lengths: vec![3, 0],
             leng_runs: vec![2, 3],
-            data_runs: vec![2, 3],
+            mapping: RowMapping::RepeatCounts(vec![2, 3]),
         };
         // Record 0 = 3 bytes, record 1 = 0 bytes. Data = record 0 only.
         let data = vec![0xAA, 0xBB, 0xCC];
@@ -3277,7 +3138,7 @@ mod tests {
             data_recs: 1,
             lengths: vec![2],
             leng_runs: vec![3],
-            data_runs: vec![3],
+            mapping: RowMapping::RepeatCounts(vec![3]),
         };
         let data = vec![0x01, 0x02];
         let padded = pm
@@ -3299,7 +3160,7 @@ mod tests {
             data_recs: 1,
             lengths: vec![5],
             leng_runs: vec![1],
-            data_runs: vec![1],
+            mapping: RowMapping::RepeatCounts(vec![1]),
         };
         let data = vec![1u8, 2, 3, 4, 5];
         // row_bytes=3 is shorter than the 5-byte record — must error.
@@ -3323,7 +3184,7 @@ mod tests {
             data_recs: 3,
             lengths: vec![2],
             leng_runs: vec![3],
-            data_runs: vec![],
+            mapping: RowMapping::Identity,
         };
         let data = vec![0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F];
         let row_lens = vec![4u32, 6, 3];
@@ -3341,9 +3202,9 @@ mod tests {
     }
 
     #[test]
-    fn pad_trimmed_rows_variable_replicates_via_data_runs() {
-        // Two data records (3-byte, 2-byte). data_runs replicate record 0
-        // across two logical rows and record 1 across three. Each
+    fn pad_trimmed_rows_variable_replicates_via_repeat_counts() {
+        // Two data records (3-byte, 2-byte). The repeat counts replicate
+        // record 0 across two logical rows and record 1 across three. Each
         // replicated logical row gets its own target width — mimics the
         // ALTREAD case where deduplicated records expand into rows of
         // differing true lengths.
@@ -3351,7 +3212,7 @@ mod tests {
             data_recs: 2,
             lengths: vec![3, 2],
             leng_runs: vec![2, 3],
-            data_runs: vec![2, 3],
+            mapping: RowMapping::RepeatCounts(vec![2, 3]),
         };
         let data = vec![0xAA, 0xBB, 0xCC, 0xDD, 0xEE];
         let row_lens = vec![5u32, 4, 3, 2, 4];
@@ -3376,7 +3237,7 @@ mod tests {
             data_recs: 1,
             lengths: vec![5],
             leng_runs: vec![1],
-            data_runs: vec![],
+            mapping: RowMapping::Identity,
         };
         let data = vec![1u8, 2, 3, 4, 5];
         // Target row width 3 < stored record length 5.
@@ -3392,7 +3253,7 @@ mod tests {
             data_recs: 2,
             lengths: vec![1],
             leng_runs: vec![2],
-            data_runs: vec![],
+            mapping: RowMapping::Identity,
         };
         let data = vec![0x01, 0x02];
         // total_rows is 2 but caller supplied only one length.
@@ -3403,7 +3264,7 @@ mod tests {
     }
 
     #[test]
-    fn pad_random_access_rows_dedups_offset_zero_across_rows() {
+    fn pad_trimmed_rows_random_access_dedups_offset_zero_across_rows() {
         // Variant-2 RA shape: 4 rows, two length runs (3 rows of length 2,
         // 1 row of length 3). Rows 0-2 share offset=0; row 3 sits at
         // offset 2. Logical width 5 — leading-trim restoration leaves
@@ -3412,14 +3273,14 @@ mod tests {
             data_recs: 4,
             lengths: vec![2, 3],
             leng_runs: vec![3, 1],
-            data_runs: vec![0, 0, 0, 2], // repurposed as data_offset[]
+            mapping: RowMapping::RandomAccessOffsets(vec![0, 0, 0, 2]),
         };
         // data: bytes 0..2 = the dedup'd 2-byte payload for the first
         // run; bytes 2..5 = the unique 3-byte payload for the last row.
         let data = vec![0x0a, 0x0b, 0xcc, 0xdd, 0xee];
         let widths = [5u32; 4];
         let out = pm
-            .pad_random_access_rows(&data, &widths, TrimSide::Leading)
+            .pad_trimmed_rows_variable(&data, &widths, TrimSide::Leading)
             .unwrap();
         // Each output row is 5 bytes; trimmed bytes right-aligned with
         // leading zeros padding the gap.
@@ -3435,24 +3296,24 @@ mod tests {
     }
 
     #[test]
-    fn pad_random_access_rows_zero_trim_emits_all_zeros() {
+    fn pad_trimmed_rows_random_access_zero_trim_emits_all_zeros() {
         // A zero-trim run means "no overlay for these rows" — the output
         // width should still be respected; bytes stay zero.
         let pm = PageMap {
             data_recs: 2,
             lengths: vec![0],
             leng_runs: vec![2],
-            data_runs: vec![0, 0],
+            mapping: RowMapping::RandomAccessOffsets(vec![0, 0]),
         };
         let data = vec![];
         let out = pm
-            .pad_random_access_rows(&data, &[4, 4], TrimSide::Leading)
+            .pad_trimmed_rows_variable(&data, &[4, 4], TrimSide::Leading)
             .unwrap();
         assert_eq!(out, vec![0u8; 8]);
     }
 
     #[test]
-    fn pad_random_access_rows_trailing_side_left_aligns() {
+    fn pad_trimmed_rows_random_access_trailing_side_left_aligns() {
         // TrimSide::Trailing: trim<0,0> with side=1 strips trailing
         // zeros, so restoration places stored bytes at the start of
         // each row.
@@ -3460,11 +3321,11 @@ mod tests {
             data_recs: 2,
             lengths: vec![2],
             leng_runs: vec![2],
-            data_runs: vec![0, 0],
+            mapping: RowMapping::RandomAccessOffsets(vec![0, 0]),
         };
         let data = vec![0x11, 0x22];
         let out = pm
-            .pad_random_access_rows(&data, &[5, 5], TrimSide::Trailing)
+            .pad_trimmed_rows_variable(&data, &[5, 5], TrimSide::Trailing)
             .unwrap();
         assert_eq!(
             out,
@@ -3476,7 +3337,7 @@ mod tests {
     }
 
     #[test]
-    fn pad_random_access_rows_rejects_trim_greater_than_logical() {
+    fn pad_trimmed_rows_random_access_rejects_trim_greater_than_logical() {
         // A trimmed length wider than the row's logical width would mean
         // trim<0,0> output more bytes than its input held — corrupt
         // page_map. Refuse.
@@ -3484,43 +3345,44 @@ mod tests {
             data_recs: 1,
             lengths: vec![10],
             leng_runs: vec![1],
-            data_runs: vec![0],
+            mapping: RowMapping::RandomAccessOffsets(vec![0]),
         };
         let data = vec![0u8; 10];
         assert!(
-            pm.pad_random_access_rows(&data, &[5], TrimSide::Leading)
+            pm.pad_trimmed_rows_variable(&data, &[5], TrimSide::Leading)
                 .is_err()
         );
     }
 
     #[test]
-    fn pad_random_access_rows_rejects_offset_past_data_end() {
+    fn pad_trimmed_rows_random_access_rejects_offset_past_data_end() {
         // Offset+length out of bounds. Loud failure beats silent bad
         // FASTQ; the caller logs the error and skips the merge.
         let pm = PageMap {
             data_recs: 1,
             lengths: vec![3],
             leng_runs: vec![1],
-            data_runs: vec![5], // 5 + 3 = 8 > data.len() = 6
+            // 5 + 3 = 8 > data.len() = 6
+            mapping: RowMapping::RandomAccessOffsets(vec![5]),
         };
         let data = vec![0u8; 6];
         assert!(
-            pm.pad_random_access_rows(&data, &[5], TrimSide::Leading)
+            pm.pad_trimmed_rows_variable(&data, &[5], TrimSide::Leading)
                 .is_err()
         );
     }
 
     #[test]
-    fn pad_random_access_rows_rejects_wrong_logical_lens_count() {
+    fn pad_trimmed_rows_random_access_rejects_wrong_logical_lens_count() {
         let pm = PageMap {
             data_recs: 2,
             lengths: vec![1],
             leng_runs: vec![2],
-            data_runs: vec![0, 0],
+            mapping: RowMapping::RandomAccessOffsets(vec![0, 0]),
         };
         let data = vec![0x01];
         assert!(
-            pm.pad_random_access_rows(&data, &[4], TrimSide::Leading)
+            pm.pad_trimmed_rows_variable(&data, &[4], TrimSide::Leading)
                 .is_err()
         );
     }
@@ -3630,14 +3492,14 @@ mod tests {
     // PageMap property tests — regression fence for issue-#22 class bugs
     //
     // Every `expand_*` method had silent-wrong-output failure modes when
-    // variable `data_runs` interacted with heterogeneous row lengths. These
+    // variable repeat counts interacted with heterogeneous row lengths. These
     // tests compare against a naive "obvious" reference expansion over
     // randomly-shaped page maps to catch any such divergence.
     // -----------------------------------------------------------------------
 
     use proptest::prelude::*;
 
-    /// Build a PageMap from `(data_run, length)` pairs — one per data record.
+    /// Build a PageMap from `(repeat_count, length)` pairs — one per data record.
     /// The on-disk format assumes rows within the same data-run share a
     /// length, so we expand + RLE to produce canonical `lengths`/`leng_runs`.
     fn page_map_from_pairs(pairs: &[(u32, u32)]) -> PageMap {
@@ -3662,13 +3524,13 @@ mod tests {
             data_recs: pairs.len() as u64,
             lengths,
             leng_runs,
-            data_runs: pairs.iter().map(|&(r, _)| r).collect(),
+            mapping: RowMapping::RepeatCounts(pairs.iter().map(|&(r, _)| r).collect()),
         }
     }
 
     proptest! {
-        /// expand_variable_data_runs matches the naive "emit record i's
-        /// bytes data_runs[i] times" expansion for every well-formed page
+        /// expand_rows matches the naive "emit record i's bytes
+        /// repeat_counts[i] times" expansion for every well-formed page
         /// map. Direct fence against issue #22: the original bug silently
         /// skipped expansion whenever `lengths` wasn't all-equal, and a
         /// property test like this one would have caught it before landing.
@@ -3681,7 +3543,7 @@ mod tests {
         ) {
             let pm = page_map_from_pairs(&pairs);
             let record_lens: Vec<u32> = pairs.iter().map(|&(_, l)| l).collect();
-            let data_runs: Vec<u32> = pairs.iter().map(|&(r, _)| r).collect();
+            let repeats: Vec<u32> = pairs.iter().map(|&(r, _)| r).collect();
 
             // data: record i is `length` bytes of value `i as u8`. Picking
             // per-record distinct bytes lets a mis-stitched output be
@@ -3693,13 +3555,13 @@ mod tests {
                 }
             }
 
-            let got = pm.expand_variable_data_runs(&data).unwrap();
+            let got = pm.expand_rows(&data, 1).unwrap();
 
             let mut expected = Vec::new();
             let mut cursor = 0usize;
             for (i, &len) in record_lens.iter().enumerate() {
                 let chunk = &data[cursor..cursor + len as usize];
-                for _ in 0..data_runs[i] as usize {
+                for _ in 0..repeats[i] as usize {
                     expected.extend_from_slice(chunk);
                 }
                 cursor += len as usize;
@@ -3707,24 +3569,31 @@ mod tests {
             prop_assert_eq!(got, expected);
         }
 
-        /// expand_data_runs (fixed-element) matches a flat_map expansion
-        /// for every well-formed `data_runs`.
+        /// expand_rows over fixed-width (one element per row) records
+        /// matches a flat_map expansion for every well-formed repeat-count
+        /// vector.
         #[test]
-        fn prop_expand_data_runs_fixed_matches_reference(
+        fn prop_expand_rows_fixed_matches_reference(
             runs in proptest::collection::vec(1u32..=4u32, 1..15),
         ) {
-            let data: Vec<u32> = (0..runs.len() as u32).collect();
+            let values: Vec<u32> = (0..runs.len() as u32).collect();
+            let mut data = Vec::new();
+            for v in &values {
+                data.extend_from_slice(&v.to_le_bytes());
+            }
             let total_rows: u32 = runs.iter().sum();
-            // expand_data_runs doesn't consult `lengths`, so the trivial
-            // (lengths=[1], leng_runs=[total]) parametrisation suffices.
+            // One u32 element per row: lengths=[1], leng_runs=[total].
             let pm = PageMap {
-                data_recs: data.len() as u64,
+                data_recs: values.len() as u64,
                 lengths: vec![1],
                 leng_runs: vec![total_rows],
-                data_runs: runs.clone(),
+                mapping: RowMapping::RepeatCounts(runs.clone()),
             };
-            let got = pm.expand_data_runs(&data);
-            let expected: Vec<u32> = data
+            let got: Vec<u32> = pm.expand_rows(&data, 4).unwrap()
+                .chunks_exact(4)
+                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect();
+            let expected: Vec<u32> = values
                 .iter()
                 .zip(runs.iter())
                 .flat_map(|(&v, &r)| std::iter::repeat_n(v, r as usize))
@@ -3732,22 +3601,26 @@ mod tests {
             prop_assert_eq!(got, expected);
         }
 
-        /// data_record_lengths reproduces the per-record `length` input.
-        /// Round-trip over the RLE (`lengths`/`leng_runs`) + `data_runs`.
+        /// logical_row_lengths reproduces one length per logical row: record
+        /// i's `length` repeated `repeat_count` times. Round-trip over the
+        /// RLE (`lengths`/`leng_runs`) encoding built by page_map_from_pairs.
         #[test]
-        fn prop_data_record_lengths_round_trip(
+        fn prop_logical_row_lengths_round_trip(
             pairs in proptest::collection::vec(
                 (1u32..=4u32, 0u32..=8u32),
                 1..12,
             ),
         ) {
             let pm = page_map_from_pairs(&pairs);
-            let got = pm.data_record_lengths();
-            let expected: Vec<u32> = pairs.iter().map(|&(_, l)| l).collect();
+            let got = pm.logical_row_lengths();
+            let expected: Vec<u32> = pairs
+                .iter()
+                .flat_map(|&(r, l)| std::iter::repeat_n(l, r as usize))
+                .collect();
             prop_assert_eq!(got, expected);
         }
 
-        /// total_rows always equals both sum(leng_runs) and sum(data_runs)
+        /// total_rows always equals both sum(leng_runs) and sum(repeat counts)
         /// for well-formed page maps. Cross-checks the two RLE encodings.
         #[test]
         fn prop_total_rows_consistent(
@@ -3759,9 +3632,38 @@ mod tests {
             let pm = page_map_from_pairs(&pairs);
             let total = pm.total_rows();
             let sum_leng: u64 = pm.leng_runs.iter().map(|&r| u64::from(r)).sum();
-            let sum_data: u64 = pm.data_runs.iter().map(|&r| u64::from(r)).sum();
+            let sum_data: u64 = pm
+                .repeat_counts()
+                .expect("page_map_from_pairs builds RepeatCounts")
+                .iter()
+                .map(|&r| u64::from(r))
+                .sum();
             prop_assert_eq!(total, sum_leng);
             prop_assert_eq!(total, sum_data);
+        }
+
+        /// row_extents_range(skip, take) returns exactly the window it was
+        /// asked for out of the full row_extents() walk — the windowed walk
+        /// must not drift from the full one.
+        #[test]
+        fn prop_row_extents_range_matches_full(
+            pairs in proptest::collection::vec(
+                (1u32..=4u32, 0u32..=8u32),
+                1..12,
+            ),
+            skip in 0usize..12,
+            take in 0usize..12,
+        ) {
+            let pm = page_map_from_pairs(&pairs);
+            let full = pm.row_extents().unwrap();
+            let window = pm.row_extents_range(skip, take).unwrap();
+            let expected: Vec<RowExtent> = full
+                .iter()
+                .skip(skip)
+                .take(take)
+                .copied()
+                .collect();
+            prop_assert_eq!(window, expected);
         }
     }
 }

--- a/crates/sracha-vdb/src/blob.rs
+++ b/crates/sracha-vdb/src/blob.rs
@@ -235,7 +235,6 @@ impl RowMapping {
     pub fn is_identity(&self) -> bool {
         matches!(self, RowMapping::Identity)
     }
-
 }
 
 /// Maximum logical rows per blob — reject page maps whose `leng_runs` sum to
@@ -2476,6 +2475,106 @@ mod tests {
         assert_eq!(pm.lengths, vec![10, 20]);
         assert_eq!(pm.leng_runs, vec![5, 3]);
         assert_eq!(pm.mapping, RowMapping::Identity);
+    }
+
+    /// Raw deflate (no zlib wrapper), matching the `deflateInit2(..., -15,
+    /// ...)` the page map serializer uses for versions 1 and 2.
+    fn deflate_raw(data: &[u8]) -> Vec<u8> {
+        use flate2::{Compression, write::DeflateEncoder};
+        use std::io::Write;
+        let mut enc = DeflateEncoder::new(Vec::new(), Compression::fast());
+        enc.write_all(data).unwrap();
+        enc.finish().unwrap()
+    }
+
+    /// Version 2 is the random-access encoding: the array after the header is
+    /// `data_offset[row_count]`, one element offset per logical row, NOT
+    /// repeat counts. Misreading this is issue #101.
+    #[test]
+    fn page_map_version2_variant0_is_random_access() {
+        // byte0 = (version 2 << 2) | variant 0 = 0x08, row_length = 3.
+        // Six rows drawn from a three-row vocabulary: offsets repeat and are
+        // not monotonic, both of which the format allows.
+        let mut data = vec![0x08, 3];
+        data.extend_from_slice(&deflate_raw(&[0, 0, 3, 3, 0, 6]));
+        let pm = page_map_deserialize(&data, 6).unwrap();
+
+        assert_eq!(pm.lengths, vec![3]);
+        assert_eq!(pm.leng_runs, vec![6]);
+        assert_eq!(
+            pm.mapping,
+            RowMapping::RandomAccessOffsets(vec![0, 0, 3, 3, 0, 6])
+        );
+        // ncbi-vdb sets data_recs = row_count here (page-map.c:1288). Deriving
+        // it from the offsets instead (e.g. max + 1 = 7) is meaningless: the
+        // offsets are neither sorted nor unique.
+        assert_eq!(pm.data_recs, 6);
+
+        // Nine stored bytes back six rows of three.
+        let expanded = pm.expand_rows(b"AAABBBCCC", 1).unwrap();
+        assert_eq!(expanded, b"AAAAAABBBBBBAAACCC");
+    }
+
+    #[test]
+    fn page_map_version2_variant2_is_random_access() {
+        // byte0 = (2 << 2) | 2 = 0x0A, leng_recs = 2.
+        // lengths=[2,3], leng_runs=[2,2], then data_offset[4].
+        let mut data = vec![0x0A, 2];
+        data.extend_from_slice(&deflate_raw(&[2, 3, 2, 2, 0, 0, 2, 2]));
+        let pm = page_map_deserialize(&data, 4).unwrap();
+
+        assert_eq!(pm.lengths, vec![2, 3]);
+        assert_eq!(pm.leng_runs, vec![2, 2]);
+        assert_eq!(
+            pm.mapping,
+            RowMapping::RandomAccessOffsets(vec![0, 0, 2, 2])
+        );
+        assert_eq!(pm.data_recs, 4);
+
+        // Rows 0-1 are two bytes at offset 0; rows 2-3 are three at offset 2.
+        let expanded = pm.expand_rows(b"ABCDE", 1).unwrap();
+        assert_eq!(expanded, b"ABABCDECDE");
+    }
+
+    /// Version 1 keeps the run-length reading, so the same trailing array
+    /// means something entirely different from the version-2 case above.
+    #[test]
+    fn page_map_version1_variant1_is_repeat_counts() {
+        // byte0 = (1 << 2) | 1 = 0x05, row_length = 3, data_recs = 2.
+        let mut data = vec![0x05, 3, 2];
+        data.extend_from_slice(&deflate_raw(&[2, 4]));
+        let pm = page_map_deserialize(&data, 6).unwrap();
+
+        assert_eq!(pm.mapping, RowMapping::RepeatCounts(vec![2, 4]));
+        // Record 0 backs rows 0-1, record 1 backs rows 2-5: 2x"AAA" + 4x"BBB".
+        let expanded = pm.expand_rows(b"AAABBB", 1).unwrap();
+        assert_eq!(expanded, b"AAAAAABBBBBBBBBBBB".to_vec());
+    }
+
+    /// Random access is only ever emitted for variants 0 and 2 — the encoder
+    /// derives variant bit 0 from `data_recs != row_count` and
+    /// `PageMapToRandomAccess` always sets them equal. Variants 1 and 3
+    /// reserve no space for `data_offset[]`, so ncbi-vdb would read a NULL
+    /// pointer; we refuse instead.
+    #[test]
+    fn page_map_version2_rejects_variants_with_data_runs() {
+        for (byte0, variant) in [(0x09u8, 1), (0x0Bu8, 3)] {
+            let mut data = vec![byte0, 3, 2];
+            data.extend_from_slice(&deflate_raw(&[2, 4, 1, 1]));
+            let err = page_map_deserialize(&data, 6)
+                .expect_err("version 2 on variant {variant} must be rejected");
+            assert!(
+                matches!(err, Error::Format(ref m) if m.contains("random access")),
+                "variant {variant}: got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn page_map_rejects_unsupported_version() {
+        // Version 3 is past everything ncbi-vdb will deserialize.
+        let err = page_map_deserialize(&[0x0C, 1], 1).expect_err("version 3 must be rejected");
+        assert!(matches!(err, Error::Format(_)), "got {err:?}");
     }
 
     #[test]

--- a/crates/sracha-vdb/src/blob.rs
+++ b/crates/sracha-vdb/src/blob.rs
@@ -261,14 +261,30 @@ impl<'a> LengthRunCursor<'a> {
         }
     }
 
-    fn next(&mut self) -> Option<u32> {
+    /// Element count of the row at the cursor, without advancing.
+    fn peek(&mut self) -> Option<u32> {
         while self.left_in_run == 0 {
             self.idx += 1;
             self.left_in_run = *self.leng_runs.get(self.idx)?;
         }
-        let len = *self.lengths.get(self.idx)?;
-        self.left_in_run -= 1;
-        Some(len)
+        self.lengths.get(self.idx).copied()
+    }
+
+    /// Advance past `n` rows and return the elements they span.
+    ///
+    /// Whole runs are consumed at a time, so skipping a record that covers
+    /// millions of rows costs one iteration per run crossed, not one per row.
+    fn skip_rows(&mut self, n: u64) -> u64 {
+        let mut remaining = n;
+        let mut span = 0u64;
+        while remaining > 0 {
+            let Some(len) = self.peek() else { break };
+            let take = remaining.min(u64::from(self.left_in_run));
+            span += take * u64::from(len);
+            self.left_in_run -= take as u32;
+            remaining -= take;
+        }
+        span
     }
 }
 
@@ -344,16 +360,41 @@ impl PageMap {
         self.row_extents_range(0, self.total_rows() as usize)
     }
 
-    /// [`row_extents`](Self::row_extents) for the window
-    /// `[skip, skip + take)` only.
-    ///
-    /// The walk still visits every length run and data record — that cost is
-    /// proportional to the *encoded* size, which is small — but it
-    /// materializes only the requested rows. Blobs where one record covers
-    /// millions of rows (SRR18959644's first READ_TYPE record spans
-    /// 22,227,968 spots) make the full expansion far more expensive than the
-    /// caller needs.
+    /// [`row_extents`](Self::row_extents) for the window `[skip, skip + take)`.
     pub fn row_extents_range(&self, skip: usize, take: usize) -> Result<Vec<RowExtent>> {
+        let mut out = Vec::with_capacity(take.min(self.total_rows() as usize));
+        self.for_each_row_extent(skip, take, |_, e| {
+            out.push(e);
+            Ok(())
+        })?;
+        Ok(out)
+    }
+
+    /// Total elements across every logical row, without allocating.
+    fn total_elems(&self) -> u64 {
+        self.lengths
+            .iter()
+            .zip(self.leng_runs.iter())
+            .map(|(&l, &r)| u64::from(l) * u64::from(r))
+            .sum()
+    }
+
+    /// Visit each logical row's extent in `[skip, skip + take)`, in row order.
+    ///
+    /// Costs one step per length run and data record crossed — proportional to
+    /// the *encoded* size, not the row count — plus one call per row visited.
+    /// The decode paths use this rather than [`row_extents`] so a blob costs no
+    /// per-row allocation; materializing one `RowExtent` per row for every blob
+    /// of every column was worth about 2x the decode CPU on archives whose page
+    /// maps are not identity. Blobs where a single record covers millions of
+    /// rows (SRR18959644's first READ_TYPE record spans 22,227,968 spots) are
+    /// read once per READ blob, so a per-row walk here would be quadratic.
+    fn for_each_row_extent(
+        &self,
+        skip: usize,
+        take: usize,
+        mut f: impl FnMut(usize, RowExtent) -> Result<()>,
+    ) -> Result<()> {
         let total_rows = self.total_rows();
         if total_rows > MAX_LOGICAL_ROWS_PER_BLOB {
             return Err(Error::Format(format!(
@@ -363,64 +404,61 @@ impl PageMap {
         let total = total_rows as usize;
         let end = skip.saturating_add(take).min(total);
         if skip >= end {
-            return Ok(Vec::new());
+            return Ok(());
         }
-        let mut out = Vec::with_capacity(end - skip);
 
-        // Walks the length runs in lockstep with the row cursor, so a row's
-        // element count is available without expanding `leng_runs`.
         let mut lens = LengthRunCursor::new(self);
 
         match &self.mapping {
             RowMapping::Identity => {
-                let mut offset = 0u32;
-                for row in 0..end {
-                    let Some(len) = lens.next() else { break };
-                    if row >= skip {
-                        out.push(RowExtent { offset, len });
-                    }
+                // Rows sit back to back, so the first requested row starts at
+                // however many elements every earlier row spans.
+                let mut offset = lens.skip_rows(skip as u64).min(u64::from(u32::MAX)) as u32;
+                for row in skip..end {
+                    let Some(len) = lens.peek() else { break };
+                    lens.skip_rows(1);
+                    f(row, RowExtent { offset, len })?;
                     offset = offset.saturating_add(len);
                 }
             }
             RowMapping::RepeatCounts(repeats) => {
-                // Each record covers `repeat` rows that share one stored copy;
-                // the cursor advances one row length per *record*.
+                // Each record covers `repeat` rows sharing one stored copy; the
+                // cursor advances one row length per *record*.
                 let mut offset = 0u32;
                 let mut row = 0usize;
                 for &repeat in repeats {
                     if row >= end {
                         break;
                     }
-                    let Some(len) = lens.next() else { break };
+                    let Some(len) = lens.peek() else { break };
                     let rows_here = repeat as usize;
-                    for r in row..(row + rows_here).min(end) {
-                        if r >= skip {
-                            out.push(RowExtent { offset, len });
-                        }
-                    }
-                    // The remaining rows of this record consume the same
-                    // length run without advancing the data cursor.
-                    for _ in 1..rows_here {
-                        lens.next();
+                    lens.skip_rows(u64::from(repeat));
+                    // Only the part of this record's span inside the window is
+                    // visited; a record covering millions of rows outside it
+                    // costs nothing.
+                    let lo = row.max(skip);
+                    let hi = (row + rows_here).min(end);
+                    for r in lo..hi {
+                        f(r, RowExtent { offset, len })?;
                     }
                     offset = offset.saturating_add(len);
                     row += rows_here;
                 }
             }
             RowMapping::RandomAccessOffsets(offsets) => {
-                for row in 0..end {
-                    let Some(len) = lens.next() else { break };
-                    if row >= skip {
-                        // A zero-length row can point anywhere; the writer
-                        // emits 0 for those (libs/vdb/blob.c:800-806).
-                        let offset = offsets.get(row).copied().unwrap_or(0);
-                        out.push(RowExtent { offset, len });
-                    }
+                lens.skip_rows(skip as u64);
+                for row in skip..end {
+                    let Some(len) = lens.peek() else { break };
+                    lens.skip_rows(1);
+                    // A zero-length row can point anywhere; the writer emits 0
+                    // for those (libs/vdb/blob.c:800-806).
+                    let offset = offsets.get(row).copied().unwrap_or(0);
+                    f(row, RowExtent { offset, len })?;
                 }
             }
         }
 
-        Ok(out)
+        Ok(())
     }
 
     /// Gather every logical row's data into one flat, row-ordered buffer.
@@ -440,47 +478,96 @@ impl PageMap {
                 "page_map: elem_bytes must be non-zero".into(),
             ));
         }
-        // Identity rows are already contiguous and in order.
-        if self.mapping.is_identity() {
-            return Ok(data.to_vec());
-        }
 
-        let extents = self.row_extents()?;
         let total_rows = self.total_rows() as usize;
-        if extents.len() != total_rows {
+        if total_rows > MAX_LOGICAL_ROWS_PER_BLOB as usize {
             return Err(Error::Format(format!(
-                "page_map: mapping covers {} of {total_rows} rows (inconsistent runs)",
-                extents.len(),
+                "page_map: logical row count {total_rows} exceeds {MAX_LOGICAL_ROWS_PER_BLOB} cap"
             )));
         }
-
-        let out_bytes: usize = extents
-            .iter()
-            .map(|e| e.len as usize * elem_bytes)
-            .try_fold(0usize, |acc, n| acc.checked_add(n))
+        let out_bytes = (self.total_elems() as usize)
+            .checked_mul(elem_bytes)
             .ok_or_else(|| Error::Format("page_map: expanded size overflows".into()))?;
-        let mut out = Vec::with_capacity(out_bytes);
 
-        for (row, extent) in extents.iter().enumerate() {
-            let start = (extent.offset as usize)
-                .checked_mul(elem_bytes)
-                .ok_or_else(|| Error::Format("page_map: row offset overflows".into()))?;
-            let len = (extent.len as usize)
-                .checked_mul(elem_bytes)
-                .ok_or_else(|| Error::Format("page_map: row length overflows".into()))?;
-            let end = start
-                .checked_add(len)
-                .ok_or_else(|| Error::Format("page_map: row extent overflows".into()))?;
-            if end > data.len() {
-                return Err(Error::Format(format!(
-                    "page_map: row {row} wants data[{start}..{end}] but data has {} bytes",
-                    data.len(),
-                )));
+        match &self.mapping {
+            // Rows are already contiguous and in row order.
+            RowMapping::Identity => Ok(data.to_vec()),
+
+            // The hot path: one stored copy backs `repeat` consecutive rows.
+            // Per-record rather than per-row so the slice arithmetic is hoisted
+            // out of the repeat loop — this function is ~two thirds of decode
+            // CPU on archives that use it, and doing the bounds math once per
+            // row instead of once per record costs about 2x.
+            RowMapping::RepeatCounts(repeats) => {
+                let mut out = Vec::with_capacity(out_bytes);
+                let mut lens = LengthRunCursor::new(self);
+                let mut cursor = 0usize;
+                let mut rows_seen = 0usize;
+                for &repeat in repeats {
+                    let Some(len) = lens.peek() else { break };
+                    lens.skip_rows(u64::from(repeat));
+                    let nbytes = (len as usize)
+                        .checked_mul(elem_bytes)
+                        .ok_or_else(|| Error::Format("page_map: row length overflows".into()))?;
+                    let end = cursor
+                        .checked_add(nbytes)
+                        .ok_or_else(|| Error::Format("page_map: record extent overflows".into()))?;
+                    if end > data.len() {
+                        return Err(Error::Format(format!(
+                            "page_map: record wants data[{cursor}..{end}] but data has {} bytes",
+                            data.len(),
+                        )));
+                    }
+                    let chunk = &data[cursor..end];
+                    for _ in 0..repeat {
+                        out.extend_from_slice(chunk);
+                    }
+                    cursor = end;
+                    rows_seen += repeat as usize;
+                }
+                if rows_seen != total_rows {
+                    return Err(Error::Format(format!(
+                        "page_map: mapping covers {rows_seen} of {total_rows} rows \
+                         (inconsistent runs)",
+                    )));
+                }
+                Ok(out)
             }
-            out.extend_from_slice(&data[start..end]);
-        }
 
-        Ok(out)
+            // Every row indexes its own slice out of a deduplicated pool, so
+            // there is nothing to hoist.
+            RowMapping::RandomAccessOffsets(offsets) => {
+                let mut out = Vec::with_capacity(out_bytes);
+                let mut lens = LengthRunCursor::new(self);
+                for row in 0..total_rows {
+                    let Some(len) = lens.peek() else { break };
+                    lens.skip_rows(1);
+                    let start = (offsets.get(row).copied().unwrap_or(0) as usize)
+                        .checked_mul(elem_bytes)
+                        .ok_or_else(|| Error::Format("page_map: row offset overflows".into()))?;
+                    let nbytes = (len as usize)
+                        .checked_mul(elem_bytes)
+                        .ok_or_else(|| Error::Format("page_map: row length overflows".into()))?;
+                    let end = start
+                        .checked_add(nbytes)
+                        .ok_or_else(|| Error::Format("page_map: row extent overflows".into()))?;
+                    if end > data.len() {
+                        return Err(Error::Format(format!(
+                            "page_map: row {row} wants data[{start}..{end}] but data has {} bytes",
+                            data.len(),
+                        )));
+                    }
+                    out.extend_from_slice(&data[start..end]);
+                }
+                if out.len() != out_bytes {
+                    return Err(Error::Format(format!(
+                        "page_map: expanded {} bytes, expected {out_bytes} (inconsistent runs)",
+                        out.len(),
+                    )));
+                }
+                Ok(out)
+            }
+        }
     }
 
     /// Expand a per-row-trimmed column (e.g. ALTREAD `trim<0,0>`) to a flat
@@ -499,25 +586,20 @@ impl PageMap {
         row_bytes: usize,
         side: TrimSide,
     ) -> Result<Vec<u8>> {
-        let row_lens = vec![row_bytes as u32; self.total_rows() as usize];
-        self.pad_trimmed_rows_variable(data, &row_lens, side)
+        self.pad_trimmed_rows(data, |_| row_bytes, side)
     }
 
     /// Variable-target version of [`pad_trimmed_rows_fixed`].
     ///
-    /// Used for columns whose logical rows have non-uniform true widths —
-    /// e.g. ALTREAD on Illumina runs after adapter trimming, where each
-    /// spot's base count matches that spot's `READ_LEN` sum. `row_lens` must
-    /// have `self.total_rows()` entries (one per logical row) and gives each
-    /// row's full pre-trim width; the page map's own `lengths` give the
-    /// trimmed width actually stored.
+    /// Used for columns whose logical rows have non-uniform true widths — e.g.
+    /// ALTREAD on Illumina runs after adapter trimming, where each spot's base
+    /// count matches that spot's `READ_LEN` sum. `row_lens` must have
+    /// `self.total_rows()` entries and gives each row's full pre-trim width;
+    /// the page map's own `lengths` give the trimmed width actually stored.
     ///
     /// Returns `sum(row_lens)` bytes — every logical row's padded bytes
     /// concatenated — so callers merging against another variable-row column
     /// can iterate byte for byte.
-    ///
-    /// Handles all three mappings, including the random-access one where
-    /// several rows share a stored copy.
     pub fn pad_trimmed_rows_variable(
         &self,
         data: &[u8],
@@ -531,21 +613,30 @@ impl PageMap {
                 row_lens.len(),
             )));
         }
+        self.pad_trimmed_rows(data, |row| row_lens[row] as usize, side)
+    }
 
-        let extents = self.row_extents()?;
-        if extents.len() != total_rows {
-            return Err(Error::Format(format!(
-                "page_map: mapping covers {} of {total_rows} rows (inconsistent runs)",
-                extents.len(),
-            )));
-        }
-
-        let total_bytes: usize = row_lens.iter().map(|&l| l as usize).sum();
+    /// Shared streaming implementation behind both `pad_trimmed_rows_*` entry
+    /// points. `target` gives each logical row's full pre-trim width; the
+    /// stored bytes are right-aligned inside it for [`TrimSide::Leading`] and
+    /// left-aligned for [`TrimSide::Trailing`], leaving the trimmed end zero.
+    ///
+    /// Handles all three mappings, including the random-access one where
+    /// several rows share one stored copy.
+    fn pad_trimmed_rows(
+        &self,
+        data: &[u8],
+        target: impl Fn(usize) -> usize,
+        side: TrimSide,
+    ) -> Result<Vec<u8>> {
+        let total_rows = self.total_rows() as usize;
+        let total_bytes: usize = (0..total_rows).map(&target).sum();
         let mut out = vec![0u8; total_bytes];
 
         let mut out_off = 0usize;
-        for (row, extent) in extents.iter().enumerate() {
-            let target = row_lens[row] as usize;
+        let mut rows_seen = 0usize;
+        self.for_each_row_extent(0, total_rows, |row, extent| {
+            let target = target(row);
             let stored = extent.len as usize;
             if stored > target {
                 return Err(Error::Format(format!(
@@ -575,6 +666,14 @@ impl PageMap {
                 }
             }
             out_off += target;
+            rows_seen += 1;
+            Ok(())
+        })?;
+
+        if rows_seen != total_rows {
+            return Err(Error::Format(format!(
+                "page_map: mapping covers {rows_seen} of {total_rows} rows (inconsistent runs)",
+            )));
         }
 
         Ok(out)

--- a/crates/sracha-vdb/src/blob_codecs.rs
+++ b/crates/sracha-vdb/src/blob_codecs.rs
@@ -59,10 +59,17 @@ pub fn decode_irzip_column(decoded: &blob::DecodedBlob<'_>) -> Result<Vec<u8>> {
     expand_via_page_map(decoded_ints, &decoded.page_map)
 }
 
-/// Expand decoded integer data via a page map's data_runs, if present.
+/// Expand decoded integer data to one entry per logical row via the page map.
 ///
 /// For columns like X, Y, and READ_LEN, the irzip/izip decoder produces
-/// unique data entries and the page map maps each row to its data entry.
+/// unique data entries and the page map says which entry each row uses.
+///
+/// Offsets in a random-access page map are *element* offsets: ncbi-vdb's
+/// `data_offset` is an `elem_count_t` indexed into the blob's element stream
+/// (`interfaces/kdb/page-map.h:77`), consumed by `PageMapIteratorDataOffset`
+/// and `KDataBufferSub`, both of which take element counts. Earlier revisions
+/// guessed between that and an "entry index" reading by testing which one fit
+/// the decoded buffer, which silently picked wrong whenever both fit.
 pub fn expand_via_page_map(
     decoded_ints: Vec<u8>,
     page_map: &Option<blob::PageMap>,
@@ -70,66 +77,10 @@ pub fn expand_via_page_map(
     let Some(pm) = page_map else {
         return Ok(decoded_ints);
     };
-    let elem_bytes = 4usize; // u32
-    let row_length = pm.lengths.first().copied().unwrap_or(1) as usize;
-    let entry_bytes = row_length * elem_bytes;
-
-    if !pm.data_runs.is_empty() && pm.data_runs.len() as u64 >= pm.total_rows() {
-        // Random-access variant: data_runs[i] picks the source for logical
-        // row i. Two offset-unit conventions coexist in practice:
-        //
-        // - entry-index (default): offset is the index of a row_length-wide
-        //   entry in the decoded buffer, so `start = offset * entry_bytes`.
-        // - u32-index (rare; e.g. DRR045255's READ_LEN blob with 1032 rows
-        //   where the decoded buffer holds a flat u32 stream): offset is
-        //   the index of a single u32, so `start = offset * elem_bytes` and
-        //   row_length consecutive u32s are consumed per row.
-        //
-        // We can't statically tell them apart — the page_map serialisation
-        // uses the same on-disk shape for both. Dispatch adaptively: if
-        // the max data_run fits the entry-index interpretation, use it;
-        // otherwise fall back to u32-index. Either way a dispatch that
-        // can't reconstruct row_count * entry_bytes of output is an error.
-        let max_offset = pm.data_runs.iter().max().copied().unwrap_or(0) as usize;
-        let entry_index_fits = max_offset * entry_bytes + entry_bytes <= decoded_ints.len();
-        let u32_index_fits =
-            row_length >= 2 && max_offset * elem_bytes + entry_bytes <= decoded_ints.len();
-        let stride = if entry_index_fits {
-            entry_bytes
-        } else if u32_index_fits {
-            elem_bytes
-        } else {
-            return Err(Error::Format(format!(
-                "page_map: max offset {max_offset} overflows decoded buffer \
-                 ({} bytes) under both entry-index (×{entry_bytes}) and u32-index \
-                 (×{elem_bytes}) interpretations",
-                decoded_ints.len(),
-            )));
-        };
-
-        let mut expanded = Vec::with_capacity(pm.data_runs.len() * entry_bytes);
-        for &offset in &pm.data_runs {
-            let start = offset as usize * stride;
-            let end = start + entry_bytes;
-            if end > decoded_ints.len() {
-                return Err(Error::Format(format!(
-                    "page_map: offset {offset} × {stride} + {entry_bytes} out of {} decoded bytes",
-                    decoded_ints.len(),
-                )));
-            }
-            expanded.extend_from_slice(&decoded_ints[start..end]);
-        }
-        Ok(expanded)
-    } else if !pm.data_runs.is_empty() {
-        // data_runs replicates physical records across rows. Records may be
-        // variable-length (array columns like READ_START on PacBio SMRT pack
-        // one NREADS-sized array per spot), so widths come from the page map's
-        // lengths/leng_runs rather than a single row_length. For uniform-length
-        // columns this reduces to the old fixed-width walk.
-        Ok(pm.expand_records_to_rows(&decoded_ints, elem_bytes)?)
-    } else {
-        Ok(decoded_ints)
+    if pm.mapping.is_identity() {
+        return Ok(decoded_ints);
     }
+    pm.expand_rows(&decoded_ints, 4)
 }
 
 /// Decode a zip_encoding data section.
@@ -256,7 +207,7 @@ pub fn decode_quality_encoding(decoded: &blob::DecodedBlob<'_>) -> Result<Vec<u8
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::blob::{DecodedBlob, PageMap};
+    use crate::blob::{DecodedBlob, PageMap, RowMapping};
     use std::borrow::Cow;
 
     /// Build a minimal v1 blob: header byte with rls=3 (implicit row_length=1),
@@ -331,12 +282,12 @@ mod tests {
     }
 
     #[test]
-    fn expand_via_page_map_empty_data_runs_passthrough() {
+    fn expand_via_page_map_identity_passthrough() {
         let pm = PageMap {
             data_recs: 1,
             lengths: vec![1],
             leng_runs: vec![1],
-            data_runs: vec![],
+            mapping: RowMapping::Identity,
         };
         let out = expand_via_page_map(vec![0xAA; 4], &Some(pm)).unwrap();
         assert_eq!(out, vec![0xAA; 4]);
@@ -344,13 +295,13 @@ mod tests {
 
     #[test]
     fn expand_via_page_map_per_row_expansion_uses_repeat_counts() {
-        // 2 records, each of row_length=1 u32. data_runs=[1,3] means the
+        // 2 records, each of row_length=1 u32. repeats=[1,3] means the
         // second record is replicated 3 times → 4 rows total × 4 bytes.
         let pm = PageMap {
             data_recs: 2,
             lengths: vec![1],
             leng_runs: vec![4],
-            data_runs: vec![1, 3],
+            mapping: RowMapping::RepeatCounts(vec![1, 3]),
         };
         let mut data = Vec::new();
         data.extend_from_slice(&1u32.to_le_bytes());
@@ -364,14 +315,14 @@ mod tests {
     }
 
     #[test]
-    fn expand_via_page_map_random_access_entry_index() {
-        // data_runs length >= total_rows triggers the random-access branch.
-        // row_length=1, entry_bytes=4. Offsets index into full entries.
+    fn expand_via_page_map_random_access_single_element_rows() {
+        // One u32 per row, so an element offset and an entry index coincide.
+        // Offsets are used verbatim and may reorder rows.
         let pm = PageMap {
             data_recs: 3,
             lengths: vec![1],
             leng_runs: vec![3],
-            data_runs: vec![0, 2, 1],
+            mapping: RowMapping::RandomAccessOffsets(vec![0, 2, 1]),
         };
         let mut data = Vec::new();
         data.extend_from_slice(&10u32.to_le_bytes());
@@ -384,21 +335,17 @@ mod tests {
     }
 
     #[test]
-    fn expand_via_page_map_random_access_u32_index_dispatch() {
-        // row_length=2: entry_bytes=8. If data_runs holds u32 indices (not
-        // entry indices), max_offset * 8 would overflow a small buffer — but
-        // max_offset * 4 fits. We verify the u32-index branch is picked and
-        // that row_length consecutive u32s flow out per logical row.
-        //
-        // Decoded buffer has 4 u32s; row_length=2 means each row consumes 2
-        // consecutive u32s. data_runs=[0, 2] means row 0 = u32s[0..2],
-        // row 1 = u32s[2..4]. With entry-index dispatch, offset 2 * 8 + 8 =
-        // 24 > 16 (overflow) → falls back to u32-index.
+    fn expand_via_page_map_random_access_multi_element_rows() {
+        // Two u32s per row. ncbi-vdb stores `data_offset` in elements, so
+        // offset 2 means "start at the third u32" — NOT "start at the third
+        // two-u32 entry". Earlier revisions guessed between those readings by
+        // testing which one fit the buffer; this shape is where the entry
+        // reading is wrong (it would run off the end at 2 * 8 + 8 = 24 > 16).
         let pm = PageMap {
             data_recs: 2,
             lengths: vec![2],
             leng_runs: vec![2],
-            data_runs: vec![0, 2],
+            mapping: RowMapping::RandomAccessOffsets(vec![0, 2]),
         };
         let mut data = Vec::new();
         for v in [100u32, 200, 300, 400] {
@@ -414,13 +361,12 @@ mod tests {
 
     #[test]
     fn expand_via_page_map_random_access_offset_overflow_errors() {
-        // row_length=1 so entry_bytes=4. Buffer has 2 u32s (8 bytes). Offset
-        // 5 overflows both dispatch modes.
+        // Buffer has 2 u32s (8 bytes); element offset 5 runs past the end.
         let pm = PageMap {
             data_recs: 3,
             lengths: vec![1],
             leng_runs: vec![3],
-            data_runs: vec![0, 1, 5],
+            mapping: RowMapping::RandomAccessOffsets(vec![0, 1, 5]),
         };
         let data = vec![0u8; 8];
         let err =
@@ -567,12 +513,9 @@ mod tests {
             prop_assert_eq!(out, data);
         }
 
-        /// In the per-row expansion branch (`data_runs.len() < total_rows`)
-        /// the output byte count is exactly `sum(data_runs) * elem_bytes`
-        /// for row_length=1 — the invariant `expand_data_runs_bytes`
-        /// enforces, exposed via `expand_via_page_map`. Values start at 2
-        /// so `sum(runs) > runs.len()` and we always hit the per-row branch
-        /// rather than the equal-length random-access branch.
+        /// Under repeat counts the output byte count is exactly
+        /// `sum(repeats) * elem_bytes` for row_length=1, and each record's
+        /// bytes appear once per row it covers.
         #[test]
         fn prop_expand_via_page_map_per_row_length_is_sum_of_runs(
             runs in proptest::collection::vec(2u32..4, 1..16)
@@ -583,7 +526,7 @@ mod tests {
                 data_recs: n as u64,
                 lengths: vec![1],
                 leng_runs: vec![total],
-                data_runs: runs.clone(),
+                mapping: RowMapping::RepeatCounts(runs.clone()),
             };
             // row_length=1 → each record is one u32 (4 bytes).
             let mut data = Vec::with_capacity(n * 4);
@@ -602,22 +545,21 @@ mod tests {
             }
         }
 
-        /// Random-access (entry-index) branch: for row_length=1, every
-        /// `data_runs[i]` picks one u32 entry, so output length always
-        /// equals `data_runs.len() * 4`.
+        /// Random access: for row_length=1 every offset picks one u32, so
+        /// the output length always equals `offsets.len() * 4` regardless of
+        /// how the offsets repeat or reorder.
         #[test]
-        fn prop_expand_via_page_map_random_access_entry_index_length(
+        fn prop_expand_via_page_map_random_access_length(
             entries in 1usize..16,
             refs in proptest::collection::vec(0u32..16, 1..32),
         ) {
             let max_ref = (entries - 1) as u32;
             let refs: Vec<u32> = refs.into_iter().map(|r| r % max_ref.max(1)).collect();
-            // For random-access dispatch, data_runs.len() must be >= total_rows.
             let pm = PageMap {
                 data_recs: refs.len() as u64,
                 lengths: vec![1],
                 leng_runs: vec![refs.len() as u32],
-                data_runs: refs.clone(),
+                mapping: RowMapping::RandomAccessOffsets(refs.clone()),
             };
             let mut data = Vec::with_capacity(entries * 4);
             for i in 0..entries {

--- a/crates/sracha-vdb/src/cache.rs
+++ b/crates/sracha-vdb/src/cache.rs
@@ -10,7 +10,7 @@
 
 use std::cell::RefCell;
 
-use crate::blob::{self, DecodedBlob, PageMap};
+use crate::blob::{self, DecodedBlob, PageMap, RowExtent};
 use crate::error::{Error, Result};
 use crate::kdb::ColumnReader;
 
@@ -42,34 +42,31 @@ pub(crate) struct DecodedColumnBlob {
     pub bytes: Vec<u8>,
     /// Present when the blob has a page map.
     pub page_map: Option<PageMap>,
-    /// `page_map.data_record_lengths()` cached once (empty if no page map).
-    /// Unit matches what the column's encoding stores: bits for
-    /// bit-packed rows, bytes for byte rows, elements for integer rows,
+    /// `page_map.row_extents()` cached once (empty if no page map): one
+    /// `(offset, len)` per logical row, resolved from whichever mapping the
+    /// page map carries. Units match what the column's encoding stores: bits
+    /// for bit-packed rows, bytes for byte rows, elements for integer rows,
     /// bases for 2na rows.
-    pub record_lens: Vec<u32>,
-    /// `record_prefix[i] = sum(record_lens[0..i]) as u64`, length = `record_lens.len() + 1`.
-    /// Lets row slicing be O(1) instead of the previous O(n²) `take(i).sum()`.
-    pub record_prefix: Vec<u64>,
-    /// Per-logical-row rec_idx (honouring `page_map.data_runs`). Empty
-    /// when the mapping is identity (no `data_runs`).
-    pub logical_to_rec: Vec<u32>,
+    pub extents: Vec<RowExtent>,
 }
 
 impl DecodedColumnBlob {
-    /// Map a blob-relative row offset to the rec_idx of its unique value.
-    pub fn rec_idx(&self, logical_offset: usize) -> Result<usize> {
-        if self.logical_to_rec.is_empty() {
-            return Ok(logical_offset);
+    /// Where a blob-relative row's data sits in the decoded payload.
+    ///
+    /// With no page map every row is one element wide at its own index.
+    pub fn extent(&self, logical_offset: usize) -> Result<RowExtent> {
+        if self.extents.is_empty() {
+            return Ok(RowExtent {
+                offset: logical_offset as u32,
+                len: 1,
+            });
         }
-        self.logical_to_rec
-            .get(logical_offset)
-            .map(|&v| v as usize)
-            .ok_or_else(|| {
-                Error::Format(format!(
-                    "logical offset {logical_offset} out of bounds ({} rows)",
-                    self.logical_to_rec.len()
-                ))
-            })
+        self.extents.get(logical_offset).copied().ok_or_else(|| {
+            Error::Format(format!(
+                "logical offset {logical_offset} out of bounds ({} rows)",
+                self.extents.len()
+            ))
+        })
     }
 }
 
@@ -130,14 +127,9 @@ impl CachedColumn {
             ColumnKind::TwoNa => decoded.data.to_vec(),
         };
         let page_map = decoded.page_map;
-        let record_lens: Vec<u32> = page_map
+        let extents = page_map
             .as_ref()
-            .map(|pm| pm.data_record_lengths())
-            .unwrap_or_default();
-        let record_prefix = compute_prefix(&record_lens);
-        let logical_to_rec = page_map
-            .as_ref()
-            .map(compute_logical_to_rec)
+            .map(|pm| pm.row_extents())
             .transpose()?
             .unwrap_or_default();
 
@@ -145,9 +137,7 @@ impl CachedColumn {
             start_id,
             bytes,
             page_map,
-            record_lens,
-            record_prefix,
-            logical_to_rec,
+            extents,
         });
 
         let borrow = self.cache.borrow();
@@ -166,9 +156,9 @@ impl CachedColumn {
     pub fn read_bool_row(&self, row_id: i64) -> Result<Vec<u8>> {
         debug_assert!(matches!(self.kind, ColumnKind::Zip));
         self.with_blob(row_id, |blob, logical_offset| {
-            let rec_idx = blob.rec_idx(logical_offset)?;
-            let start_bits = blob.record_prefix[rec_idx] as usize;
-            let len_bits = blob.record_lens[rec_idx] as usize;
+            let extent = blob.extent(logical_offset)?;
+            let start_bits = extent.offset as usize;
+            let len_bits = extent.len as usize;
             let mut out = Vec::with_capacity(len_bits);
             for i in 0..len_bits {
                 let bit_idx = start_bits + i;
@@ -187,9 +177,9 @@ impl CachedColumn {
     pub fn read_byte_row(&self, row_id: i64) -> Result<Vec<u8>> {
         debug_assert!(matches!(self.kind, ColumnKind::Zip));
         self.with_blob(row_id, |blob, logical_offset| {
-            let rec_idx = blob.rec_idx(logical_offset)?;
-            let start = blob.record_prefix[rec_idx] as usize;
-            let len = blob.record_lens[rec_idx] as usize;
+            let extent = blob.extent(logical_offset)?;
+            let start = extent.offset as usize;
+            let len = extent.len as usize;
             let end = start + len;
             if end > blob.bytes.len() {
                 return Err(Error::Format(format!(
@@ -205,9 +195,9 @@ impl CachedColumn {
     pub fn read_i32_row(&self, row_id: i64) -> Result<Vec<i32>> {
         debug_assert!(matches!(self.kind, ColumnKind::Irzip { elem_bits: 32 }));
         self.with_blob(row_id, |blob, logical_offset| {
-            let rec_idx = blob.rec_idx(logical_offset)?;
-            let start = (blob.record_prefix[rec_idx] as usize) * 4;
-            let len_elems = blob.record_lens[rec_idx] as usize;
+            let extent = blob.extent(logical_offset)?;
+            let start = (extent.offset as usize) * 4;
+            let len_elems = extent.len as usize;
             let end = start + len_elems * 4;
             if end > blob.bytes.len() {
                 return Err(Error::Format(format!(
@@ -226,9 +216,9 @@ impl CachedColumn {
     pub fn read_u32_row(&self, row_id: i64) -> Result<Vec<u32>> {
         debug_assert!(matches!(self.kind, ColumnKind::Irzip { elem_bits: 32 }));
         self.with_blob(row_id, |blob, logical_offset| {
-            let rec_idx = blob.rec_idx(logical_offset)?;
-            let start = (blob.record_prefix[rec_idx] as usize) * 4;
-            let len_elems = blob.record_lens[rec_idx] as usize;
+            let extent = blob.extent(logical_offset)?;
+            let start = (extent.offset as usize) * 4;
+            let len_elems = extent.len as usize;
             let end = start + len_elems * 4;
             if end > blob.bytes.len() {
                 return Err(Error::Format(format!(
@@ -247,9 +237,9 @@ impl CachedColumn {
     pub fn read_i64_row(&self, row_id: i64) -> Result<Vec<i64>> {
         debug_assert!(matches!(self.kind, ColumnKind::Irzip { elem_bits: 64 }));
         self.with_blob(row_id, |blob, logical_offset| {
-            let rec_idx = blob.rec_idx(logical_offset)?;
-            let start = (blob.record_prefix[rec_idx] as usize) * 8;
-            let len_elems = blob.record_lens[rec_idx] as usize;
+            let extent = blob.extent(logical_offset)?;
+            let start = (extent.offset as usize) * 8;
+            let len_elems = extent.len as usize;
             let end = start + len_elems * 8;
             if end > blob.bytes.len() {
                 return Err(Error::Format(format!(
@@ -266,7 +256,7 @@ impl CachedColumn {
 
     /// Scalar fixed-width integer with optional `data_runs` RLE (used by
     /// `GLOBAL_REF_START`, `REF_LEN`, `REFERENCE.SEQ_LEN`). The blob
-    /// payload holds only the unique values; `rec_idx(offset)` resolves
+    /// payload holds only the unique values; the row's extent resolves
     /// which one this row maps to.
     pub fn read_scalar_i64(&self, row_id: i64) -> Result<i64> {
         self.read_scalar_int(row_id, 64)
@@ -282,9 +272,9 @@ impl CachedColumn {
             ColumnKind::Irzip { elem_bits: eb } if eb == elem_bits
         ));
         self.with_blob(row_id, |blob, logical_offset| {
-            let rec_idx = blob.rec_idx(logical_offset)?;
+            let extent = blob.extent(logical_offset)?;
             let bytes_per = (elem_bits / 8) as usize;
-            let byte_off = rec_idx * bytes_per;
+            let byte_off = extent.offset as usize * bytes_per;
             if byte_off + bytes_per > blob.bytes.len() {
                 return Err(Error::Format(format!(
                     "scalar row {row_id}: byte offset {byte_off} past decoded {}",
@@ -323,13 +313,13 @@ impl CachedColumn {
             let pm = blob.page_map.as_ref().ok_or_else(|| {
                 Error::Format("2na column: page_map required for record boundaries".into())
             })?;
-            let _ = pm; // presence-only check; record_lens already cached.
-            let rec_idx = blob.rec_idx(logical_offset)?;
-            let len_bases = blob.record_lens[rec_idx] as usize;
+            let _ = pm; // presence-only check; extents already cached.
+            let extent = blob.extent(logical_offset)?;
+            let len_bases = extent.len as usize;
             if len_bases == 0 {
                 return Ok(Vec::new());
             }
-            let start_bits = (blob.record_prefix[rec_idx] as usize) * 2;
+            let start_bits = (extent.offset as usize) * 2;
 
             // 2na → 4na nibble lookup. Bases are MSB-first within each
             // byte (verified by cross-check against vdb-dump on
@@ -362,50 +352,6 @@ impl ColumnKind {
             ColumnKind::TwoNa => 2,
         }
     }
-}
-
-fn compute_prefix(record_lens: &[u32]) -> Vec<u64> {
-    let mut prefix = Vec::with_capacity(record_lens.len() + 1);
-    let mut acc: u64 = 0;
-    prefix.push(0);
-    for &l in record_lens {
-        acc += u64::from(l);
-        prefix.push(acc);
-    }
-    prefix
-}
-
-/// Maximum logical rows per blob — reject crafted page maps whose
-/// `leng_runs` sum to more than this. Real SRA blobs hold well under this
-/// (a few million rows is typical, hundreds of millions is the high end).
-const MAX_LOGICAL_ROWS_PER_BLOB: u64 = 1_000_000_000;
-
-fn compute_logical_to_rec(pm: &PageMap) -> Result<Vec<u32>> {
-    if pm.data_runs.is_empty() {
-        return Ok(Vec::new());
-    }
-    let total = pm.total_rows();
-    // Random-access variant: data_runs[i] is the rec_idx for logical row i.
-    if (pm.data_runs.len() as u64) >= total {
-        return Ok(pm.data_runs.clone());
-    }
-    // Run-length variant: data_runs[i] is the repeat count for rec_idx i.
-    //
-    // `total` is the sum of `pm.leng_runs` (parsed from idx2/page-map bytes).
-    // A crafted page map can make this arbitrarily large; reject before
-    // allocating.
-    if total > MAX_LOGICAL_ROWS_PER_BLOB {
-        return Err(Error::Format(format!(
-            "page map: logical row count {total} exceeds {MAX_LOGICAL_ROWS_PER_BLOB} cap"
-        )));
-    }
-    let mut out = Vec::with_capacity(total as usize);
-    for (i, &repeat) in pm.data_runs.iter().enumerate() {
-        for _ in 0..repeat {
-            out.push(i as u32);
-        }
-    }
-    Ok(out)
 }
 
 fn decode_bytes_payload(decoded: &DecodedBlob<'_>) -> Result<Vec<u8>> {
@@ -473,81 +419,109 @@ fn decode_integer_bytes(decoded: &DecodedBlob<'_>, elem_bits: u32) -> Result<Vec
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::blob::PageMap;
+    use crate::blob::{PageMap, RowMapping};
 
-    fn pm(data_runs: Vec<u32>, lengths: Vec<u32>, leng_runs: Vec<u32>) -> PageMap {
+    fn pm(mapping: RowMapping, lengths: Vec<u32>, leng_runs: Vec<u32>) -> PageMap {
+        let data_recs = match &mapping {
+            RowMapping::RepeatCounts(v) => v.len() as u64,
+            _ => leng_runs.iter().map(|&r| u64::from(r)).sum(),
+        };
         PageMap {
-            data_recs: data_runs.len() as u64,
+            data_recs,
             lengths,
             leng_runs,
-            data_runs,
+            mapping,
         }
     }
 
+    /// Identity: rows sit back to back, each one element wide.
     #[test]
-    fn prefix_sum_empty() {
-        let p = compute_prefix(&[]);
-        assert_eq!(p, vec![0]);
+    fn extents_identity_are_contiguous() {
+        let extents = pm(RowMapping::Identity, vec![1], vec![4])
+            .row_extents()
+            .unwrap();
+        let offsets: Vec<u32> = extents.iter().map(|e| e.offset).collect();
+        assert_eq!(offsets, vec![0, 1, 2, 3]);
+        assert!(extents.iter().all(|e| e.len == 1));
     }
 
+    /// Repeat counts: [3, 2, 4] means rows 0..3 share record 0, rows 3..5
+    /// share record 1, rows 5..9 share record 2 — so the data cursor advances
+    /// once per record, not once per row.
     #[test]
-    fn prefix_sum_basic() {
-        let p = compute_prefix(&[3, 5, 2]);
-        assert_eq!(p, vec![0, 3, 8, 10]);
+    fn extents_repeat_counts_share_offsets() {
+        let extents = pm(RowMapping::RepeatCounts(vec![3, 2, 4]), vec![1], vec![9])
+            .row_extents()
+            .unwrap();
+        let offsets: Vec<u32> = extents.iter().map(|e| e.offset).collect();
+        assert_eq!(offsets, vec![0, 0, 0, 1, 1, 2, 2, 2, 2]);
     }
 
+    /// Random access: the stored value IS the row's element offset. These are
+    /// not record indices — they may repeat and may decrease.
     #[test]
-    fn logical_to_rec_empty_is_identity() {
-        let map = compute_logical_to_rec(&pm(vec![], vec![1], vec![1])).unwrap();
-        assert!(
-            map.is_empty(),
-            "no data_runs → identity mapping (empty vec)"
+    fn extents_random_access_use_offsets_verbatim() {
+        let offs = vec![2, 0, 1, 3];
+        let extents = pm(
+            RowMapping::RandomAccessOffsets(offs.clone()),
+            vec![1],
+            vec![4],
+        )
+        .row_extents()
+        .unwrap();
+        assert_eq!(
+            extents.iter().map(|e| e.offset).collect::<Vec<_>>(),
+            offs,
+            "random-access offsets must pass through untouched"
+        );
+    }
+
+    /// A row wider than one element scales the offset by the row length only
+    /// through `lengths`, never by multiplying the stored offset.
+    #[test]
+    fn extents_random_access_multi_element_rows() {
+        let extents = pm(
+            RowMapping::RandomAccessOffsets(vec![0, 4, 0]),
+            vec![2],
+            vec![3],
+        )
+        .row_extents()
+        .unwrap();
+        assert_eq!(
+            extents
+                .iter()
+                .map(|e| (e.offset, e.len))
+                .collect::<Vec<_>>(),
+            vec![(0, 2), (4, 2), (0, 2)]
         );
     }
 
     #[test]
-    fn logical_to_rec_run_length() {
-        // data_runs = [3, 2, 4] → rows 0..3 → rec 0, 3..5 → rec 1, 5..9 → rec 2.
-        let map = compute_logical_to_rec(&pm(vec![3, 2, 4], vec![1], vec![9])).unwrap();
-        assert_eq!(map, vec![0, 0, 0, 1, 1, 2, 2, 2, 2]);
-    }
-
-    #[test]
-    fn logical_to_rec_random_access() {
-        // data_runs has one entry per logical row → treat as rec_idx lookup.
-        // total_rows (leng_runs sum) = 4; data_runs.len()=4 → random-access.
-        let dr = vec![2, 0, 1, 3];
-        let map = compute_logical_to_rec(&pm(dr.clone(), vec![1], vec![4])).unwrap();
-        assert_eq!(map, dr);
-    }
-
-    #[test]
-    fn decoded_rec_idx_identity() {
+    fn decoded_extent_without_page_map_is_identity() {
         let blob = DecodedColumnBlob {
             start_id: 0,
             bytes: Vec::new(),
             page_map: None,
-            record_lens: Vec::new(),
-            record_prefix: vec![0],
-            logical_to_rec: Vec::new(),
+            extents: Vec::new(),
         };
-        assert_eq!(blob.rec_idx(0).unwrap(), 0);
-        assert_eq!(blob.rec_idx(42).unwrap(), 42);
+        assert_eq!(blob.extent(0).unwrap(), RowExtent { offset: 0, len: 1 });
+        assert_eq!(blob.extent(42).unwrap(), RowExtent { offset: 42, len: 1 });
     }
 
     #[test]
-    fn decoded_rec_idx_lookup() {
+    fn decoded_extent_lookup_and_bounds() {
         let blob = DecodedColumnBlob {
             start_id: 0,
             bytes: Vec::new(),
             page_map: None,
-            record_lens: Vec::new(),
-            record_prefix: vec![0],
-            logical_to_rec: vec![0, 0, 1, 1, 2],
+            extents: vec![
+                RowExtent { offset: 0, len: 3 },
+                RowExtent { offset: 0, len: 3 },
+                RowExtent { offset: 3, len: 3 },
+            ],
         };
-        assert_eq!(blob.rec_idx(0).unwrap(), 0);
-        assert_eq!(blob.rec_idx(2).unwrap(), 1);
-        assert_eq!(blob.rec_idx(4).unwrap(), 2);
-        assert!(blob.rec_idx(5).is_err());
+        assert_eq!(blob.extent(0).unwrap(), RowExtent { offset: 0, len: 3 });
+        assert_eq!(blob.extent(2).unwrap(), RowExtent { offset: 3, len: 3 });
+        assert!(blob.extent(3).is_err());
     }
 }

--- a/crates/sracha-vdb/src/dump.rs
+++ b/crates/sracha-vdb/src/dump.rs
@@ -357,7 +357,11 @@ fn materialize_dna2na(decoded: &DecodedBlob<'_>, row_count: u64) -> Result<(Vec<
     let packed = decode_2na_payload(decoded, expected_bases)?;
     let actual_bases = elem_count(decoded, &packed, 2);
     let bases = unpack_2na(&packed, actual_bases);
-    split_by_rows(decoded, bases, row_count, 1)
+    // Deduplicated blobs store one copy per data record, so the unpacked
+    // bases have to be expanded to one run per logical row before they can be
+    // sliced against the (per-row) split plan.
+    let bases = expand_rows_if_needed(decoded, bases, 1)?;
+    split_by_rows_already_expanded(decoded, bases, row_count, 1)
 }
 
 /// Obtain the packed 2na bytes for a READ blob.
@@ -389,6 +393,22 @@ fn materialize_dna4na_bin(
     let raw = decode_zip_encoding(decoded)?;
     let offsets = split_offsets(decoded, row_count, 1)?;
     let expected = offsets.last().copied().unwrap_or(0);
+    // 4na:packed can't be expanded before unpacking, so a deduplicated blob
+    // is only handled in its (far more common) one-byte-per-base form.
+    if !mapping_is_identity(decoded) {
+        let expanded = expand_rows_if_needed(decoded, raw, 1)?;
+        if expanded.len() == expected {
+            let out: Vec<u8> = expanded
+                .iter()
+                .map(|b| decode_4na_nibble(b & 0x0F))
+                .collect();
+            return Ok((out, offsets));
+        }
+        return Err(Error::Format(format!(
+            "dump: ALTREAD payload expands to {} bytes, expected {expected} (4na:bin)",
+            expanded.len(),
+        )));
+    }
     if raw.len() == expected {
         let out: Vec<u8> = raw.iter().map(|b| decode_4na_nibble(b & 0x0F)).collect();
         return Ok((out, offsets));
@@ -413,26 +433,20 @@ fn decode_4na_nibble(n: u8) -> u8 {
 fn materialize_quality(decoded: &DecodedBlob<'_>, row_count: u64) -> Result<(Vec<u8>, Vec<usize>)> {
     let raw = decode_quality_encoding(decoded)?;
     let ascii = phred_to_ascii(&raw);
-    split_by_rows(decoded, ascii, row_count, 1)
+    // Rows deduplicated at write time are stored once; expand before slicing.
+    let ascii = expand_rows_if_needed(decoded, ascii, 1)?;
+    split_by_rows_already_expanded(decoded, ascii, row_count, 1)
 }
 
 fn materialize_ascii(decoded: &DecodedBlob<'_>, row_count: u64) -> Result<(Vec<u8>, Vec<usize>)> {
     let raw = decode_zip_encoding(decoded)?;
-    let raw = if let Some(pm) = decoded.page_map.as_ref() {
-        if pm.data_runs.is_empty() {
-            raw
-        } else {
-            pm.expand_variable_data_runs(&raw)?
-        }
-    } else {
-        raw
-    };
+    let raw = expand_rows_if_needed(decoded, raw, 1)?;
     split_by_rows_already_expanded(decoded, raw, row_count, 1)
 }
 
 fn materialize_u32(decoded: &DecodedBlob<'_>, row_count: u64) -> Result<(Vec<u8>, Vec<usize>)> {
     let raw = decode_irzip_column(decoded)?;
-    // `decode_irzip_column` already runs the page_map data_runs expansion,
+    // `decode_irzip_column` already runs the page_map row expansion,
     // so `raw` is flat row bytes at `entry_bytes = row_length * 4`.
     split_by_rows_already_expanded(decoded, raw, row_count, 4)
 }
@@ -553,19 +567,36 @@ fn expand_leng_runs(pm: &PageMap) -> Vec<u32> {
 }
 
 /// For fixed-size element columns (u32, u8), replicate physical records to
-/// per-row data via the page map's data_runs (honouring variable per-record
+/// per-row data via the page map's mapping (honouring variable per-record
 /// lengths) — otherwise return as-is.
 fn expand_runs_if_any(
     decoded: &DecodedBlob<'_>,
     data: Vec<u8>,
     elem_bytes: usize,
 ) -> Result<Vec<u8>> {
-    if let Some(pm) = decoded.page_map.as_ref()
-        && !pm.data_runs.is_empty()
-    {
-        return pm.expand_records_to_rows(&data, elem_bytes);
+    expand_rows_if_needed(decoded, data, elem_bytes)
+}
+
+/// True when every data record covers exactly one logical row, so the decoded
+/// payload is already in row order.
+fn mapping_is_identity(decoded: &DecodedBlob<'_>) -> bool {
+    decoded
+        .page_map
+        .as_ref()
+        .is_none_or(|pm| pm.mapping.is_identity())
+}
+
+/// Expand a decoded payload from one entry per data record to one per logical
+/// row, honouring whichever mapping the page map carries.
+fn expand_rows_if_needed(
+    decoded: &DecodedBlob<'_>,
+    data: Vec<u8>,
+    elem_bytes: usize,
+) -> Result<Vec<u8>> {
+    match decoded.page_map.as_ref() {
+        Some(pm) if !pm.mapping.is_identity() => pm.expand_rows(&data, elem_bytes),
+        _ => Ok(data),
     }
-    Ok(data)
 }
 
 /// After elements have been unpacked/expanded to one ASCII byte per elem
@@ -589,7 +620,7 @@ fn split_by_rows(
 }
 
 /// Like [`split_by_rows`] but for byte streams that already include
-/// data_runs expansion (e.g. `decode_irzip_column` result).
+/// row expansion (e.g. `decode_irzip_column` result).
 fn split_by_rows_already_expanded(
     decoded: &DecodedBlob<'_>,
     data: Vec<u8>,
@@ -916,7 +947,7 @@ mod tests {
             data_recs: 5,
             lengths: vec![0, 8, 0],
             leng_runs: vec![2, 1, 2],
-            data_runs: vec![],
+            mapping: crate::blob::RowMapping::Identity,
         };
         let data = vec![0x1b, 0xe4];
         let blob = DecodedBlob {

--- a/validation/corpus.sh
+++ b/validation/corpus.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Select accessions from the distilled corpus (validation/corpus.tsv).
+#
+# The corpus is one row per archive worth re-checking after a decoder change:
+# every entry either broke something once or is the only cover for a platform,
+# layout, read length, or archive shape. Prefer it over a fresh random sample
+# when you want a regression check rather than a survey.
+#
+# Usage:
+#   bash validation/corpus.sh                    # core tier, one accession per line
+#   bash validation/corpus.sh --tier all         # include the large extended tier
+#   bash validation/corpus.sh --shape csra       # only reference-compressed archives
+#   bash validation/corpus.sh --platform PACBIO_SMRT
+#   bash validation/corpus.sh --why              # accession + what it covers
+#   bash validation/corpus.sh --summary          # coverage counts and download size
+#
+# Typical A/B run:
+#   bash validation/corpus.sh > /tmp/core.txt
+#   bash validation/ab_corpus.sh --sbatch \
+#       --baseline OLD/sracha --candidate NEW/sracha -a /tmp/core.txt
+
+set -uo pipefail
+
+TSV="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/corpus.tsv"
+[[ -f "$TSV" ]] || { echo "missing $TSV" >&2; exit 1; }
+
+TIER="core"
+SHAPE=""
+PLATFORM=""
+MODE="list"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tier) TIER="$2"; shift 2 ;;
+        --shape) SHAPE="$2"; shift 2 ;;
+        --platform) PLATFORM="$2"; shift 2 ;;
+        --why) MODE="why"; shift ;;
+        --summary) MODE="summary"; shift ;;
+        -h|--help) sed -n '3,25p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+awk -F'\t' -v tier="$TIER" -v shape="$SHAPE" -v plat="$PLATFORM" -v mode="$MODE" '
+    /^#/ || $1 == "accession" { next }
+    tier != "all" && $2 != tier { next }
+    shape != "" && $3 != shape { next }
+    plat  != "" && $4 != plat  { next }
+    {
+        rows++
+        n_shape[$3]++; n_plat[$4]++; n_layout[$6]++
+        bytes += $10
+        if (mode == "list") print $1
+        else if (mode == "why") printf "%-13s %s\n", $1, $11
+    }
+    END {
+        if (mode != "summary") exit
+        printf "accessions   : %d\n", rows
+        printf "download     : %.1f GB\n", bytes / 1e9
+        printf "shapes       :"; for (k in n_shape)  printf " %s=%d", k, n_shape[k];  printf "\n"
+        printf "platforms    :"; for (k in n_plat)   printf " %s=%d", k, n_plat[k];   printf "\n"
+        printf "layouts      :"; for (k in n_layout) printf " %s=%d", k, n_layout[k]; printf "\n"
+    }
+' "$TSV"

--- a/validation/corpus.tsv
+++ b/validation/corpus.tsv
@@ -9,6 +9,12 @@
 # shape  table    = flat KAR table   db = database with a SEQUENCE table
 #        csra     = reference-compressed, has PRIMARY_ALIGNMENT + REFERENCE
 #
+# Not every row exercises the FASTQ decoder. `sracha fastq` refuses cSRA and
+# 454 outright, so those rows check that both binaries refuse identically
+# (verdict REJECT_CSRA / REJECT_PLATFORM in ab_corpus.sh); reach their decode
+# paths with `sracha vdb dump` instead. Treating a REJECT as decode coverage
+# is the mistake this note exists to prevent.
+#
 # Usage:
 #   awk -F'\t' '$2=="core" && !/^#/ {print $1}' validation/corpus.tsv > core.txt
 #   bash validation/ab_corpus.sh --sbatch --baseline OLD --candidate NEW -a core.txt
@@ -37,8 +43,8 @@ DRR019046	core	table	ILLUMINA	Illumina HiSeq 2000	SINGLE	miRNA-Seq	17171857	51	5
 DRR023226	core	db	ILLUMINA	Illumina Genome Analyzer IIx	SINGLE	RNA-Seq	8563991	86	414662256	READ and QUALITY columns with mismatched blob counts
 DRR004435	core	table	ILLUMINA	Illumina Genome Analyzer IIx	SINGLE	OTHER	36805747	34	728056928	2 bp adapter ahead of a 34 bp read; routing to _2 with no _1
 DRR050206	core	table	ILLUMINA	Illumina HiSeq 2000	SINGLE	RNA-Seq	3043495	49	102425783	content-equal but md5-divergent output
-SRR341578	core	csra	ILLUMINA	Illumina HiSeq 2000	PAIRED	WGS	7549706	202	932308473	aligned cSRA: PRIMARY_ALIGNMENT + REFERENCE + SEQUENCE
-SRR000001	core	table	LS454	454 GS FLX	PAIRED	WGS	470985	248	312527083	454 pyrosequencing, flat table
+SRR341578	core	csra	ILLUMINA	Illumina HiSeq 2000	PAIRED	WGS	7549706	202	932308473	aligned cSRA: PRIMARY_ALIGNMENT + REFERENCE + SEQUENCE; fastq refuses it, use vdb dump
+SRR000001	core	table	LS454	454 GS FLX	PAIRED	WGS	470985	248	312527083	454 pyrosequencing, flat table; fastq refuses the platform, use vdb dump
 SRR2584863	core	table	ILLUMINA	Illumina HiSeq 2500	PAIRED	WGS	1553259	300	302057279	HiSeq paired flat table
 SRR28588231	core	db	ILLUMINA	Illumina MiSeq	PAIRED	AMPLICON	66220	602	23395841	MiSeq 2x301 amplicon
 SRR10358300	core	db	ILLUMINA	Illumina MiSeq	PAIRED	AMPLICON	62983	600	24227855	align schema, unmapped; MiSeq amplicon

--- a/validation/corpus.tsv
+++ b/validation/corpus.tsv
@@ -1,0 +1,52 @@
+# Distilled validation corpus for sracha.
+#
+# One row per archive worth re-checking after any decoder change. Every entry
+# is here because it broke something or because it is the only cover for a
+# platform, layout, read length, or archive shape.
+#
+# tier   core     = run by default; the whole tier is a few hundred GB of decode
+#        extended = large archives, run when the change touches their path
+# shape  table    = flat KAR table   db = database with a SEQUENCE table
+#        csra     = reference-compressed, has PRIMARY_ALIGNMENT + REFERENCE
+#
+# Usage:
+#   awk -F'\t' '$2=="core" && !/^#/ {print $1}' validation/corpus.tsv > core.txt
+#   bash validation/ab_corpus.sh --sbatch --baseline OLD --candidate NEW -a core.txt
+#
+accession	tier	shape	platform	model	layout	strategy	reads	avg_read_len	size_bytes	covers
+SRR35917722	extended	db	ILLUMINA	Illumina NovaSeq X	PAIRED	RNA-Seq	695578709	302	32160632119	version-2 random-access page map; rows share a deduplicated vocabulary (#101)
+DRR028486	core	table	ILLUMINA	Illumina HiSeq 2500	PAIRED	RNA-Seq	1759140	302	372039045	ALTREAD N-mask dropped when the random-access shape was guessed (#101)
+SRR33907345	core	db	ILLUMINA	Illumina MiSeq	PAIRED	WGS	305571	488	77521894	variable-length data_runs in a READ blob; dropped a spot when unexpanded (#22)
+DRR045255	core	db	ILLUMINA	Illumina MiSeq	PAIRED	RNA-Seq	3745800	147	245875647	random-access READ_LEN offsets; cross-batch spot numbering past 1,048,576
+DRR040793	core	table	ILLUMINA	Illumina HiSeq 2000	PAIRED	OTHER	870924	200	122476723	NAME_FMT per-row template overrides; fine-grained tile interleave
+DRR024182	core	table	ILLUMINA	Illumina HiSeq 2500	PAIRED	WGS	4806031	200	567683965	variant-2 random-access ALTREAD; 6481 rows share offset 0
+DRR035866	core	table	ILLUMINA	Illumina MiSeq	PAIRED	OTHER	208643	502	66338519	ALTREAD blobs twice the size of READ blobs (2:1 row pairing)
+DRR006688	core	table	ILLUMINA	Illumina Genome Analyzer IIx	SINGLE	RNA-Seq	8843478	76	430438287	ALTREAD N-mask vs quality-based masking (FAIL_SEQ divergence)
+SRR18959644	core	db	BGISEQ	BGISEQ-500	PAIRED	RNA-Seq	44457242	150	4168694011	one READ_TYPE record spans 22,227,968 spots; windowed expansion only
+DRR001816	core	table	ILLUMINA	Illumina Genome Analyzer IIx	SINGLE	RNA-Seq	35949084	36	734255205	izip-encoded quality from the srf-load era, not deflate
+ERR15141550	core	db	OXFORD_NANOPORE	PromethION	SINGLE	WGS	553585	2847	1428803617	v2 iunzip blob with osize == data.len(); raw passthrough (#20)
+SRR14724462	core	db	ILLUMINA	Illumina NovaSeq 6000	PAIRED	WXS	41135235	302	4057553143	bam-loaded but fully unmapped: align schema with no PRIMARY_ALIGNMENT
+DRR035195	core	db	ILLUMINA	Illumina MiSeq	PAIRED	WGS	598383	486	0	delite-processed SRA-Lite; synthesized quality must match fasterq-dump
+DRR032988	core	db	PACBIO_SMRT	PacBio RS	SINGLE	WGS	326964	4185	5306051249	PacBio blob whose data runs align exactly with its length runs
+DRR035183	core	db	ILLUMINA	Illumina MiSeq	PAIRED	WGS	644410	428	172248773	md5 parity case that regressed twice
+SRR36401016	core	db	ILLUMINA	Illumina NovaSeq 6000	PAIRED	WGS	48639849	300	8510845882	compressor drained only 19 of N blocks before the writer ran
+SRR15000000	core	db	ILLUMINA	Illumina NovaSeq 6000	PAIRED	AMPLICON	4006555	96	126844353	newer-writer archive layout
+SRR9827735	core	db	ILLUMINA	NextSeq 500	PAIRED	RNA-Seq	23039135	55	1275408432	10x 26/55/8 read layout mis-split into 44/45
+SRR38107137	core	db	PACBIO_SMRT	Sequel	SINGLE	FL-cDNA	50511	2479	42332890	PacBio sequence and quality mismatches vs fasterq-dump
+DRR019046	core	table	ILLUMINA	Illumina HiSeq 2000	SINGLE	miRNA-Seq	17171857	51	579182626	skey name reconstruction on a flat table; adjacent-template prefix bytes
+DRR023226	core	db	ILLUMINA	Illumina Genome Analyzer IIx	SINGLE	RNA-Seq	8563991	86	414662256	READ and QUALITY columns with mismatched blob counts
+DRR004435	core	table	ILLUMINA	Illumina Genome Analyzer IIx	SINGLE	OTHER	36805747	34	728056928	2 bp adapter ahead of a 34 bp read; routing to _2 with no _1
+DRR050206	core	table	ILLUMINA	Illumina HiSeq 2000	SINGLE	RNA-Seq	3043495	49	102425783	content-equal but md5-divergent output
+SRR341578	core	csra	ILLUMINA	Illumina HiSeq 2000	PAIRED	WGS	7549706	202	932308473	aligned cSRA: PRIMARY_ALIGNMENT + REFERENCE + SEQUENCE
+SRR000001	core	table	LS454	454 GS FLX	PAIRED	WGS	470985	248	312527083	454 pyrosequencing, flat table
+SRR2584863	core	table	ILLUMINA	Illumina HiSeq 2500	PAIRED	WGS	1553259	300	302057279	HiSeq paired flat table
+SRR28588231	core	db	ILLUMINA	Illumina MiSeq	PAIRED	AMPLICON	66220	602	23395841	MiSeq 2x301 amplicon
+SRR10358300	core	db	ILLUMINA	Illumina MiSeq	PAIRED	AMPLICON	62983	600	24227855	align schema, unmapped; MiSeq amplicon
+SRR38889541	core	db	PACBIO_SMRT	Revio	SINGLE	AMPLICON	25000	1473	11366482	PacBio Revio HiFi long reads
+SRR38892122	core	db	OXFORD_NANOPORE	PromethION	SINGLE	WGS	1828	4766	6985886	Oxford Nanopore PromethION long reads
+DRR002770	core	table	ION_TORRENT	Ion Torrent PGM	SINGLE	WGS	908553	281	675763350	Ion Torrent PGM, variable read length
+DRR010063	core	table	ABI_SOLID	AB 5500xl Genetic Analyzer	SINGLE	WGS	631524	75	27458459	ABI SOLiD colorspace decode path
+DRR171344	core	db	CAPILLARY	AB 3730xL Genetic Analyzer	SINGLE	WGS	30801	1088	24820152	Sanger capillary reads
+DRR1001272	core	db	DNBSEQ	unspecified	PAIRED	AMPLICON	102234	444	19559696	DNBSEQ paired amplicon
+ERR13764617	core	db	ELEMENT	Element AVITI	SINGLE	RNA-Seq	1352371	75	69961841	Element AVITI
+SRR32909377	core	db	ULTIMA	UG 100	PAIRED	OTHER	33004	484	5860358	Ultima UG 100


### PR DESCRIPTION
Fixes #101.

## The bug

The page map header's version field distinguishes two incompatible readings of the same on-disk slot:

- versions 0 and 1 store `data_run[]` — run-length counts saying how many consecutive rows share a data record;
- version 2 stores `data_offset[]` — one **element** offset per logical row into a deduplicated vocabulary.

ncbi-vdb aliases both arrays onto a single allocation and keeps a `random_access` bool to say which is live (`libs/kdb/page-map.c`, `PageMapDeserialize_v0`). sracha parsed both into an untyped `PageMap::data_runs` and dropped the distinction. Five call sites guessed it back from the data's shape (`data_runs.len() >= total_rows`); eleven others assumed repeat counts unconditionally.

On `SRR35917722` a version-2 blob — 16,384 rows of 302 bases stored as an 18-row vocabulary — reached `expand_variable_data_runs`, which walked the offsets as run lengths and demanded 36,240 bytes from a 5,436-byte buffer:

```
Error: VDB format error: page_map: variable data truncated - have 5436 bytes, need 36240
```

## The fix

`PageMap.data_runs` is replaced by a typed `RowMapping` — `Identity`, `RepeatCounts`, or `RandomAccessOffsets` — set from the header at deserialize time. Rows resolve to `(offset, len)` through a single walk that mirrors ncbi-vdb's `PageMapFindRow`, exposed both as a materializing `row_extents()` for random access and as a lazy visitor for the cold paths; `expand_rows` specializes per mapping for the reasons in the performance section below. That collapses seven overlapping expansion methods into three and removes every shape-based guess.

## Also fixed, found by reading the C source

The issue reports one symptom; matching the reference implementation turned up three more, all latent:

- **`expand_via_page_map` guessed the offset unit.** It chose between an "entry index" and a "u32 index" reading by testing which fit the buffer. `data_offset` is an `elem_count_t` — always an element offset. The entry reading is wrong whenever a row holds more than one element, and the guess silently picked it whenever both fit.
- **`cache.rs` treated random-access offsets as per-row record indices.** They are neither sorted nor unique, so the cSRA path read the wrong records.
- **Variant 0 random access set `data_recs = max(offset) + 1`**; ncbi-vdb sets it to `row_count`.
- **`sracha vdb dump` never expanded deduplicated rows** in its READ, quality, or 4na paths, so it failed on any archive using them — reproducible on the reporter's accession without downloading it, via the remote-range path.
- **Version 2 on variants 1 or 3 is now rejected.** The encoder cannot emit it and ncbi-vdb would dereference a NULL `data_offset`.

## Validation

A three-way A/B (baseline, candidate, `fasterq-dump`) over **369 accessions × 2 split modes**, plus a second array over accessions cited by past fixes.

| | main corpus | pathological |
|---|---|---|
| rows | 738 | 26 |
| UNCHANGED | 592 | 16 |
| STILL_BROKEN (pre-existing, byte-identical to baseline) | 138 | 4 |
| rejected by both binaries (cSRA / 454) | 4 | 6 |
| **FIXED** | 4 | 0 |
| **REGRESSED** | **0** | **0** |

Four rows changed, all of them `FIXED`: **DRR028486** and **DRR028482**, in both split modes. Every one changed *toward* sra-tools:

```
base_vs_cand      DIFFER (md5, both files)
cand_vs_fasterq   IDENTICAL
base_vs_fasterq   DIFFER (content, both files)
```

The baseline was emitting raw 2na basecalls where ALTREAD says `N`, so real ambiguity annotations were leaking into FASTQ as confident base calls — silently, with a zero exit code, in at least 200 records. That is the ALTREAD path whose random-access shape the old code guessed.

On the reporter's accession, quality — the column that crashed — is **byte-identical to `vdb-dump` across 2,000 rows** in four windows spread through the archive. READ matches in 1,994; the six differences are a pre-existing scope difference in `vdb dump -C READ` (it renders the physical column without the schema's `bit_or(ALTREAD)` N-mask), confirmed identical in baseline and candidate on `SRR28588231` and unrelated to this change.

The cSRA path can't be covered by the corpus (both binaries refuse aligned archives for FASTQ), so it was checked directly on `VDB-3418.sra`: FASTQ output byte-identical in both split modes, and all three tables — `PRIMARY_ALIGNMENT`, `REFERENCE`, `SEQUENCE` — dump byte-identically. All eight local fixtures are byte-identical across both splits, including `DRR045255`, the fixture that specifically guards the random-access `READ_LEN` blob whose offset handling changed.

709 unit tests pass; clippy and `fmt` clean.

Of the 138 pre-existing `STILL_BROKEN` rows, 76 are one thing: for single-read runs in `--split-files`, `fasterq-dump` writes `ACC.fastq` where sracha writes `ACC_1.fastq`. That is unchanged by this PR (identical in both binaries) and looks unfiled — worth its own issue.

## Performance

The first cut of the rewrite resolved every logical row independently — two checked multiplies, a checked add and a bounds check per row — where the old code hoisted that arithmetic out of the repeat loop and walked one data record at a time. That cost **2.4x the decode CPU** on SRR18959644, an archive whose page maps dedup heavily. It was not caught by any test, and it does not show up on archives whose page maps are identity, which is why the corpus stayed clean.

`perf` put 68% of samples inside `expand_rows`. The fix specializes the three mappings rather than routing them all through one per-row visitor. Measured on SRR18959644, two runs each on one node:

| | wall | user | sys | total CPU |
|---|---|---|---|---|
| baseline | 19.86 s | 87.4 | 60.2 | 147.6 |
| candidate | 19.27 s | 93.0 | 55.4 | 148.4 |

Total CPU is at parity, wall is marginally better, and output is byte-identical. Two controls — DRR045255 (245 MB) and SRR38294732 (740 MB) — were within noise before and after, confirming the regression was specific to dedup-heavy page maps.

Worth knowing for review: **the corpus ran against the pre-perf-fix binary**, deliberately, so the arrays would not have their binary swapped mid-flight. That transfers only because the perf change is output-equivalent, which was checked three ways: a windowed-vs-full-walk proptest, byte-identical FASTQ across all eight local fixtures, and identical md5 on SRR18959644 itself at every step of the optimization.

## Test coverage added

The deserializer tests only exercised version 0, so nothing checked the step that actually broke. Added round-trips through `page_map_deserialize` for version 2 variants 0 and 2 (asserting the trailing array becomes `RandomAccessOffsets` and `data_recs` stays `row_count`), the version-1 repeat-count reading of the same byte shape, and rejection of version 2 on variants 1 and 3.

## Distilled corpus

`validation/corpus.tsv` is 36 archives, one row each, with the reason it earned its place. The random corpora answer "does sracha still match fasterq-dump on typical Illumina data" — they miss the archives that actually broke things and most platforms entirely, so a decoder change could pass a 369-accession A/B while silently breaking colorspace, capillary, or reference-compressed input.

Covers every platform SRA serves (Illumina, BGISEQ, DNBSEQ, Element, Ultima, PacBio, Nanopore, Ion Torrent, SOLiD, capillary, 454), both layouts, read lengths from 34 bp to 4.8 kb, and all three archive shapes including a real cSRA. Platform metadata comes from ENA; archive shape is probed with `sracha vdb tables` rather than assumed — eight initial guesses were wrong. `corpus.sh` selects and summarizes (`--tier`, `--shape`, `--platform`, `--why`).
