### PR TITLE
fix(pipeline): decline ABI SOLiD by platform, not by KAR layout (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Fixes
 
+- Decline ABI SOLiD archives by name instead of blaming the KAR layout
+  (#109). SOLiD keeps colorspace bases in `CSREAD`/`ALTCSREAD` and has no
+  `READ` column, so the cursor's column probe failed before the platform check
+  ran and reported "SEQUENCE table not found in KAR archive" — pointing users
+  at a corrupt file or a bad download rather than at an encoding sracha does
+  not decode. The platform now comes from `md/cur` before any column opens, so
+  SOLiD gets the same message as the other legacy platforms.
+
 - Verify the decoded spot count against the SEQUENCE table's row count
   (#117). `BIO_BASE_COUNT` cannot see a run that emits the right total bases
   across the wrong number of spots — issue #22 was exactly that shape.

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -398,16 +398,24 @@ fn decode_and_write(
     if table != "SEQUENCE" {
         tracing::info!("{accession}: reading reads from {table} table");
     }
-    let cursor = VdbCursor::open_table(&mut archive, sra_path, table)?;
-
     // Check platform — reject legacy platforms with complex read structures.
-    if let Some(platform) = cursor.platform()
-        && is_unsupported_platform(platform)
+    //
+    // This runs before the cursor opens, not after. The cursor requires a
+    // physical READ column, and ABI SOLiD archives have none: colorspace
+    // reads live in CSREAD/ALTCSREAD. Checking after the open meant SOLiD
+    // runs died in the column probe with "SEQUENCE table not found in KAR
+    // archive", telling the user their file was broken when it was merely
+    // an encoding sracha declines (issue #109). The platform lives in
+    // `md/cur`, which every archive carries, so asking first costs one
+    // small metadata read and gives every declined platform the same
+    // message.
+    if let Some(platform) = crate::vdb::cursor::archive_platform(&mut archive, table)
+        && is_unsupported_platform(&platform)
     {
-        return Err(Error::UnsupportedPlatform {
-            platform: platform.to_string(),
-        });
+        return Err(Error::UnsupportedPlatform { platform });
     }
+
+    let cursor = VdbCursor::open_table(&mut archive, sra_path, table)?;
 
     // Detect SRA-lite from actual file: the QUALITY column is absent
     // (classic variant) or the VDB metadata carries the `SOFTWARE/delite`

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -177,6 +177,40 @@ fn ensure_srr000001() -> PathBuf {
     path
 }
 
+/// Ensure the DRR010063 fixture (ABI SOLiD / AB 5500xl, 27 MiB).
+///
+/// The only colorspace shape in the validation corpus: a flat table whose
+/// columns are `ALTCSREAD CSREAD QUALITY X Y` — no `READ` at all. Covers
+/// issue #109, where the missing READ column made the cursor blame the KAR
+/// layout instead of the platform.
+fn ensure_drr010063() -> PathBuf {
+    static DOWNLOAD: Once = Once::new();
+    let path = fixtures_dir().join("DRR010063.sra");
+
+    DOWNLOAD.call_once(|| {
+        if path.exists() {
+            return;
+        }
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let url = "https://sra-pub-run-odp.s3.amazonaws.com/sra/DRR010063/DRR010063";
+        eprintln!("downloading DRR010063 fixture from {url} ...");
+
+        let resp = reqwest::blocking::get(url)
+            .unwrap_or_else(|e| panic!("failed to download DRR010063: {e}"));
+        assert!(
+            resp.status().is_success(),
+            "HTTP {} downloading DRR010063 fixture",
+            resp.status()
+        );
+        let bytes = resp.bytes().unwrap();
+        std::fs::write(&path, &bytes).unwrap();
+    });
+
+    assert!(path.exists(), "fixture not found at {}", path.display());
+    path
+}
+
 /// Ensure the VDB-3418 fixture (BAM-loaded cSRA, 12 MiB, 985 SEQUENCE /
 /// 938 PRIMARY_ALIGNMENT rows; schema `NCBI:align:db:alignment_sorted#1.3`).
 ///
@@ -1507,6 +1541,35 @@ fn ls454_platform_is_rejected_end_to_end() {
         "no FASTQ output should be written for rejected platform, found: {:?}",
         files.iter().map(|e| e.file_name()).collect::<Vec<_>>(),
     );
+}
+
+#[ignore]
+#[test]
+fn abi_solid_platform_is_rejected_end_to_end() {
+    // Issue #109: ABI SOLiD stores colorspace bases in CSREAD/ALTCSREAD and
+    // has no READ column, so the cursor's column probe used to fail before
+    // the platform check ran and reported "SEQUENCE table not found in KAR
+    // archive" — a corruption claim about a perfectly good file. DRR010063
+    // is a flat table (no `tbl/` wrapper), which is also the layout where the
+    // platform has to come from the root `md/cur`.
+    let sra_path = ensure_drr010063();
+    let tmp = tempfile::tempdir().unwrap();
+    let config = test_config(tmp.path(), SplitMode::SplitFiles, CompressionMode::None);
+
+    let result = sracha_core::pipeline::run_fastq(&sra_path, Some("DRR010063"), &config);
+    match result {
+        Err(sracha_core::error::Error::UnsupportedPlatform { platform }) => {
+            assert_eq!(
+                platform, "ABI_SOLID",
+                "expected ABI_SOLID rejection, got {platform}",
+            );
+        }
+        Ok(stats) => panic!(
+            "ABI SOLiD must be rejected, but decode succeeded with {} spots",
+            stats.spots_read,
+        ),
+        Err(e) => panic!("unexpected non-UnsupportedPlatform error: {e}"),
+    }
 }
 
 #[ignore]

--- a/crates/sracha-vdb/src/cursor.rs
+++ b/crates/sracha-vdb/src/cursor.rs
@@ -696,11 +696,7 @@ impl VdbCursor {
             archive: &mut KarArchive<R>,
             path: &str,
         ) -> Option<(Option<Vec<ReadDescriptor>>, Option<String>)> {
-            let md_bytes = archive.read_file(path).ok()?;
-            if md_bytes.len() < 8 {
-                return None;
-            }
-            let tree_data = md_bytes[8..].to_vec();
+            let tree_data = md_tree_data(archive, path)?;
             let rps = match crate::metadata::parse_read_structure(&tree_data) {
                 Ok(descs) => Some(descs),
                 Err(e) => {
@@ -962,6 +958,44 @@ fn find_table_col_base<R: Read + Seek>(archive: &KarArchive<R>, table: &str) -> 
 /// SEQUENCE (`insp_db_type()`). Used by the pipeline to pick the table.
 pub fn archive_has_consensus_table<R: Read + Seek>(archive: &KarArchive<R>) -> bool {
     find_table_col_base(archive, "CONSENSUS").is_ok()
+}
+
+/// Read an `md/cur` metadata blob and strip the 8-byte KDB header, leaving
+/// the PBSTree node data that the [`crate::metadata`] parsers expect.
+fn md_tree_data<R: Read + Seek>(archive: &mut KarArchive<R>, path: &str) -> Option<Vec<u8>> {
+    let md_bytes = archive.read_file(path).ok()?;
+    if md_bytes.len() < 8 {
+        return None;
+    }
+    Some(md_bytes[8..].to_vec())
+}
+
+/// Read the run's sequencing platform from VDB metadata alone, without
+/// opening a single column.
+///
+/// [`VdbCursor::open_table`] requires a physical `READ` column, so a caller
+/// that learns the platform from a live cursor cannot learn it at all for
+/// archives that keep their bases somewhere else. ABI SOLiD is exactly that
+/// shape: colorspace reads live in `CSREAD`/`ALTCSREAD` and there is no
+/// `READ`, so the column probe fails first and the user is told the SEQUENCE
+/// table is missing — a claim about file integrity, when the file is fine and
+/// merely encoded in a way sracha does not decode (issue #109). Callers that
+/// decline runs on platform grounds must therefore ask *before* they open the
+/// cursor.
+///
+/// Looks in the table's own `md/cur` first, then the database-level one,
+/// matching the precedence [`VdbCursor`] uses for its own platform field, and
+/// works for flat tables (no `tbl/` wrapper) because the root `md/cur` is
+/// where they keep it.
+pub fn archive_platform<R: Read + Seek>(
+    archive: &mut KarArchive<R>,
+    table: &str,
+) -> Option<String> {
+    md_tree_data(archive, &format!("tbl/{table}/md/cur"))
+        .and_then(|tree| crate::metadata::detect_platform(&tree))
+        .or_else(|| {
+            md_tree_data(archive, "md/cur").and_then(|tree| crate::metadata::detect_platform(&tree))
+        })
 }
 
 /// Reject archives that need ncbi-vdb's schema-aware virtual cursor.
@@ -1505,6 +1539,66 @@ mod tests {
         let cursor = VdbCursor::open(&mut archive, &sra_path).unwrap();
 
         assert_eq!(cursor.platform(), Some("ILLUMINA"));
+        let _ = std::fs::remove_file(&sra_path);
+    }
+
+    /// Build a flat (non-database) colorspace archive: a root-level `col/`
+    /// holding only `CSREAD`, plus a root `md/cur`. This is the ABI SOLiD
+    /// shape (DRR010063) — the bases are colorspace and there is no `READ`
+    /// column anywhere in the archive.
+    fn build_flat_colorspace_archive(md_bytes: &[u8]) -> Vec<u8> {
+        let col_data = b"01230";
+        let idx1 = build_idx1_v1(col_data.len() as u64, 1, 0);
+        let idx0 = build_kdb_blob_loc(0, 5, 1, 1);
+
+        let mut data_section = Vec::new();
+        let idx1_off = 0u64;
+        data_section.extend_from_slice(&idx1);
+        let idx0_off = data_section.len() as u64;
+        data_section.extend_from_slice(&idx0);
+        let data_off = data_section.len() as u64;
+        data_section.extend_from_slice(col_data);
+        let md_off = data_section.len() as u64;
+        data_section.extend_from_slice(md_bytes);
+
+        let idx1_node = build_file_node("idx1", idx1_off, idx1.len() as u64);
+        let idx0_node = build_file_node("idx0", idx0_off, idx0.len() as u64);
+        let data_node = build_file_node("data", data_off, col_data.len() as u64);
+
+        let csread_dir = build_dir_node("CSREAD", &[&data_node, &idx0_node, &idx1_node]);
+        let col_dir = build_dir_node("col", &[&csread_dir]);
+        let md_file = build_file_node("cur", md_off, md_bytes.len() as u64);
+        let md_dir = build_dir_node("md", &[&md_file]);
+
+        build_kar_archive(&[&col_dir, &md_dir], &data_section)
+    }
+
+    /// Issue #109: a colorspace archive's platform must be readable without
+    /// opening a column, because the column probe can never succeed on one.
+    #[test]
+    fn archive_platform_reads_colorspace_archive_without_a_read_column() {
+        let md = build_metadata_bytes(&[], Some(b"NCBI:SRA:ABI:tbl:v2#1.0.4"));
+        let archive_bytes = build_flat_colorspace_archive(&md);
+        let sra_path = write_temp_sra(&archive_bytes);
+        let mut archive = KarArchive::open(Cursor::new(archive_bytes)).unwrap();
+
+        assert_eq!(
+            archive_platform(&mut archive, "SEQUENCE").as_deref(),
+            Some("ABI_SOLID"),
+            "platform must come from md/cur, which needs no column",
+        );
+
+        // And the reason it has to: opening the cursor on the same archive
+        // fails in the column probe, blaming the KAR layout for what is
+        // really an encoding sracha declines. Callers must ask about the
+        // platform before they get here.
+        let Err(err) = VdbCursor::open(&mut archive, &sra_path) else {
+            panic!("a colorspace archive has no READ column, so the cursor cannot open");
+        };
+        assert!(
+            err.to_string().contains("table not found"),
+            "expected the column-probe failure this check pre-empts, got: {err}",
+        );
         let _ = std::fs::remove_file(&sra_path);
     }
 


### PR DESCRIPTION
## The bug

`sracha fastq` on an ABI SOLiD archive reported a corrupt container:

```
$ sracha fastq DRR010063.sra --split split-files -O out
Error: VDB format error: SEQUENCE table not found in KAR archive
       (tried database and flat-table layouts)
```

The archive is fine. Declining it is correct — sracha refuses legacy
platforms — but the message named the container instead of the encoding, so
it read as file corruption or a bad download.

## Root cause

SOLiD is colorspace: `abi-load` writes the bases to `CSREAD`/`ALTCSREAD` and
there is no `READ` column at all. `sracha vdb columns DRR010063.sra` returns
`ALTCSREAD CSREAD QUALITY X Y`.

The platform check that already refuses LS454 / ION_TORRENT / CAPILLARY /
HELICOS ran one line *after* `VdbCursor::open_table`, reading `cursor.platform()`
off a cursor that can only exist once `READ` has been found. For every other
legacy platform that ordering is invisible — they all have a `READ` column, so
the cursor opens and the check fires. SOLiD is the one shape where the probe
that has to succeed first cannot succeed at all, so the column lookup failed
and reported a missing table.

## The fix

Ask before opening. The platform lives in `md/cur`, which every archive
carries and which needs no column, so a new `cursor::archive_platform` reads
it from there — table-level `md/cur` first, then database-level, matching the
precedence `VdbCursor` uses for its own platform field. That fallback is also
what makes it work on a flat table like DRR010063, where the root `md/cur` is
the only one there is. `decode_and_write` now consults it before
`VdbCursor::open_table`.

## Verification

Debug build, run against the archive from the issue and the platforms that
must not have changed:

| archive | result |
| --- | --- |
| DRR010063 (AB 5500xl) | before: `VDB format error: SEQUENCE table not found in KAR archive (tried database and flat-table layouts)`, exit 1<br>after: `Error: unsupported platform: ABI_SOLID — sracha does not support legacy sequencing platforms`, exit 1, no output directory created |
| SRR000001 (454) | `Error: unsupported platform: LS454 — sracha does not support legacy sequencing platforms`, exit 1 — unchanged |
| SRR33907345 | 305,571 spots / 611,142 reads, exit 0 |
| SRR28588231 | 66,220 spots / 132,440 reads, exit 0 |
| SRR38892122 | 1,828 spots / 1,828 reads, exit 0 — a CONSENSUS-table run, so it also covers passing a non-SEQUENCE table name through the new lookup |

`cargo nextest run --workspace`: 736 passed. `cargo clippy --all-targets
--all-features -- -D warnings`: clean. `cargo fmt --all -- --check`: clean.

Tests added:

- `sracha-vdb cursor::tests::archive_platform_reads_colorspace_archive_without_a_read_column`
  (runs by default) builds a synthetic flat colorspace archive and asserts
  both halves of the fix — the platform is readable from metadata alone, and
  the cursor on that same archive still fails in the column probe, which is
  why the question has to be asked first.
- `sracha-core::pipeline abi_solid_platform_is_rejected_end_to_end`
  (`#[ignore]`d, fetches the real DRR010063) mirrors the existing LS454 test.
  Run manually: passes. The LS454 one still passes too.

Long-standing, not a regression. Found by the validation corpus, where
DRR010063 came back `REJECTED_BOTH` rather than the `REJECT_PLATFORM` the
harness recognises for the other legacy platforms.

Fixes #109
