### PR TITLE
fix(vdb): decode 4-channel log-odds QUALITY on the `q4` schema (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Fixes
 
+- Decode 4-channel log-odds QUALITY on the `q4` Illumina schema (#113). Those
+  archives store `NCBI:qual4` — four log-odds channels per base behind a
+  two-stage `zip`/`qual4_encode` chain — and sracha stopped after the inflate,
+  emitting the intermediate encoded bytes as phred. Every base of every spot
+  was wrong, silently. DRR001867's 14.2M spots now match `fasterq-dump` byte
+  for byte.
+
 - Decode `izip_encoding` QUALITY through the blob header instead of probing
   (#111). Quality on srf-load-era archives is byte-plane (irzip) data whose
   plane count and min/slope live in the blob header, not an izip container.

--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -600,6 +600,11 @@ pub(crate) fn decode_blob_to_fastq(
             {
                 qdata = pm.expand_rows(&qdata, 1)?;
             }
+            // The `q4` Illumina schema stores four log-odds channels per
+            // base rather than one phred byte. The logical phred column is
+            // `log_odds_to_phred(cut<0>(.QUALITY))`, so de-interleave channel
+            // 0 and map it; reading the raw stream as phred yields values far
+            // outside the phred range (#113).
             qdata
         } else {
             Vec::new()

--- a/crates/sracha-vdb/src/blob_codecs.rs
+++ b/crates/sracha-vdb/src/blob_codecs.rs
@@ -178,20 +178,165 @@ pub fn decode_zip_encoding(decoded: &blob::DecodedBlob<'_>) -> Result<Vec<u8>> {
     Ok(decoded.data.to_vec())
 }
 
-/// Decode the QUALITY blob payload, handling both `zip_encoding` (deflate/
-/// zlib — modern Illumina) and `izip_encoding` (NCBI integer compression —
-/// older srf-load-era Illumina such as DRR001816).
+/// Decode `NCBI:SRA:qual4_encode` output to four log-odds channels per base.
 ///
-/// The encoding isn't tagged in the blob header, so we probe. zlib streams
-/// always start with a `0x78` CMF byte for the deflate window sizes NCBI
-/// uses, so when we see one we go straight to [`decode_zip_encoding`] and
-/// skip the iZip probe entirely — that closes the path that drove issue
-/// #30, where SRA-Lite quality blobs were being interpreted as iZip with
-/// arbitrary `data_count` values. Otherwise try `izip_decode` (now bounded
-/// against the input size) and fall back to deflate on failure.
+/// A byte-oriented codebook over whole 4-tuples, emitted one variable-length
+/// code per base (`libs/sraxf/qual4_decode.c`, codebook in `qual4_codec.h`):
+///
+/// | leading byte | bytes | quad |
+/// |---|---|---|
+/// | `0..=80` | 4 | literal `[b0-40, b1-40, b2-40, b3-40]` |
+/// | `81` | 1 | `[-5, -5, -5, -5]` — the `N` marker |
+/// | `82` | 1 | `[qmax, qmin, qmin, qmin]` |
+/// | `83..=91` | 2 | `[v, ..]` with one slot set from `v`, rest `qmin` |
+/// | `92..=255` | — | malformed |
+///
+/// For the pattern codes `v = b1 - 40`, and the non-`qmin` slot holds `-v`
+/// (83-85), `-v + 1` (86-88) or `-v - 1` (89-91); which slot is 1, 2 or 3 as
+/// the code cycles.
+///
+/// Channel 0 is the *called* base's quality — the stored order is "swapped",
+/// with index 0 exchanged with the called base's 2na code. Recovering A/C/G/T
+/// order would need the basecalls, but the phred column is `cut<0>`, so this
+/// decoder needs no READ input.
+///
+/// Value bytes are not range-checked by the reference; arithmetic wraps at
+/// `i8`. Mirrored here so corrupt input decodes bit-identically rather than
+/// saturating or panicking.
+pub fn qual4_decode(src: &[u8], dcount: usize, qmin: i8, qmax: i8) -> Result<Vec<u8>> {
+    const KNOWN_BAD: u8 = 81;
+    const KNOWN_GOOD: u8 = 82;
+    const PATTERN_FIRST: u8 = 83;
+    const PATTERN_LAST: u8 = 91;
+
+    let out_len = dcount
+        .checked_mul(4)
+        .ok_or_else(|| Error::Format("qual4: output size overflows".into()))?;
+    let mut out = vec![0u8; out_len];
+    let mut j = 0usize;
+    let mut st = 0u8;
+    let mut pending = 0u8;
+
+    for &b in src {
+        if j >= dcount {
+            break;
+        }
+        let val = b.wrapping_sub(40) as i8;
+        let q = j * 4;
+        match st {
+            0 => {
+                if b < KNOWN_BAD {
+                    out[q] = val as u8;
+                    st = 1;
+                } else if b == KNOWN_BAD {
+                    out[q..q + 4].copy_from_slice(&[(-5i8) as u8; 4]);
+                } else if b == KNOWN_GOOD {
+                    out[q] = qmax as u8;
+                    out[q + 1] = qmin as u8;
+                    out[q + 2] = qmin as u8;
+                    out[q + 3] = qmin as u8;
+                } else {
+                    pending = b;
+                    st = 4;
+                }
+            }
+            1 => {
+                out[q + 1] = val as u8;
+                st = 2;
+            }
+            2 => {
+                out[q + 2] = val as u8;
+                st = 3;
+            }
+            3 => {
+                out[q + 3] = val as u8;
+                st = 0;
+            }
+            _ => {
+                if !(PATTERN_FIRST..=PATTERN_LAST).contains(&pending) {
+                    return Err(Error::Format(format!(
+                        "qual4: unknown codebook byte {pending}"
+                    )));
+                }
+                let idx = (pending - PATTERN_FIRST) as usize;
+                let v = val as i32;
+                let other = match idx / 3 {
+                    0 => -v,
+                    1 => -v + 1,
+                    _ => -v - 1,
+                };
+                let slot = idx % 3 + 1;
+                out[q] = val as u8;
+                out[q + 1] = qmin as u8;
+                out[q + 2] = qmin as u8;
+                out[q + 3] = qmin as u8;
+                out[q + slot] = (other as i8) as u8;
+                st = 0;
+            }
+        }
+        if st == 0 {
+            j += 1;
+        }
+    }
+
+    // The reference rejects the blob unless every requested quad was produced;
+    // trailing input past `dcount` is ignored, an incomplete quad is not.
+    if j != dcount {
+        return Err(Error::Format(format!(
+            "qual4: decoded {j} of {dcount} quads"
+        )));
+    }
+    Ok(out)
+}
+
+/// Decode the QUALITY blob payload.
+///
+/// Three encodings appear in the wild and the blob does not name which one it
+/// is, so the header is consulted first and the payload probed only after:
+///
+/// - `qual4_encoding` (`q4` Illumina schema) — a two-frame chain, `zip`
+///   outside and the qual4 codebook inside. Recognised by the second header
+///   frame's two ops, and collapsed to one phred byte per base here (#113).
+/// - `izip_encoding` (srf-load-era Illumina) — byte-plane data whose plane
+///   count and min/slope live in the blob header (#111).
+/// - `zip_encoding` (modern Illumina) — deflate/zlib.
+///
+/// zlib streams always start with a `0x78` CMF byte for the window sizes NCBI
+/// uses, so seeing one routes straight to [`decode_zip_encoding`] and skips
+/// the iZip probe — that closes the path behind issue #30, where SRA-Lite
+/// quality blobs were read as iZip with arbitrary `data_count` values.
 pub fn decode_quality_encoding(decoded: &blob::DecodedBlob<'_>) -> Result<Vec<u8>> {
     if decoded.data.is_empty() {
         return decode_zip_encoding(decoded);
+    }
+    // `NCBI:SRA:qual4_encoding#1` is a two-stage chain — `zip` outside, the
+    // qual4 codebook inside — so the blob carries two header frames:
+    //
+    //   frame0  version 1, no ops,      osize = inflated size
+    //   frame1  version 0, ops=[a, b],  osize = 4 bytes per base
+    //
+    // Every other codec here reads `headers.first()` and assumes a single
+    // transform, which left this column stopping after the inflate and
+    // handing the intermediate `encoded_qual4` bytes out as phred (#113).
+    // The ops are `qmin + 40` and `qmax + 40` (qual4_decode.c:176-188).
+    if decoded.headers.len() >= 2
+        && let inner = &decoded.headers[1]
+        && inner.ops.len() == 2
+        && inner.osize > 0
+        && inner.osize % 4 == 0
+    {
+        let inflated = decode_zip_encoding(decoded)?;
+        let qmin = (i32::from(inner.ops[0]) - 40) as i8;
+        let qmax = (i32::from(inner.ops[1]) - 40) as i8;
+        let dcount = (inner.osize / 4) as usize;
+        if let Ok(q4) = qual4_decode(&inflated, dcount, qmin, qmax) {
+            // Collapse to one phred byte per base here rather than handing
+            // four channels upward. The page map counts *elements*, and every
+            // caller expands it at one byte per element — a 4-byte element
+            // silently mis-expands on any blob whose map is not identity
+            // (which is most of them on this archive's blob 200).
+            return Ok(crate::encoding::qual4_log_odds_to_phred(&q4));
+        }
     }
     if decoded.data.first() == Some(&0x78) {
         return decode_zip_encoding(decoded);
@@ -590,5 +735,101 @@ mod tests {
             let out = expand_via_page_map(data, &Some(pm)).unwrap();
             prop_assert_eq!(out.len(), refs.len() * 4);
         }
+    }
+
+    // -----------------------------------------------------------------
+    // qual4 codebook (#113)
+    // -----------------------------------------------------------------
+
+    /// Literal quad: leading byte < 81 means four value bytes, each biased +40.
+    #[test]
+    fn qual4_literal_quad() {
+        let src = [40u8, 30, 20, 10]; // -> 0, -10, -20, -30
+        let out = qual4_decode(&src, 1, -40, 40).unwrap();
+        assert_eq!(
+            out.iter().map(|&b| b as i8).collect::<Vec<_>>(),
+            vec![0, -10, -20, -30]
+        );
+    }
+
+    /// Code 81 is the `N` marker and expands to (-5, -5, -5, -5) — the
+    /// 0xFBFBFBFB the schema maps to log-odds -6.
+    #[test]
+    fn qual4_known_bad_is_the_n_quad() {
+        let out = qual4_decode(&[81], 1, -40, 40).unwrap();
+        assert_eq!(
+            out.iter().map(|&b| b as i8).collect::<Vec<_>>(),
+            vec![-5, -5, -5, -5]
+        );
+    }
+
+    /// Code 82 expands to (qmax, qmin, qmin, qmin) using the header's bounds.
+    #[test]
+    fn qual4_known_good_uses_header_bounds() {
+        let out = qual4_decode(&[82], 1, -40, 40).unwrap();
+        assert_eq!(
+            out.iter().map(|&b| b as i8).collect::<Vec<_>>(),
+            vec![40, -40, -40, -40]
+        );
+    }
+
+    /// The nine pattern codes place one derived value and fill the rest with
+    /// qmin. 83-85 use -v, 86-88 use -v+1, 89-91 use -v-1; the slot cycles
+    /// 1, 2, 3 within each group.
+    #[test]
+    fn qual4_pattern_codes_place_value_and_fill_qmin() {
+        let cases: [(u8, [i8; 4]); 9] = [
+            (83, [10, -10, -40, -40]),
+            (84, [10, -40, -10, -40]),
+            (85, [10, -40, -40, -10]),
+            (86, [10, -9, -40, -40]),
+            (87, [10, -40, -9, -40]),
+            (88, [10, -40, -40, -9]),
+            (89, [10, -11, -40, -40]),
+            (90, [10, -40, -11, -40]),
+            (91, [10, -40, -40, -11]),
+        ];
+        for (code, want) in cases {
+            let out = qual4_decode(&[code, 50], 1, -40, 40).unwrap();
+            let got: Vec<i8> = out.iter().map(|&b| b as i8).collect();
+            assert_eq!(got, want.to_vec(), "code {code}");
+        }
+    }
+
+    /// The reference rejects a blob that does not yield exactly `dcount`
+    /// quads, so a truncated trailing code must error rather than pad.
+    #[test]
+    fn qual4_incomplete_trailing_quad_errors() {
+        assert!(qual4_decode(&[40, 30], 1, -40, 40).is_err());
+        assert!(qual4_decode(&[81], 2, -40, 40).is_err());
+    }
+
+    /// Codes past the table are malformed. The reference notices on the
+    /// *following* byte, because state 0 defers an unknown code.
+    #[test]
+    fn qual4_unknown_code_errors() {
+        assert!(qual4_decode(&[92, 40], 1, -40, 40).is_err());
+    }
+
+    /// Trailing input past `dcount` is ignored, not an error.
+    #[test]
+    fn qual4_extra_trailing_input_is_ignored() {
+        let out = qual4_decode(&[81, 81, 81], 2, -40, 40).unwrap();
+        assert_eq!(out.len(), 8);
+    }
+
+    /// Mixed stream: every code shape back to back stays in sync.
+    #[test]
+    fn qual4_mixed_stream_stays_aligned() {
+        // literal, known_good, pattern, known_bad
+        let src = [40u8, 30, 20, 10, 82, 84, 50, 81];
+        let out = qual4_decode(&src, 4, -40, 40).unwrap();
+        let got: Vec<i8> = out.iter().map(|&b| b as i8).collect();
+        assert_eq!(
+            got,
+            vec![
+                0, -10, -20, -30, 40, -40, -40, -40, 10, -40, -10, -40, -5, -5, -5, -5
+            ]
+        );
     }
 }

--- a/crates/sracha-vdb/src/encoding.rs
+++ b/crates/sracha-vdb/src/encoding.rs
@@ -225,6 +225,43 @@ pub fn merge_altread_bin(bases: &mut [u8], altread_bytes: &[u8], num_bases: usiz
 // Public API — Quality scores
 // ---------------------------------------------------------------------------
 
+/// Convert a 4-channel log-odds quality stream to one Phred score per base.
+///
+/// The `q4` Illumina schema stores `NCBI:qual4` — four
+/// `INSDC:quality:log_odds` values per base — and derives the logical phred
+/// column as `log_odds_to_phred(cut<0>(.QUALITY))`, i.e. channel 0 of each
+/// 4-tuple mapped through a lookup table.
+///
+/// The mapping is the 47-entry table in ncbi-vdb's
+/// `interfaces/ncbi/seq.vschema:809-838`, clipped to `[-6, 40]`. It is NOT
+/// the `10*log10(1 + 10^(x/10)) + 0.499` formula quoted in the comment above
+/// that table — the two disagree at the low end (the formula gives 1 for
+/// x = -6 where the table gives 0), and the table is what the reference
+/// implementation actually evaluates.
+///
+/// Returns one phred byte per base. Input length must be a multiple of 4.
+pub fn qual4_log_odds_to_phred(qual4: &[u8]) -> Vec<u8> {
+    qual4
+        .chunks_exact(4)
+        .map(|c| log_odds_to_phred(c[0] as i8))
+        .collect()
+}
+
+/// Single log-odds value to Phred, per ncbi-vdb's lookup table.
+#[inline]
+pub fn log_odds_to_phred(log_odds: i8) -> u8 {
+    // Table index is `clip(log_odds, -6, 40) + 6`.
+    const TO_PHRED: [u8; 47] = [
+        0, 1, 1, 2, 2, 3, 3, // -6 ..= 0
+        4, 4, 5, 5, 6, 7, 8, 9, 10, 10, // 1 ..= 10
+        11, 12, 13, 14, 15, 16, 17, 18, 19, 20, // 11 ..= 20
+        21, 22, 23, 24, 25, 26, 27, 28, 29, 30, // 21 ..= 30
+        31, 32, 33, 34, 35, 36, 37, 38, 39, 40, // 31 ..= 40
+    ];
+    let clipped = log_odds.clamp(-6, 40);
+    TO_PHRED[(clipped as i32 + 6) as usize]
+}
+
 /// Convert binary Phred quality scores to Phred+33 ASCII encoding.
 ///
 /// Each input byte is treated as a numeric Phred score; the output byte is
@@ -687,5 +724,40 @@ mod tests {
             let expected = if pass { b'?' } else { b'$' };
             prop_assert!(q.iter().all(|&b| b == expected));
         }
+    }
+
+    /// The log-odds -> phred map is the 47-entry table in ncbi-vdb's
+    /// seq.vschema, not the formula quoted in the comment above it. They
+    /// disagree at the low end: the formula gives 1 for -6, the table 0.
+    #[test]
+    fn log_odds_to_phred_matches_the_reference_table() {
+        assert_eq!(log_odds_to_phred(-6), 0);
+        assert_eq!(log_odds_to_phred(-5), 1);
+        assert_eq!(log_odds_to_phred(-1), 3);
+        assert_eq!(log_odds_to_phred(0), 3);
+        assert_eq!(log_odds_to_phred(1), 4);
+        assert_eq!(log_odds_to_phred(10), 10);
+        // 11 and up are identity.
+        for q in 11..=40i8 {
+            assert_eq!(log_odds_to_phred(q), q as u8, "log-odds {q}");
+        }
+    }
+
+    #[test]
+    fn log_odds_to_phred_clips_out_of_range() {
+        assert_eq!(log_odds_to_phred(-128), log_odds_to_phred(-6));
+        assert_eq!(log_odds_to_phred(127), log_odds_to_phred(40));
+    }
+
+    /// Only channel 0 survives: it is the called base's quality, which is
+    /// what the schema's `cut<0>` selects.
+    #[test]
+    fn qual4_conversion_takes_channel_zero() {
+        // two bases: (0, -10, -20, -30) and (40, -40, -40, -40)
+        let q4: Vec<u8> = [0i8, -10, -20, -30, 40, -40, -40, -40]
+            .iter()
+            .map(|&v| v as u8)
+            .collect();
+        assert_eq!(qual4_log_odds_to_phred(&q4), vec![3, 40]);
     }
 }


### PR DESCRIPTION
Fixes #113.

## The bug

Archives on `NCBI:SRA:Illumina:tbl:q4` emitted wrong quality for **every base of every spot**, silently — correct sequences, correct names, correct counts, zero exit code:

```
fasterq-dump  I<II=-)I/D65(-II0B30B*(F$(-)?:(795F1
sracha        "!7Y82'udzpssssstkssssssssssvZsssssv
```

## Root cause

Their physical QUALITY is `NCBI:qual4` — four `INSDC:quality:log_odds` channels per base — behind a **two-stage chain**:

```
decode { NCBI:SRA:encoded_qual4 unzipped = unzip#1(@); return NCBI:SRA:qual4_decode#1(unzipped); }
```

sracha did the inflate and stopped, handing the intermediate `encoded_qual4` bytes to the FASTQ writer as phred. Every codec in `blob_codecs.rs` reads `headers.first()` and assumes a single transform, so the second frame — which carries the codebook parameters and the true output size — was never consulted.

The traces made this unambiguous: the "garbage" buffer lengths matched frame0's `osize` exactly, while frame1's `osize` was `2359296 = 4 × 589824` bases.

## The fix

`qual4_decode`, a 5-state codebook over the inflated bytes (`libs/sraxf/qual4_decode.c`, table in `qual4_codec.h`):

| leading byte | bytes | quad |
|---|---|---|
| `0..=80` | 4 | literal, each `-40` |
| `81` | 1 | `[-5,-5,-5,-5]` — the `N` marker |
| `82` | 1 | `[qmax, qmin, qmin, qmin]` |
| `83..=91` | 2 | one derived slot, rest `qmin` |

The blob header's two ops are `qmin+40` and `qmax+40` (so the observed `[0, 80]` is qmin −40, qmax +40). Value arithmetic wraps at `i8` rather than saturating, matching the reference on corrupt input.

Channel 0 is the **called base's** quality — the stored order is "swapped", index 0 exchanged with the called base's 2na code — so the phred column is `cut<0>` and **no READ input is needed**. It maps through the 47-entry table at `seq.vschema:809-838`, which is authoritative: it disagrees with the formula in the comment directly above it at the low end (`-6` maps to 0, not 1).

## One subtlety worth review

The log-odds conversion is folded **into the codec**, not done in the pipeline. Returning four channels upward looked correct on most blobs and corrupted blob 200 — page maps count *elements*, and every caller expands at one byte per element, so a 4-byte element mis-expands on any blob whose map isn't identity. Collapsing to phred inside the codec preserves that invariant.

That bug was invisible in spot checks (the first 3.2M spots were fine) and only appeared in the full-file md5.

## Verification

- **DRR001867**: full-file `--split-files` output md5-identical to fasterq-dump (`13c3275674de217739a414d6dda000d3`) across all **14,242,983 spots**.
- All eight local fixtures byte-unchanged.
- **DRR001816** still matches its reference, so #111's irzip path didn't regress.
- 725 unit tests pass; clippy and `fmt` clean. Nine new tests cover every codebook shape, the truncation and unknown-code errors, and the conversion table.

Long-standing, not a regression. Surfaced by the union corpus after #103 fixed this archive's filename and let its content be compared at all.