### PR TITLE
fix(vdb): keep zero-length read slots in static READ_LEN (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Fixes
 
+- Keep zero-length read slots in the archive's static READ_LEN (#118).
+  `latf-load` archives declare `READ_LEN = [100, 0]` and carry no READ_LEN
+  column, but the metadata accessor discarded any descriptor containing a
+  zero. That sent them down the even-split heuristic, which cut every 100 bp
+  spot into 50/50 — emitting **half the run's bases** with no error and a zero
+  exit code. Five corpus accessions were affected; all now match
+  `fasterq-dump` byte for byte.
+
 - Check that a blob's spot boundaries consume exactly its decoded bases
   (#117). `READ_LEN` defines where each spot starts inside the sequence
   stream; the per-spot check saw only overrun, so a short accounting silently

--- a/crates/sracha-vdb/src/cursor.rs
+++ b/crates/sracha-vdb/src/cursor.rs
@@ -296,8 +296,16 @@ impl VdbCursor {
     /// non-zero length. Returns `None` if any length is 0 (variable/unknown).
     pub fn metadata_read_lengths(&self) -> Option<Vec<u32>> {
         let descs = self.metadata_read_descs.as_ref()?;
-        if descs.iter().all(|d| d.read_len > 0) {
-            Some(descs.iter().map(|d| d.read_len).collect())
+        let lens: Vec<u32> = descs.iter().map(|d| d.read_len).collect();
+        // A zero-length slot is legitimate: it marks a read the run does not
+        // use, and the decoder drops it like any other empty read. Rejecting
+        // the whole descriptor over one zero sent `latf-load` archives — whose
+        // static READ_LEN is `[100, 0]` — down the even-split heuristic, which
+        // cut every 100 bp spot into 50/50 and silently emitted half the run
+        // (#118). Only an all-zero descriptor is unusable, since it yields no
+        // spot length to divide by.
+        if lens.iter().any(|&l| l > 0) {
+            Some(lens)
         } else {
             None
         }
@@ -1376,6 +1384,41 @@ mod tests {
 
         assert_eq!(cursor.metadata_reads_per_spot(), Some(2));
         assert_eq!(cursor.metadata_read_lengths(), Some(vec![151, 151]));
+        let _ = std::fs::remove_file(&sra_path);
+    }
+
+    /// A zero-length read slot is legitimate — it marks a read the run does
+    /// not use, and the decoder drops it like any other empty read.
+    /// Discarding the whole descriptor over one zero sent `latf-load`
+    /// archives down the even-split heuristic, cutting every 100 bp spot into
+    /// 50/50 and silently emitting half the run (#118).
+    #[test]
+    fn metadata_read_lengths_keeps_a_zero_length_slot() {
+        let md = build_metadata_bytes(&[("READ_0", b"B|100|"), ("READ_1", b"B|0|")], None);
+        let archive_bytes = build_sra_archive_with_metadata(Some(&md));
+        let sra_path = write_temp_sra(&archive_bytes);
+        let mut archive = KarArchive::open(Cursor::new(archive_bytes)).unwrap();
+        let cursor = VdbCursor::open(&mut archive, &sra_path).unwrap();
+
+        assert_eq!(
+            cursor.metadata_read_lengths(),
+            Some(vec![100, 0]),
+            "the 100 bp read must survive its empty sibling"
+        );
+        let _ = std::fs::remove_file(&sra_path);
+    }
+
+    /// An all-zero descriptor still yields nothing: it gives no spot length
+    /// to divide by, so the caller has to fall back.
+    #[test]
+    fn metadata_read_lengths_rejects_an_all_zero_descriptor() {
+        let md = build_metadata_bytes(&[("READ_0", b"B|0|"), ("READ_1", b"B|0|")], None);
+        let archive_bytes = build_sra_archive_with_metadata(Some(&md));
+        let sra_path = write_temp_sra(&archive_bytes);
+        let mut archive = KarArchive::open(Cursor::new(archive_bytes)).unwrap();
+        let cursor = VdbCursor::open(&mut archive, &sra_path).unwrap();
+
+        assert_eq!(cursor.metadata_read_lengths(), None);
         let _ = std::fs::remove_file(&sra_path);
     }
 


### PR DESCRIPTION
Fixes #118.

## The bug

Five corpus accessions emitted **exactly half their bases**, silently, with a zero exit code:

```
DRR032355   fasterq-dump  149,883,600 bases
            sracha         74,941,800 bases
```

Every 100 bp spot arrived as a single 50 bp read:

```
sracha        @DRR032355.1 1 length=50
fasterq-dump  @DRR032355.1 1 length=100
```

## Root cause

They are `latf-load` archives on `NCBI:align:tbl:seq#1`. They carry **no READ_LEN column** and declare the layout statically:

```
col/READ_LEN/row   = [100, 0]
col/READ_START/row = [0, 100]
```

one 100-base read plus an unused second slot.

`metadata_read_lengths()` required *every* entry to be non-zero:

```rust
if descs.iter().all(|d| d.read_len > 0) { ... } else { None }
```

so that second slot discarded the whole descriptor. With no exact lengths available the decoder fell through to its heuristic, which divides the spot length evenly across `metadata_reads_per_spot` — `100 / 2 = 50` — and the second 50 bases were then dropped as a technical read.

A zero-length slot is not degenerate metadata. It marks a read the run does not use, and the decoder already drops empty reads downstream. Only an all-zero descriptor is genuinely unusable, since it gives no spot length to divide by, and that case still returns `None`.

## Verification

Against sra-tools 3.2.1, `--split-3`, full-file md5:

| archive | result |
|---|---|
| DRR032355 | matches fasterq-dump |
| DRR035457 | matches fasterq-dump |
| DRR035760 | matches fasterq-dump |
| DRR050631 | matches fasterq-dump |
| DRR032766 | matches fasterq-dump |

Eleven unaffected archives spanning Illumina, PacBio, Nanopore, cSRA and the accessions repaired earlier this week are **byte-unchanged**. 730 unit tests pass; clippy and `fmt` clean.

## Why the new strictness checks miss it

Worth stating, since #115 and #117 were added specifically to catch silent corruption: **neither detects this.** The static READ_LEN and the decoded buffer agree with each other at 50 bases per spot — there is nothing internally inconsistent to find. Only the run-level comparison against `STATS/TABLE/BASE_COUNT`, the remaining item in #117, would flag it, because it is anchored to loader-recorded truth rather than self-consistency.

## Provenance

Long-standing, not a regression. These were the only unexplained `STILL_BROKEN` rows in a 386-accession × 2-split A/B; every other failure resolved to a known cause.