### PR TITLE
fix(fastq): drop the mate suffix for single-read `--split-files` output (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Fixes
 
+- Name the `--split-files` output `ACC.fastq` for single-read archives (#103).
+  fasterq-dump suffixes by mate index there, except when the archive stores
+  one read per spot, where it writes a bare filename; sracha always wrote
+  `ACC_1.fastq`. The decision keys off the stored read count rather than how
+  many reads survive filtering, so DRR004435 — where a 2 bp adapter is dropped
+  and only mate 2 remains — still writes `DRR004435_2.fastq`.
+
+## Unreleased
+
+### Fixes
+
 - Decode version-2 (random-access) page maps as per-row element offsets
   instead of repeat counts (#101). A page map's `data_offset[]` and
   `data_run[]` share one slot in the on-disk format, and sracha kept both in

--- a/crates/sracha-core/src/fastq/mod.rs
+++ b/crates/sracha-core/src/fastq/mod.rs
@@ -493,16 +493,31 @@ struct ReadSegment<'a> {
 ///   to 0, sending everything to the unpaired file.
 ///
 /// `mate_idx` is the 1-based original slot, `emit_idx` the 0-based position
-/// among surviving segments, and `bio_reads` the number of biological reads
-/// that passed the zero-length and min-length filters.
+/// among surviving segments, `bio_reads` the number of biological reads that
+/// passed the zero-length and min-length filters, and `spot_reads` the number
+/// of reads the spot holds *before* any filtering.
+///
+/// `spot_reads` is what decides the `--split-files` filename. fasterq-dump
+/// suffixes by mate index there, except when the archive stores a single read
+/// per spot, where it writes a bare `ACC.fastq`. It is the stored read count
+/// that matters, not how many survive filtering: on DRR004435 a 2 bp adapter
+/// is dropped and only mate 2 survives, and fasterq-dump still writes
+/// `DRR004435_2.fastq` — so keying this off `bio_reads` would rename that file.
 pub(crate) fn slot_for_segment(
     split_mode: SplitMode,
     mate_idx: u32,
     emit_idx: usize,
     bio_reads: usize,
+    spot_reads: usize,
 ) -> OutputSlot {
     match split_mode {
-        SplitMode::SplitFiles => OutputSlot::ReadN(mate_idx.saturating_sub(1)),
+        SplitMode::SplitFiles => {
+            if spot_reads < 2 {
+                OutputSlot::Unpaired
+            } else {
+                OutputSlot::ReadN(mate_idx.saturating_sub(1))
+            }
+        }
         SplitMode::Split3 => {
             if bio_reads < 2 {
                 OutputSlot::Unpaired
@@ -539,7 +554,13 @@ pub fn format_spot(
     if segments.is_empty() {
         return Vec::new();
     }
-    route_segments_to_slots(&segments, &spot.name, run_name, config)
+    route_segments_to_slots(
+        &segments,
+        &spot.name,
+        run_name,
+        config,
+        spot.read_lengths.len(),
+    )
 }
 
 /// Split a spot's concatenated sequence/quality into per-read segments,
@@ -604,6 +625,7 @@ fn route_segments_to_slots(
     spot_name: &[u8],
     run_name: &str,
     config: &FastqConfig,
+    spot_reads: usize,
 ) -> Vec<(OutputSlot, FastqRecord)> {
     let mut results = Vec::with_capacity(segments.len());
     let format = |seg: &ReadSegment<'_>| {
@@ -630,7 +652,13 @@ fn route_segments_to_slots(
 
     let bio_reads = segments.iter().filter(|s| s.biological).count();
     for (emit_idx, seg) in segments.iter().enumerate() {
-        let slot = slot_for_segment(config.split_mode, seg.mate_idx, emit_idx, bio_reads);
+        let slot = slot_for_segment(
+            config.split_mode,
+            seg.mate_idx,
+            emit_idx,
+            bio_reads,
+            spot_reads,
+        );
         results.push((slot, format(seg)));
     }
 
@@ -858,7 +886,9 @@ mod tests {
     }
 
     #[test]
-    fn single_read_routes_to_read_n0_in_split_files() {
+    fn single_read_routes_to_unsuffixed_file_in_split_files() {
+        // An archive storing one read per spot gets a bare `ACC.fastq` from
+        // fasterq-dump's --split-files, not `ACC_1.fastq` (issue #103).
         let spot = single_read_spot(b"1", b"ACGT", b"????");
         let config = FastqConfig {
             split_mode: SplitMode::SplitFiles,
@@ -867,7 +897,38 @@ mod tests {
         let results = format_spot(&spot, "SRR1", &config);
 
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].0, OutputSlot::ReadN(0));
+        assert_eq!(results[0].0, OutputSlot::Unpaired);
+    }
+
+    #[test]
+    fn lone_surviving_mate_keeps_its_suffix_in_split_files() {
+        // DRR004435's shape: the spot stores two reads, a 2 bp adapter ahead
+        // of a biological read. The adapter is filtered out, leaving one
+        // segment — but the file is still `_2`, because the archive stores
+        // two reads per spot. Routing on the surviving count instead of the
+        // stored count would rename this to `ACC.fastq`.
+        let spot = SpotRecord {
+            name: b"1".to_vec(),
+            sequence: b"ACACGTACGT".to_vec(),
+            quality: b"??????????".to_vec(),
+            read_lengths: vec![2, 8],
+            read_types: vec![BIO, BIO],
+            read_filter: vec![0, 0],
+            spot_group: Vec::new(),
+        };
+        let config = FastqConfig {
+            split_mode: SplitMode::SplitFiles,
+            min_read_len: Some(4),
+            ..default_config()
+        };
+        let results = format_spot(&spot, "SRR1", &config);
+
+        assert_eq!(results.len(), 1, "the 2 bp adapter is filtered out");
+        assert_eq!(
+            results[0].0,
+            OutputSlot::ReadN(1),
+            "surviving mate 2 still writes _2"
+        );
     }
 
     #[test]

--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -1416,6 +1416,7 @@ pub(crate) fn decode_blob_to_fastq(
                             seg.mate_idx,
                             emit_idx,
                             bio_reads,
+                            spot_read_lengths.len(),
                         );
                         emit(slot, seg, spot_number, description);
                     }


### PR DESCRIPTION
Fixes #103.

## The bug

`fasterq-dump --split-files` names its files by mate index, except when the archive stores a single read per spot — there it writes a bare `ACC.fastq`. sracha always wrote `ACC_1.fastq`, so a pipeline globbing `${ACC}.fastq` after `--split-files` found nothing. `--split-3` and `--split-spot` already agreed.

## The subtlety

Route on the spot's **stored** read count, not on how many reads survive filtering. Those differ, and the difference is a trap: on `DRR004435` a 2 bp adapter sits ahead of a 34 bp biological read, the adapter is filtered out, and fasterq-dump *still* writes `DRR004435_2.fastq` for the lone survivor. Keying off the surviving count — the obvious reading, and what `--split-3` does — would have renamed that file and traded one naming bug for another.

`--split-3` genuinely does route on the surviving count (`bio_reads < 2 → Unpaired`), which is why it was tempting; the two modes just have different rules.

## Verification

Against sra-tools 3.2.1, filenames **and** content, on all three shapes:

| archive | shape | fasterq-dump | sracha | content |
|---|---|---|---|---|
| SRR38892122 | one read per spot | `SRR38892122.fastq` | same | identical |
| SRR28588231 | paired | `_1.fastq`, `_2.fastq` | same | identical |
| DRR004435 | adapter filtered out | `DRR004435_2.fastq` | same | identical |

710 unit tests pass; clippy and `fmt` clean.

## Impact

This was the single largest source of disagreement in the validation corpus — **76 of 138 failing rows** in a 369-accession × 2-split A/B, every one a SINGLE-layout run. It masked real signal: a reviewer scanning corpus output had to sort naming noise from actual decode differences.

## Tests

`single_read_routes_to_read_n0_in_split_files` asserted the old behaviour and is updated. A companion test pins the DRR004435 shape so the surviving-count reading cannot creep back in.