### PR TITLE
fix(pipeline): check the quality stream against the sequence stream (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Fixes
 
+- Refuse to emit records whose quality does not correspond to their sequence
+  (#115). Strict mode checked quality per spot, but the per-spot slice is
+  correctly sized by construction, so a wrong-sized quality buffer produced
+  correctly-sized slices of the wrong bytes and no counter moved — how three
+  quality bugs (#101, #111, #113) shipped with correct sequences, correct
+  counts and a zero exit code. A blob-level check now compares the decoded
+  quality stream against the decoded sequence stream; both are one byte per
+  base, so any difference is fatal under the default strict mode.
+
 - Decode 4-channel log-odds QUALITY on the `q4` Illumina schema (#113). Those
   archives store `NCBI:qual4` — four log-odds channels per base behind a
   two-stage `zip`/`qual4_encode` chain — and sracha stopped after the inflate,

--- a/crates/sracha-core/src/fastq/mod.rs
+++ b/crates/sracha-core/src/fastq/mod.rs
@@ -31,6 +31,16 @@ pub struct IntegrityDiag {
     /// Blobs where the decoded quality stream ran short of the sequence
     /// stream, forcing per-spot synthesized quality fallback.
     pub quality_overruns: AtomicU64,
+    /// Blobs whose decoded quality stream was not the same length as the
+    /// decoded sequence stream.
+    ///
+    /// Both are one byte per base, so any difference means the quality being
+    /// written does not correspond to the bases it is written against. The
+    /// per-spot slicing cannot see this — it takes `spot_total_bases` from
+    /// wherever the cursor points, so every spot gets a correctly *sized*
+    /// slice of the wrong bytes. Three quality-decode bugs (#101, #111, #113)
+    /// shipped through that blind spot; this is the counter that closes it.
+    pub quality_blob_length_mismatch: AtomicU64,
     /// Blobs whose full quality payload was all-zero (SRA-lite style) and
     /// was replaced with a uniform Phred fallback.
     pub all_zero_quality_blobs: AtomicU64,
@@ -47,6 +57,7 @@ impl IntegrityDiag {
         self.quality_length_mismatches.load(Ordering::Relaxed) != 0
             || self.quality_invalid_bytes.load(Ordering::Relaxed) != 0
             || self.quality_overruns.load(Ordering::Relaxed) != 0
+            || self.quality_blob_length_mismatch.load(Ordering::Relaxed) != 0
             || self.all_zero_quality_blobs.load(Ordering::Relaxed) != 0
             || self.paired_spot_violations.load(Ordering::Relaxed) != 0
             || self.truncated_spots.load(Ordering::Relaxed) != 0
@@ -61,6 +72,7 @@ impl IntegrityDiag {
         self.quality_length_mismatches.load(Ordering::Relaxed) != 0
             || self.quality_invalid_bytes.load(Ordering::Relaxed) != 0
             || self.quality_overruns.load(Ordering::Relaxed) != 0
+            || self.quality_blob_length_mismatch.load(Ordering::Relaxed) != 0
             || self.paired_spot_violations.load(Ordering::Relaxed) != 0
     }
 
@@ -68,10 +80,12 @@ impl IntegrityDiag {
     pub fn summary(&self) -> String {
         format!(
             "quality_length_mismatches={}, quality_invalid_bytes={}, quality_overruns={}, \
-             all_zero_quality_blobs={}, paired_spot_violations={}, truncated_spots={}",
+             quality_blob_length_mismatch={}, all_zero_quality_blobs={}, \
+             paired_spot_violations={}, truncated_spots={}",
             self.quality_length_mismatches.load(Ordering::Relaxed),
             self.quality_invalid_bytes.load(Ordering::Relaxed),
             self.quality_overruns.load(Ordering::Relaxed),
+            self.quality_blob_length_mismatch.load(Ordering::Relaxed),
             self.all_zero_quality_blobs.load(Ordering::Relaxed),
             self.paired_spot_violations.load(Ordering::Relaxed),
             self.truncated_spots.load(Ordering::Relaxed),
@@ -2020,5 +2034,50 @@ mod tests {
         let lines: Vec<&str> = text.lines().collect();
         assert_eq!(lines[1].len(), lines[3].len());
         assert_eq!(lines[1], "ACGT");
+    }
+
+    // -----------------------------------------------------------------
+    // Blob-level quality/sequence correspondence (#115)
+    // -----------------------------------------------------------------
+
+    /// The counter that closes the blind spot behind #101/#111/#113 must be
+    /// strict-fatal, or a run producing wrong quality still exits zero.
+    #[test]
+    fn quality_blob_length_mismatch_is_strict_fatal() {
+        let d = IntegrityDiag::default();
+        assert!(!d.any(), "a clean run reports nothing");
+        assert!(!d.any_strict_fatal());
+
+        d.quality_blob_length_mismatch
+            .fetch_add(1, Ordering::Relaxed);
+
+        assert!(d.any(), "a mismatched blob must be visible");
+        assert!(
+            d.any_strict_fatal(),
+            "strict mode must refuse a run whose quality does not correspond \
+             to its sequence"
+        );
+    }
+
+    #[test]
+    fn quality_blob_length_mismatch_appears_in_the_summary() {
+        let d = IntegrityDiag::default();
+        d.quality_blob_length_mismatch
+            .fetch_add(7, Ordering::Relaxed);
+        let s = d.summary();
+        assert!(
+            s.contains("quality_blob_length_mismatch=7"),
+            "summary was: {s}"
+        );
+    }
+
+    /// `all_zero_quality_blobs` stays non-fatal: SRA-Lite ships synthesized
+    /// quality by design, so it is expected rather than a defect.
+    #[test]
+    fn sra_lite_synthesized_quality_stays_non_fatal() {
+        let d = IntegrityDiag::default();
+        d.all_zero_quality_blobs.fetch_add(1, Ordering::Relaxed);
+        assert!(d.any(), "still reported");
+        assert!(!d.any_strict_fatal(), "but must not fail a strict run");
     }
 }

--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -622,6 +622,26 @@ pub(crate) fn decode_blob_to_fastq(
         (all, is_empty)
     };
 
+    // Invariant: the decoded quality stream covers exactly the bases this
+    // blob decoded. Both are one byte per base.
+    //
+    // The per-spot slicing below cannot check this. It takes
+    // `spot_total_bases` from wherever the cursor points, so a quality buffer
+    // of the wrong total size still yields a correctly *sized* slice for every
+    // spot — of the wrong bytes. #111 (0.75x) and #113 (3.13x) both shipped
+    // through that blind spot with sequences, names and counts all correct.
+    if !quality_is_empty && quality_all.len() != read_data.len() {
+        diag.quality_blob_length_mismatch
+            .fetch_add(1, Ordering::Relaxed);
+        tracing::warn!(
+            "blob {blob_idx}: decoded quality is {} bytes for {} bases — the quality \
+             stream does not correspond to the sequence stream, so records from this \
+             blob would carry quality read from the wrong offsets",
+            quality_all.len(),
+            read_data.len(),
+        );
+    }
+
     // ------------------------------------------------------------------
     // N-masking: ALTREAD (4na) ambiguity merge.
     //
@@ -1246,14 +1266,21 @@ pub(crate) fn decode_blob_to_fastq(
             }
         };
 
-        // Invariant: quality must be exactly as long as sequence.
-        debug_assert_eq!(
-            quality.len(),
-            sequence.len(),
-            "blob {blob_idx}, spot {spot_idx_in_blob}: quality length {} != sequence length {}",
-            quality.len(),
-            sequence.len(),
-        );
+        // Invariant: quality must be exactly as long as sequence. The
+        // slicing above satisfies this by construction today, so the branch
+        // costs a length compare and never taken — but it is the last gate
+        // before bytes reach the writer, and a `debug_assert!` here would be
+        // compiled out of exactly the builds users run.
+        if quality.len() != sequence.len() {
+            diag.quality_length_mismatches
+                .fetch_add(1, Ordering::Relaxed);
+            tracing::warn!(
+                "blob {blob_idx}, spot {spot_idx_in_blob}: quality length {} != \
+                 sequence length {}",
+                quality.len(),
+                sequence.len(),
+            );
+        }
 
         // Spot number: always numeric 1-based index.
         let spot_number_str = itoa_buf.format(spots_before as usize + spot_idx_in_blob + 1);

--- a/crates/sracha-core/src/pipeline/marker.rs
+++ b/crates/sracha-core/src/pipeline/marker.rs
@@ -111,6 +111,9 @@ pub(crate) fn write_stats_file(entry: StatsEntry<'_>) -> Result<()> {
             "quality_length_mismatches": diag.quality_length_mismatches.load(Ordering::Relaxed),
             "quality_invalid_bytes": diag.quality_invalid_bytes.load(Ordering::Relaxed),
             "quality_overruns": diag.quality_overruns.load(Ordering::Relaxed),
+            "quality_blob_length_mismatch": diag
+                .quality_blob_length_mismatch
+                .load(Ordering::Relaxed),
             "all_zero_quality_blobs": diag.all_zero_quality_blobs.load(Ordering::Relaxed),
             "paired_spot_violations": diag.paired_spot_violations.load(Ordering::Relaxed),
             "truncated_spots": diag.truncated_spots.load(Ordering::Relaxed),


### PR DESCRIPTION
Fixes #115.

## Why strict mode caught nothing

Strict integrity checking is **on by default** and missed all three quality bugs found this week (#101, #111, #113). Each emitted wrong records with correct sequences, correct names, correct spot counts and a zero exit code.

The checks are per-spot, and the hot path slices each spot's quality as

```rust
let q = &quality_all[qual_offset..qual_offset + spot_total_bases];
```

which is correctly sized **by construction**. When the decoded quality buffer is the wrong size overall, every spot still receives a correctly-sized slice — just of the wrong bytes. No counter moves. And the one invariant that would have noticed was a `debug_assert_eq!`, compiled out of exactly the builds users run.

| bug | decoded quality vs sequence |
|---|---|
| #111 DRR001816 | 0.75x |
| #113 DRR001867 | 3.13x, 3.28x, 3.55x (varying per blob) |

A fixed 36 bp read cannot have a 3.13x quality buffer. Nothing looked.

## The change

A blob-level comparison: decoded quality and decoded sequence are both one byte per base, so their lengths must be equal. Both #111 and #113 violate it on **blob 0**, before a single record is written.

The per-spot invariant is promoted from `debug_assert_eq!` to a counted check — a length compare on a branch never taken today, but it is the last gate before bytes reach the writer.

`quality_blob_length_mismatch` is strict-fatal and appears in `stats.json`. `all_zero_quality_blobs` stays non-fatal, since SRA-Lite ships synthesized quality by design.

## Verified both directions

A check like this is only useful if it is both sensitive and specific, so I tested both:

- **Sensitive** — DRR001867 without #113 is refused: `quality_blob_length_mismatch=868`, exit 1, instead of writing 14,242,983 spots of wrong quality.
- **Specific** — 11 healthy archives spanning Illumina, PacBio, Nanopore, cSRA, plus both previously-broken-now-fixed accessions (DRR001816, DRR004435), all exit 0.
- **Composes** — with #113 applied, DRR001867 passes and its output is byte-identical to fasterq-dump.

717 unit tests pass; clippy and `fmt` clean.

## Note on ordering

This is independent of #114 but interacts with it: on `main` as it stands, DRR001867 is genuinely broken, so this PR will correctly refuse it. If both land, that archive converts cleanly. Merging this **before** #114 would turn a silent-corruption bug into a loud failure for those archives, which is arguably the better interim state, but worth a deliberate choice rather than an accident of ordering.

## What this does not cover

Sequence-side corruption. #101's ALTREAD leak produced correct *lengths* with wrong bases, and no length check can see that. Comparing decoded bases against `READ_LEN` totals would be the analogous guard and is worth a follow-up.