### PR TITLE
fix(vdb): decode `izip_encoding` QUALITY via the blob header (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Fixes
 
+- Decode `izip_encoding` QUALITY through the blob header instead of probing
+  (#111). Quality on srf-load-era archives is byte-plane (irzip) data whose
+  plane count and min/slope live in the blob header, not an izip container.
+  Probing it as an izip container fails, and the fallback decoded it as
+  deflate, yielding plausible-but-wrong scores for every base of every spot
+  with no error — DRR001816's 35.9M spots now match `fasterq-dump` byte for
+  byte. Sequences, names and counts were always correct, so nothing failed
+  loudly.
+
 - Apply the ALTREAD ambiguity mask in `vdb dump -C READ` (#104). The dump
   rendered the physical READ column while `vdb-dump` renders the logical one
   the schema defines, so the two disagreed wherever a submitter recorded an

--- a/crates/sracha-vdb/src/blob_codecs.rs
+++ b/crates/sracha-vdb/src/blob_codecs.rs
@@ -196,6 +196,28 @@ pub fn decode_quality_encoding(decoded: &blob::DecodedBlob<'_>) -> Result<Vec<u8
     if decoded.data.first() == Some(&0x78) {
         return decode_zip_encoding(decoded);
     }
+    // Header-driven irzip. `izip_encoding` quality (srf-load-era Illumina)
+    // arrives with a v1+ compression header carrying the plane count in `ops`
+    // and min/slope in `args`, exactly like the integer columns — the payload
+    // is bit-plane encoded, not an izip container and not deflate. Probing it
+    // as either yields plausible-looking garbage rather than an error, so the
+    // header has to be consulted before the probes run. See
+    // `decode_irzip_column`, which has always done this for X/Y/READ_LEN;
+    // quality never did (#111).
+    if let Some(hdr) = decoded.headers.first().filter(|h| h.version >= 1)
+        && !(hdr.ops.is_empty() && hdr.args.is_empty())
+    {
+        let planes = hdr.ops.first().copied().unwrap_or(0xFF);
+        let min = hdr.args.first().copied().unwrap_or(0);
+        let slope = hdr.args.get(1).copied().unwrap_or(0);
+        // Quality is one byte per element, so osize is the element count.
+        let num_elems = hdr.osize as u32;
+        if let Ok(q) = blob::irzip_decode(&decoded.data, 8, num_elems, min, slope, planes, None)
+            && q.len() == hdr.osize as usize
+        {
+            return Ok(q);
+        }
+    }
     if let Ok(qdata) = blob::izip_decode(&decoded.data, 8)
         && !qdata.is_empty()
     {


### PR DESCRIPTION
Fixes #111.

## The bug

Quality scores were wrong on every srf-load-era archive — not shifted, just unrelated values:

```
fasterq-dump  IIIHIIIIIIIIIIIIIIIHIIIHIIIGIIIIIIGH
sracha        3!!$#!!!!!!!!!!!!!!$#!!$#!!&%!!!!!&#
```

For all 35,949,084 spots of DRR001816. Sequences, spot names, read lengths and counts were all correct, so nothing failed and nothing looked wrong unless you diffed the quality lines against sra-tools. Anything downstream that trims or filters on quality — most pipelines — was silently affected.

## Root cause

`decode_quality_encoding` picked a codec by probing the payload: zlib if it starts with `0x78`, else izip, else zlib again. Neither probe is right for these blobs.

The archive's schema declares:

```
physical column < INSDC:quality:phred > izip_encoding#1 .QUALITY = in_qual_phred;
```

`izip_encoding`'s decode is `iunzip#2.1`, and ncbi-vdb dispatches that on the **blob header version**, not on the payload (`libs/vxf/irzip.c:425-464`):

- **version 0** — the izip container, with its fixed 93-byte header
- **versions 1-3** — bare byte-plane (irzip) streams, plane count and min/slope in the *blob header*, no in-band header at all

A 2011 SRF archive is version 1 or 2. Parsing a 93-byte izip header out of it reads deflate bytes as `data_flags`, which failed with `izip: type_data too short` on every single blob. The `if let Ok(...)` probe swallowed that error and fell through to deflate, which produced garbage instead of failing.

`decode_irzip_column` has always done this correctly for X/Y/READ_LEN — which is why spot names on this archive were right while quality was wrong.

## The fix

Consult the header before probing: same plane/min/slope extraction as the integer path, `elem_bits = 8`. The result is accepted **only if its length matches the header's `osize`**, so a wrong guess still falls through to the existing probes rather than silently winning.

## Verification

- **DRR001816**: full-file `--split-files` output is now md5-identical to fasterq-dump (`80227c1f180047366934db5a7b3f5055`), where before it differed in every quality line.
- **All nine local fixtures byte-unchanged** across split modes — the modern deflate-quality path is untouched.
- 714 unit tests pass; clippy and `fmt` clean.

## Notes

Long-standing, not a regression: byte-identical output from the pre-#101 binary.

It stayed hidden because the validation corpus compared this accession as a *filename* mismatch (`DRR001816_1.fastq` vs `DRR001816.fastq`) and never diffed the contents. #103 fixed the naming, which unmasked it — concretely the "naming noise hides real signal" argument from that issue, and an argument for #107 (the corpus never checks `vdb dump`) and #108 (it never checks cost).