### PR TITLE
feat(pipeline): verify the decoded spot count during conversion (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixes
 
+- Verify the decoded spot count against the SEQUENCE table's row count
+  (#117). `BIO_BASE_COUNT` cannot see a run that emits the right total bases
+  across the wrong number of spots — issue #22 was exactly that shape.
+  `sracha validate` has always made this comparison; the conversion path never
+  did. Strict-fatal.
+
 - Verify decoded bases against the archive's recorded `BIO_BASE_COUNT` (#117).
   Every other integrity check compares the decoder against itself, which
   cannot see a decode where all streams agree on the wrong answer — #118

--- a/crates/sracha-core/src/fastq/mod.rs
+++ b/crates/sracha-core/src/fastq/mod.rs
@@ -53,6 +53,13 @@ pub struct IntegrityDiag {
     /// A tally rather than a violation count: compared at end of run against
     /// the loader's `STATS/TABLE/BIO_BASE_COUNT`.
     pub bio_bases_seen: AtomicU64,
+    /// Set when the decoded spot count disagrees with the SEQUENCE table's
+    /// row count.
+    ///
+    /// `BIO_BASE_COUNT` alone cannot see this: a run emitting the right total
+    /// bases spread across the wrong number of spots passes it cleanly. Issue
+    /// #22 was exactly that shape — a spot undercount with plausible output.
+    pub spot_count_mismatch: AtomicU64,
     /// Set when that comparison disagrees.
     ///
     /// The only check anchored to something outside the decode. Everything
@@ -79,6 +86,7 @@ impl IntegrityDiag {
             || self.quality_blob_length_mismatch.load(Ordering::Relaxed) != 0
             || self.sequence_blob_length_mismatch.load(Ordering::Relaxed) != 0
             || self.base_count_mismatch.load(Ordering::Relaxed) != 0
+            || self.spot_count_mismatch.load(Ordering::Relaxed) != 0
             || self.all_zero_quality_blobs.load(Ordering::Relaxed) != 0
             || self.paired_spot_violations.load(Ordering::Relaxed) != 0
             || self.truncated_spots.load(Ordering::Relaxed) != 0
@@ -96,6 +104,7 @@ impl IntegrityDiag {
             || self.quality_blob_length_mismatch.load(Ordering::Relaxed) != 0
             || self.sequence_blob_length_mismatch.load(Ordering::Relaxed) != 0
             || self.base_count_mismatch.load(Ordering::Relaxed) != 0
+            || self.spot_count_mismatch.load(Ordering::Relaxed) != 0
             || self.paired_spot_violations.load(Ordering::Relaxed) != 0
     }
 
@@ -104,14 +113,16 @@ impl IntegrityDiag {
         format!(
             "quality_length_mismatches={}, quality_invalid_bytes={}, quality_overruns={}, \
              quality_blob_length_mismatch={}, sequence_blob_length_mismatch={}, \
-             base_count_mismatch={}, all_zero_quality_blobs={}, \
-             paired_spot_violations={}, truncated_spots={}",
+             base_count_mismatch={}, spot_count_mismatch={}, \
+             all_zero_quality_blobs={}, paired_spot_violations={}, \
+             truncated_spots={}",
             self.quality_length_mismatches.load(Ordering::Relaxed),
             self.quality_invalid_bytes.load(Ordering::Relaxed),
             self.quality_overruns.load(Ordering::Relaxed),
             self.quality_blob_length_mismatch.load(Ordering::Relaxed),
             self.sequence_blob_length_mismatch.load(Ordering::Relaxed),
             self.base_count_mismatch.load(Ordering::Relaxed),
+            self.spot_count_mismatch.load(Ordering::Relaxed),
             self.all_zero_quality_blobs.load(Ordering::Relaxed),
             self.paired_spot_violations.load(Ordering::Relaxed),
             self.truncated_spots.load(Ordering::Relaxed),
@@ -2128,5 +2139,37 @@ mod tests {
         assert!(!d.any(), "a tally alone is not an integrity problem");
         assert!(!d.any_strict_fatal());
         assert!(d.summary().contains("base_count_mismatch=0"));
+    }
+
+    /// A spot undercount is invisible to the base-count check when the bases
+    /// happen to total correctly, so it needs its own counter — issue #22 was
+    /// exactly that shape.
+    #[test]
+    fn spot_count_mismatch_is_strict_fatal() {
+        let d = IntegrityDiag::default();
+        assert!(!d.any_strict_fatal());
+        d.spot_count_mismatch.fetch_add(1, Ordering::Relaxed);
+        assert!(d.any(), "must be reported");
+        assert!(d.any_strict_fatal(), "and must fail a strict run");
+        assert!(d.summary().contains("spot_count_mismatch=1"));
+    }
+
+    /// The two external anchors are independent: bases can total correctly
+    /// while the spot count is wrong, and vice versa.
+    #[test]
+    fn base_and_spot_anchors_are_independent() {
+        let bases_only = IntegrityDiag::default();
+        bases_only
+            .base_count_mismatch
+            .fetch_add(1, Ordering::Relaxed);
+        assert!(bases_only.any_strict_fatal());
+        assert_eq!(bases_only.spot_count_mismatch.load(Ordering::Relaxed), 0);
+
+        let spots_only = IntegrityDiag::default();
+        spots_only
+            .spot_count_mismatch
+            .fetch_add(1, Ordering::Relaxed);
+        assert!(spots_only.any_strict_fatal());
+        assert_eq!(spots_only.base_count_mismatch.load(Ordering::Relaxed), 0);
     }
 }

--- a/crates/sracha-core/src/pipeline/marker.rs
+++ b/crates/sracha-core/src/pipeline/marker.rs
@@ -118,6 +118,7 @@ pub(crate) fn write_stats_file(entry: StatsEntry<'_>) -> Result<()> {
                 .sequence_blob_length_mismatch
                 .load(Ordering::Relaxed),
             "base_count_mismatch": diag.base_count_mismatch.load(Ordering::Relaxed),
+            "spot_count_mismatch": diag.spot_count_mismatch.load(Ordering::Relaxed),
             "bio_bases_seen": diag.bio_bases_seen.load(Ordering::Relaxed),
             "all_zero_quality_blobs": diag.all_zero_quality_blobs.load(Ordering::Relaxed),
             "paired_spot_violations": diag.paired_spot_violations.load(Ordering::Relaxed),

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -590,6 +590,7 @@ fn decode_and_write(
     // closures can borrow it without moving the config.
     // Captured before the cursor is consumed; compared once the run ends.
     let expected_bio_bases: Option<u64> = cursor.bio_base_count();
+    let expected_spots: u64 = cursor.spot_count();
 
     let fallback_read_lengths: Option<Vec<u32>> = if !has_read_len {
         let picked = resolve_fallback_read_lengths(
@@ -1089,6 +1090,18 @@ fn decode_and_write(
                  records {expected} (STATS/TABLE/BIO_BASE_COUNT)",
             );
         }
+    }
+
+    // Spot count is the other half of the external anchor. `BIO_BASE_COUNT`
+    // cannot see a run that emits the right total bases across the wrong
+    // number of spots — issue #22 was exactly that. `sracha validate` has
+    // always compared these; the conversion path never did.
+    if expected_spots > 0 && total_spots != expected_spots {
+        diag.spot_count_mismatch.fetch_add(1, Ordering::Relaxed);
+        tracing::warn!(
+            "{accession}: decoded {total_spots} spots but the SEQUENCE table \
+             holds {expected_spots} rows",
+        );
     }
 
     Ok((total_spots, reads_written, final_paths))


### PR DESCRIPTION
The second external anchor, alongside the base count from #121. Addresses item 3 of #117.

## Why base count alone is not enough

Bases totalling correctly does not mean the spots are right. A run can emit the expected number of bases spread across the wrong number of spots and pass every check we have — **issue #22 was exactly that shape**, a spot undercount with plausible-looking output.

## The gap

`sracha validate` has always compared the decoded spot count against the SEQUENCE table's row count:

```rust
if expected_spots > 0 && decoded_spots != expected_spots {
    errors.push(format!("spot count mismatch: metadata says {expected_spots}, decoded {decoded_spots}"));
}
```

The **conversion** path — the one that actually writes files people keep — never did.

## Why this is the cheapest and safest of the checks added this week

Unlike #115, #117 and #121, this introduces no new invariant. The tally already exists, the row count is already read, and the comparison is already proven in another code path: `sracha validate` reports `ok` on every archive I tested, including the two most pathological ones repaired today (DRR032355 and DRR001816). This wires a working invariant into the path that was missing it.

## Verified

- **12 archives** spanning Illumina, PacBio, Nanopore and cSRA, plus every accession repaired this week — all pass.
- **35-accession distilled corpus A/B** against current `main`: 52 UNCHANGED, **0 REGRESSED**, remainder the expected legacy-platform / cSRA / SOLiD refusals. No output changes, since this only adds a check.
- 734 unit tests pass; clippy and `fmt` clean.

## Remaining in #117

`STATS/QUALITY/PHRED_*` histogram verification — the only proposal that checks quality *values* rather than counts. It costs an increment per base and its accounting against `--skip-technical` / `--min-read-len` needs establishing from a known-good archive, so it wants a deliberate pass rather than being tacked onto a release. Also still open: whether `truncated_spots` should stay non-fatal, which needs a corpus measurement first (#108 territory).