### PR TITLE
fix(pipeline): check spot boundaries against the decoded sequence (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Fixes
 
+- Check that a blob's spot boundaries consume exactly its decoded bases
+  (#117). `READ_LEN` defines where each spot starts inside the sequence
+  stream; the per-spot check saw only overrun, so a short accounting silently
+  dropped the tail and shifted every later record. Strict-fatal, mirroring the
+  quality check in #115. Note this does not catch #118, where `READ_LEN` and
+  the decoded buffer agree with each other but both hold half the spot.
+
 - Refuse to emit records whose quality does not correspond to their sequence
   (#115). Strict mode checked quality per spot, but the per-spot slice is
   correctly sized by construction, so a wrong-sized quality buffer produced

--- a/crates/sracha-core/src/fastq/mod.rs
+++ b/crates/sracha-core/src/fastq/mod.rs
@@ -41,6 +41,13 @@ pub struct IntegrityDiag {
     /// slice of the wrong bytes. Three quality-decode bugs (#101, #111, #113)
     /// shipped through that blind spot; this is the counter that closes it.
     pub quality_blob_length_mismatch: AtomicU64,
+    /// Blobs whose spot boundaries did not consume exactly the decoded bases.
+    ///
+    /// `READ_LEN` defines where each spot starts inside the decoded sequence
+    /// stream. If the two disagree in total, the boundaries are wrong and
+    /// every record past the divergence carries bases from the wrong offsets.
+    /// The per-spot check sees only overrun, never a short accounting.
+    pub sequence_blob_length_mismatch: AtomicU64,
     /// Blobs whose full quality payload was all-zero (SRA-lite style) and
     /// was replaced with a uniform Phred fallback.
     pub all_zero_quality_blobs: AtomicU64,
@@ -58,6 +65,7 @@ impl IntegrityDiag {
             || self.quality_invalid_bytes.load(Ordering::Relaxed) != 0
             || self.quality_overruns.load(Ordering::Relaxed) != 0
             || self.quality_blob_length_mismatch.load(Ordering::Relaxed) != 0
+            || self.sequence_blob_length_mismatch.load(Ordering::Relaxed) != 0
             || self.all_zero_quality_blobs.load(Ordering::Relaxed) != 0
             || self.paired_spot_violations.load(Ordering::Relaxed) != 0
             || self.truncated_spots.load(Ordering::Relaxed) != 0
@@ -73,6 +81,7 @@ impl IntegrityDiag {
             || self.quality_invalid_bytes.load(Ordering::Relaxed) != 0
             || self.quality_overruns.load(Ordering::Relaxed) != 0
             || self.quality_blob_length_mismatch.load(Ordering::Relaxed) != 0
+            || self.sequence_blob_length_mismatch.load(Ordering::Relaxed) != 0
             || self.paired_spot_violations.load(Ordering::Relaxed) != 0
     }
 
@@ -80,12 +89,13 @@ impl IntegrityDiag {
     pub fn summary(&self) -> String {
         format!(
             "quality_length_mismatches={}, quality_invalid_bytes={}, quality_overruns={}, \
-             quality_blob_length_mismatch={}, all_zero_quality_blobs={}, \
-             paired_spot_violations={}, truncated_spots={}",
+             quality_blob_length_mismatch={}, sequence_blob_length_mismatch={}, \
+             all_zero_quality_blobs={}, paired_spot_violations={}, truncated_spots={}",
             self.quality_length_mismatches.load(Ordering::Relaxed),
             self.quality_invalid_bytes.load(Ordering::Relaxed),
             self.quality_overruns.load(Ordering::Relaxed),
             self.quality_blob_length_mismatch.load(Ordering::Relaxed),
+            self.sequence_blob_length_mismatch.load(Ordering::Relaxed),
             self.all_zero_quality_blobs.load(Ordering::Relaxed),
             self.paired_spot_violations.load(Ordering::Relaxed),
             self.truncated_spots.load(Ordering::Relaxed),

--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -1483,6 +1483,26 @@ pub(crate) fn decode_blob_to_fastq(
         spot_idx_in_blob += 1;
     }
 
+    // Invariant: the spots consumed exactly the bases this blob decoded.
+    //
+    // The loop above catches per-spot *overrun* — READ_LEN claiming more bases
+    // than remain — but nothing notices the other direction, where the spot
+    // boundaries stop short and the tail of `read_data` is silently dropped.
+    // Either way the two streams disagree about where spots begin, so every
+    // record after the first divergence carries bases from the wrong offsets.
+    // This is the sequence-side analogue of the quality check above (#115,
+    // #117).
+    if seq_offset != read_data.len() {
+        diag.sequence_blob_length_mismatch
+            .fetch_add(1, Ordering::Relaxed);
+        tracing::warn!(
+            "blob {blob_idx}: READ_LEN accounts for {seq_offset} of {} decoded bases \
+             after {spot_idx_in_blob} spots — the spot boundaries do not match the \
+             sequence stream",
+            read_data.len(),
+        );
+    }
+
     // Collect populated LUT entries in slot-index order, then overflow.
     let mut records: Vec<BlobSlotOutput> = Vec::with_capacity(4);
     for entry in slot_lut.into_iter().flatten() {

--- a/crates/sracha-core/src/pipeline/marker.rs
+++ b/crates/sracha-core/src/pipeline/marker.rs
@@ -114,6 +114,9 @@ pub(crate) fn write_stats_file(entry: StatsEntry<'_>) -> Result<()> {
             "quality_blob_length_mismatch": diag
                 .quality_blob_length_mismatch
                 .load(Ordering::Relaxed),
+            "sequence_blob_length_mismatch": diag
+                .sequence_blob_length_mismatch
+                .load(Ordering::Relaxed),
             "all_zero_quality_blobs": diag.all_zero_quality_blobs.load(Ordering::Relaxed),
             "paired_spot_violations": diag.paired_spot_violations.load(Ordering::Relaxed),
             "truncated_spots": diag.truncated_spots.load(Ordering::Relaxed),


### PR DESCRIPTION
Partially addresses #117 — the blob-level half. The run-level `STATS` comparison is left open.

## The gap

The sequence-side analogue of #115. `READ_LEN` defines where each spot starts inside the decoded sequence stream. The spot loop already catches per-spot **overrun** — `READ_LEN` claiming more bases than remain — and increments `truncated_spots`. It never notices the other direction: if the boundaries stop short, the tail of the decoded buffer is silently dropped and every record past the divergence carries bases from the wrong offsets.

## The change

Compare the consumed offset against the decoded length once per blob; count `sequence_blob_length_mismatch`, strict-fatal, surfaced in `stats.json` alongside the quality counter.

## Verified

14 archives spanning Illumina, PacBio, Nanopore, BGISEQ and cSRA, including all four accessions repaired this week (DRR001816, DRR001867, DRR028486, DRR004435) — all clean. The single non-zero exit is `SRR000001`, which sracha declines by platform (454) before decoding, confirmed by its error message rather than assumed.

728 unit tests pass; clippy and `fmt` clean.

## What it does not catch — tested, not assumed

**#118.** Five `latf-load` archives emit exactly half their bases (74,941,800 vs 149,883,600 on DRR032355). I built this check and ran it against that archive specifically: **it passes.** `READ_LEN` and the decoded READ buffer agree with each other at 50 bases per spot — both are consistently half — so an internal-consistency check cannot see it.

That is worth stating because it bounds what this class of check buys. Self-consistency catches streams that disagree; it cannot catch a decode where everything agrees on the wrong answer. Only the run-level comparison against `STATS/TABLE/BASE_COUNT` — loader-recorded truth, not self-consistency — would flag #118, which makes it the more valuable of the two remaining items in #117.