### PR TITLE
docs(validation): correct corpus rows that `fastq` declines

### DIFF
--- a/validation/corpus.tsv
+++ b/validation/corpus.tsv
@@ -9,11 +9,14 @@
 # shape  table    = flat KAR table   db = database with a SEQUENCE table
 #        csra     = reference-compressed, has PRIMARY_ALIGNMENT + REFERENCE
 #
-# Not every row exercises the FASTQ decoder. `sracha fastq` refuses cSRA and
-# 454 outright, so those rows check that both binaries refuse identically
-# (verdict REJECT_CSRA / REJECT_PLATFORM in ab_corpus.sh); reach their decode
-# paths with `sracha vdb dump` instead. Treating a REJECT as decode coverage
-# is the mistake this note exists to prevent.
+# Not every row exercises the FASTQ decoder. `sracha fastq` declines cSRA and
+# the legacy platforms — 454, Ion Torrent, capillary — and cannot read ABI
+# SOLiD colorspace at all (#109). Those five rows check that both binaries
+# decline identically (verdict REJECT_CSRA / REJECT_PLATFORM / REJECTED_BOTH
+# in ab_corpus.sh); reach their decode paths with `sracha vdb dump` instead.
+# Treating a REJECT as decode coverage is the mistake this note exists to
+# prevent, and the `covers` column says so per row rather than leaving it to
+# be inferred from the platform.
 #
 # Usage:
 #   awk -F'\t' '$2=="core" && !/^#/ {print $1}' validation/corpus.tsv > core.txt
@@ -50,9 +53,9 @@ SRR28588231	core	db	ILLUMINA	Illumina MiSeq	PAIRED	AMPLICON	66220	602	23395841	M
 SRR10358300	core	db	ILLUMINA	Illumina MiSeq	PAIRED	AMPLICON	62983	600	24227855	align schema, unmapped; MiSeq amplicon
 SRR38889541	core	db	PACBIO_SMRT	Revio	SINGLE	AMPLICON	25000	1473	11366482	PacBio Revio HiFi long reads
 SRR38892122	core	db	OXFORD_NANOPORE	PromethION	SINGLE	WGS	1828	4766	6985886	Oxford Nanopore PromethION long reads
-DRR002770	core	table	ION_TORRENT	Ion Torrent PGM	SINGLE	WGS	908553	281	675763350	Ion Torrent PGM, variable read length
-DRR010063	core	table	ABI_SOLID	AB 5500xl Genetic Analyzer	SINGLE	WGS	631524	75	27458459	ABI SOLiD colorspace decode path
-DRR171344	core	db	CAPILLARY	AB 3730xL Genetic Analyzer	SINGLE	WGS	30801	1088	24820152	Sanger capillary reads
+DRR002770	core	table	ION_TORRENT	Ion Torrent PGM	SINGLE	WGS	908553	281	675763350	Ion Torrent PGM, variable read length; fastq declines the platform, use vdb dump
+DRR010063	core	table	ABI_SOLID	AB 5500xl Genetic Analyzer	SINGLE	WGS	631524	75	27458459	ABI SOLiD: colorspace CSREAD/ALTCSREAD, no READ column; fastq cannot convert it (#109)
+DRR171344	core	db	CAPILLARY	AB 3730xL Genetic Analyzer	SINGLE	WGS	30801	1088	24820152	Sanger capillary reads; fastq declines the platform, use vdb dump
 DRR1001272	core	db	DNBSEQ	unspecified	PAIRED	AMPLICON	102234	444	19559696	DNBSEQ paired amplicon
 ERR13764617	core	db	ELEMENT	Element AVITI	SINGLE	RNA-Seq	1352371	75	69961841	Element AVITI
 SRR32909377	core	db	ULTIMA	UG 100	PAIRED	OTHER	33004	484	5860358	Ultima UG 100


### PR DESCRIPTION
Documentation-only change to `validation/corpus.tsv`. No accessions added or removed, no code touched.

## What was wrong

Running the distilled corpus as a real A/B (pre-#101 `main` vs current `main`) showed that **five of its eleven platforms never reach the FASTQ decoder**:

| accession | platform | outcome |
|---|---|---|
| SRR000001 | 454 | declined as a legacy platform |
| DRR002770 | Ion Torrent | declined as a legacy platform |
| DRR171344 | Capillary | declined as a legacy platform |
| SRR341578 | Illumina (cSRA) | declined as aligned |
| DRR010063 | ABI SOLiD | **cannot be read at all** (#109) |

Only the 454 and cSRA rows said so. The Ion Torrent and capillary rows read as ordinary decode coverage, and the SOLiD row claimed to cover an "ABI SOLiD colorspace decode path" — which does not exist. That archive stores `CSREAD`/`ALTCSREAD` with no `READ` column, and `sracha fastq` fails on it outright (with a misleading error, filed as #109).

## Why it matters

The whole point of the file is that a reader can tell what each row buys them. A row that says "colorspace decode path" but actually tests a refusal is worse than no row at all — it implies coverage that isn't there, which is exactly the failure mode the header note already warned about for other rows.

## The mistake behind it

I wrote those `covers` notes from ENA platform metadata without checking whether sracha could read the files. That is the same assume-don't-verify error that hit the `shape` column when the corpus was built — the difference is that `shape` got probed with `sracha vdb tables` before landing, and eight of my guesses turned out wrong. The `covers` column got no equivalent check.

## What changed

- The three misleading `covers` entries now state the refusal explicitly.
- The header note lists all five declining rows and the three verdicts they produce (`REJECT_CSRA` / `REJECT_PLATFORM` / `REJECTED_BOTH`) instead of the two it happened to mention.