### PR TITLE
feat(pipeline): verify decoded bases against the archive's BIO_BASE_COUNT (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Fixes
 
+- Verify decoded bases against the archive's recorded `BIO_BASE_COUNT` (#117).
+  Every other integrity check compares the decoder against itself, which
+  cannot see a decode where all streams agree on the wrong answer — #118
+  emitted half of five runs with static READ_LEN and the decoded buffer in
+  perfect agreement. The loader records how many biological bases a run holds;
+  comparing against it is the one check anchored outside the decode.
+  Strict-fatal.
+
 - Keep zero-length read slots in the archive's static READ_LEN (#118).
   `latf-load` archives declare `READ_LEN = [100, 0]` and carry no READ_LEN
   column, but the metadata accessor discarded any descriptor containing a

--- a/crates/sracha-core/src/fastq/mod.rs
+++ b/crates/sracha-core/src/fastq/mod.rs
@@ -48,6 +48,18 @@ pub struct IntegrityDiag {
     /// every record past the divergence carries bases from the wrong offsets.
     /// The per-spot check sees only overrun, never a short accounting.
     pub sequence_blob_length_mismatch: AtomicU64,
+    /// Biological bases seen by the decoder, before any user-facing filter.
+    ///
+    /// A tally rather than a violation count: compared at end of run against
+    /// the loader's `STATS/TABLE/BIO_BASE_COUNT`.
+    pub bio_bases_seen: AtomicU64,
+    /// Set when that comparison disagrees.
+    ///
+    /// The only check anchored to something outside the decode. Everything
+    /// else here verifies the decoder against itself, which cannot catch a
+    /// decode where every stream agrees on the wrong answer — #118 emitted
+    /// exactly half of five runs that way.
+    pub base_count_mismatch: AtomicU64,
     /// Blobs whose full quality payload was all-zero (SRA-lite style) and
     /// was replaced with a uniform Phred fallback.
     pub all_zero_quality_blobs: AtomicU64,
@@ -66,6 +78,7 @@ impl IntegrityDiag {
             || self.quality_overruns.load(Ordering::Relaxed) != 0
             || self.quality_blob_length_mismatch.load(Ordering::Relaxed) != 0
             || self.sequence_blob_length_mismatch.load(Ordering::Relaxed) != 0
+            || self.base_count_mismatch.load(Ordering::Relaxed) != 0
             || self.all_zero_quality_blobs.load(Ordering::Relaxed) != 0
             || self.paired_spot_violations.load(Ordering::Relaxed) != 0
             || self.truncated_spots.load(Ordering::Relaxed) != 0
@@ -82,6 +95,7 @@ impl IntegrityDiag {
             || self.quality_overruns.load(Ordering::Relaxed) != 0
             || self.quality_blob_length_mismatch.load(Ordering::Relaxed) != 0
             || self.sequence_blob_length_mismatch.load(Ordering::Relaxed) != 0
+            || self.base_count_mismatch.load(Ordering::Relaxed) != 0
             || self.paired_spot_violations.load(Ordering::Relaxed) != 0
     }
 
@@ -90,12 +104,14 @@ impl IntegrityDiag {
         format!(
             "quality_length_mismatches={}, quality_invalid_bytes={}, quality_overruns={}, \
              quality_blob_length_mismatch={}, sequence_blob_length_mismatch={}, \
-             all_zero_quality_blobs={}, paired_spot_violations={}, truncated_spots={}",
+             base_count_mismatch={}, all_zero_quality_blobs={}, \
+             paired_spot_violations={}, truncated_spots={}",
             self.quality_length_mismatches.load(Ordering::Relaxed),
             self.quality_invalid_bytes.load(Ordering::Relaxed),
             self.quality_overruns.load(Ordering::Relaxed),
             self.quality_blob_length_mismatch.load(Ordering::Relaxed),
             self.sequence_blob_length_mismatch.load(Ordering::Relaxed),
+            self.base_count_mismatch.load(Ordering::Relaxed),
             self.all_zero_quality_blobs.load(Ordering::Relaxed),
             self.paired_spot_violations.load(Ordering::Relaxed),
             self.truncated_spots.load(Ordering::Relaxed),
@@ -2089,5 +2105,28 @@ mod tests {
         d.all_zero_quality_blobs.fetch_add(1, Ordering::Relaxed);
         assert!(d.any(), "still reported");
         assert!(!d.any_strict_fatal(), "but must not fail a strict run");
+    }
+
+    /// The only counter anchored to something outside the decode. Every other
+    /// check verifies the decoder against itself, which cannot see a decode
+    /// where all streams agree on the wrong answer.
+    #[test]
+    fn base_count_mismatch_is_strict_fatal() {
+        let d = IntegrityDiag::default();
+        assert!(!d.any_strict_fatal());
+        d.base_count_mismatch.fetch_add(1, Ordering::Relaxed);
+        assert!(d.any(), "must be reported");
+        assert!(d.any_strict_fatal(), "and must fail a strict run");
+    }
+
+    /// `bio_bases_seen` is a tally, not a violation: a healthy run has a large
+    /// non-zero value and must still pass.
+    #[test]
+    fn bio_bases_seen_is_a_tally_not_a_violation() {
+        let d = IntegrityDiag::default();
+        d.bio_bases_seen.fetch_add(149_883_600, Ordering::Relaxed);
+        assert!(!d.any(), "a tally alone is not an integrity problem");
+        assert!(!d.any_strict_fatal());
+        assert!(d.summary().contains("base_count_mismatch=0"));
     }
 }

--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -1221,6 +1221,7 @@ pub(crate) fn decode_blob_to_fastq(
         biological: bool,
     }
     let mut segments: Vec<ReadSeg> = Vec::with_capacity(rps);
+    let mut bio_bases_in_blob: u64 = 0;
 
     while rl_cursor + rps <= read_lengths.len() {
         let spot_read_lengths = &read_lengths[rl_cursor..rl_cursor + rps];
@@ -1342,6 +1343,13 @@ pub(crate) fn decode_blob_to_fastq(
             }
 
             let biological = crate::fastq::read_is_biological(spot_read_types, i);
+            if biological {
+                // Tallied before the technical and min-length filters so the
+                // total is a property of the archive, not of the user's flags.
+                // Accumulated locally and published once per blob — an atomic
+                // per read would be contended across every rayon worker.
+                bio_bases_in_blob += rlen_usize as u64;
+            }
 
             // Filter: skip technical reads if configured.
             if config.skip_technical && !biological {
@@ -1501,6 +1509,11 @@ pub(crate) fn decode_blob_to_fastq(
              sequence stream",
             read_data.len(),
         );
+    }
+
+    if bio_bases_in_blob != 0 {
+        diag.bio_bases_seen
+            .fetch_add(bio_bases_in_blob, Ordering::Relaxed);
     }
 
     // Collect populated LUT entries in slot-index order, then overflow.

--- a/crates/sracha-core/src/pipeline/marker.rs
+++ b/crates/sracha-core/src/pipeline/marker.rs
@@ -117,6 +117,8 @@ pub(crate) fn write_stats_file(entry: StatsEntry<'_>) -> Result<()> {
             "sequence_blob_length_mismatch": diag
                 .sequence_blob_length_mismatch
                 .load(Ordering::Relaxed),
+            "base_count_mismatch": diag.base_count_mismatch.load(Ordering::Relaxed),
+            "bio_bases_seen": diag.bio_bases_seen.load(Ordering::Relaxed),
             "all_zero_quality_blobs": diag.all_zero_quality_blobs.load(Ordering::Relaxed),
             "paired_spot_violations": diag.paired_spot_violations.load(Ordering::Relaxed),
             "truncated_spots": diag.truncated_spots.load(Ordering::Relaxed),

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -588,6 +588,9 @@ fn decode_and_write(
     // Fallback per-read lengths (from VDB metadata or the NCBI EUtils API).
     // Only used when READ_LEN column is absent. Cloned once here so rayon
     // closures can borrow it without moving the config.
+    // Captured before the cursor is consumed; compared once the run ends.
+    let expected_bio_bases: Option<u64> = cursor.bio_base_count();
+
     let fallback_read_lengths: Option<Vec<u32>> = if !has_read_len {
         let picked = resolve_fallback_read_lengths(
             cursor.metadata_read_lengths(),
@@ -1068,6 +1071,23 @@ fn decode_and_write(
     if !config.stdout {
         for (final_path, tmp_path) in &output_paths {
             std::fs::rename(tmp_path, final_path).map_err(Error::Io)?;
+        }
+    }
+
+    // The one check anchored outside the decode. The loader recorded how many
+    // biological bases this run holds, so a conversion that quietly emits a
+    // fraction of them is visible even when every internal stream agrees with
+    // every other — #118 lost exactly half of five runs that way, with static
+    // READ_LEN and the decoded buffer in perfect agreement at 50 of 100 bases
+    // per spot.
+    if let Some(expected) = expected_bio_bases.filter(|&n| n > 0) {
+        let seen = diag.bio_bases_seen.load(Ordering::Relaxed);
+        if seen != expected {
+            diag.base_count_mismatch.fetch_add(1, Ordering::Relaxed);
+            tracing::warn!(
+                "{accession}: decoded {seen} biological bases but the archive \
+                 records {expected} (STATS/TABLE/BIO_BASE_COUNT)",
+            );
         }
     }
 

--- a/crates/sracha-vdb/src/cursor.rs
+++ b/crates/sracha-vdb/src/cursor.rs
@@ -64,6 +64,8 @@ pub struct VdbCursor {
     /// Read descriptors inferred from table metadata (used when READ_LEN
     /// column is absent, e.g. SRA-lite files).
     metadata_read_descs: Option<Vec<ReadDescriptor>>,
+    /// `STATS/TABLE/BIO_BASE_COUNT`, when the loader recorded one.
+    bio_base_count: Option<u64>,
     /// Sequencing platform detected from VDB schema metadata.
     platform: Option<String>,
     /// `true` when the metadata shows a `SOFTWARE/delite` node — the tell-tale
@@ -102,6 +104,7 @@ impl VdbCursor {
         // Parse table metadata (md/cur) to extract reads_per_spot and
         // platform for SRA-lite files that lack physical READ_LEN/NREADS columns.
         let (metadata_read_descs, platform) = Self::detect_metadata(archive, table);
+        let bio_base_count = read_stats_u64_from_archive(archive, "BIO_BASE_COUNT");
         let is_sra_lite = Self::detect_sra_lite(archive);
 
         // READ is required.
@@ -192,9 +195,20 @@ impl VdbCursor {
             first_row,
             row_count,
             metadata_read_descs,
+            bio_base_count,
             platform,
             is_sra_lite,
         })
+    }
+
+    /// Biological bases the loader recorded for this run
+    /// (`STATS/TABLE/BIO_BASE_COUNT`).
+    ///
+    /// Independent of anything the decoder computes, so it can be used to
+    /// confirm a conversion emitted the run it was given rather than a
+    /// self-consistent fraction of it.
+    pub fn bio_base_count(&self) -> Option<u64> {
+        self.bio_base_count
     }
 
     /// Total number of spots (rows) in the SEQUENCE table.
@@ -1040,10 +1054,18 @@ fn reject_if_csra<R: Read + Seek>(archive: &mut KarArchive<R>, seq_col_base: &st
 /// Scan table and database-level `md/cur` trees for `STATS/TABLE/CMP_BASE_COUNT`
 /// and return the first non-`None` value found.
 fn read_cmp_base_count_from_archive<R: Read + Seek>(archive: &mut KarArchive<R>) -> Option<u64> {
+    read_stats_u64_from_archive(archive, "CMP_BASE_COUNT")
+}
+
+/// Read a `STATS/TABLE/<name>` counter from either md/cur tree.
+fn read_stats_u64_from_archive<R: Read + Seek>(
+    archive: &mut KarArchive<R>,
+    name: &str,
+) -> Option<u64> {
     for path in ["tbl/SEQUENCE/md/cur", "md/cur"] {
         if let Ok(md_bytes) = archive.read_file(path)
             && md_bytes.len() >= 8
-            && let Some(n) = crate::metadata::read_cmp_base_count(&md_bytes[8..])
+            && let Some(n) = crate::metadata::read_stats_table_u64(&md_bytes[8..], name)
         {
             return Some(n);
         }

--- a/crates/sracha-vdb/src/metadata.rs
+++ b/crates/sracha-vdb/src/metadata.rs
@@ -192,17 +192,26 @@ pub fn is_aligned_database_schema(schema_name: &str) -> bool {
 /// - `None` — the node is absent (most non-cSRA runs), no signal either
 ///   way.
 pub fn read_cmp_base_count(tree_data: &[u8]) -> Option<u64> {
+    read_stats_table_u64(tree_data, "CMP_BASE_COUNT")
+}
+
+/// Read a `STATS/TABLE/<name>` u64 counter from a metadata tree.
+///
+/// The loader writes these when it builds the archive, so they are an
+/// independent record of what the run contains rather than something derived
+/// from the same decode being checked. `BASE_COUNT`, `BIO_BASE_COUNT` and
+/// `SPOT_COUNT` all live here.
+pub fn read_stats_table_u64(tree_data: &[u8], name: &str) -> Option<u64> {
     let nodes = parse_meta_nodes(tree_data).ok()?;
-    // STATS is a top-level node with nested children; we want STATS/TABLE/CMP_BASE_COUNT.
     fn find_child<'a>(parent: &'a [MetaNode], name: &str) -> Option<&'a MetaNode> {
         parent.iter().find(|n| n.name == name)
     }
     let stats = find_child(&nodes, "STATS")?;
     let table = find_child(&stats.children, "TABLE")?;
-    let cmp = find_child(&table.children, "CMP_BASE_COUNT")?;
-    if cmp.value.len() >= 8 {
+    let node = find_child(&table.children, name)?;
+    if node.value.len() >= 8 {
         let mut b = [0u8; 8];
-        b.copy_from_slice(&cmp.value[..8]);
+        b.copy_from_slice(&node.value[..8]);
         Some(u64::from_le_bytes(b))
     } else {
         None


### PR DESCRIPTION
Completes the remaining item in #117.

## Why self-consistency is not enough

Every integrity check sracha had compares the decoder against itself. That cannot see a decode where all the streams agree on the wrong answer — and twice this week they did.

**#118** is the clean demonstration: five runs emitted exactly half their bases, with the static `READ_LEN` and the decoded buffer agreeing perfectly at 50 of 100 bases per spot. Nothing was internally inconsistent, so nothing could be detected. Both #115 and #117's blob-level checks were already in place and both passed.

## The change

The loader records `STATS/TABLE/BIO_BASE_COUNT` when it builds the archive. It is independent of anything the decoder computes, so comparing against it catches a conversion that quietly emits a fraction of its input.

Biological bases are tallied as they are decoded — **before** the technical and minimum-length filters, so the total is a property of the archive rather than of the user's flags — and compared once at the end. `base_count_mismatch` is strict-fatal and appears in `stats.json` alongside `bio_bases_seen`.

The tally accumulates in a local and publishes **one atomic per blob**. A `fetch_add` per read would be contended across every rayon worker, which is exactly how the page-map rewrite in #101 cost 2.4x decode CPU before it was caught.

## Verified both directions

**Specific** — 10 archives spanning Illumina, PacBio, Nanopore, plus every accession repaired this week (DRR001816, DRR032355, DRR004435), all pass with no false positives.

**Sensitive** — with #118's one-line fix reverted, DRR032355 is refused:

```
Error: integrity check failed for DRR032355:
  quality_length_mismatches=0, quality_invalid_bytes=0, quality_overruns=0,
  quality_blob_length_mismatch=0, sequence_blob_length_mismatch=0,
  base_count_mismatch=1, all_zero_quality_blobs=0,
  paired_spot_violations=0, truncated_spots=0
```

Every other counter reads **0** — including both self-consistency checks added earlier this week — and only this one fires. That is the whole argument for external anchoring, stated by the tool itself.

732 unit tests pass; clippy and `fmt` clean.

## Scope

Applies when the archive records a non-zero `BIO_BASE_COUNT`; runs without it are unaffected. `STATS/QUALITY/PHRED_*` histogram verification — which would check quality *values* rather than counts — remains open in #117 and is the natural next step, though it costs an increment per base and likely belongs behind a flag.