### PR TITLE
release: 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ open an issue with the accession.
 ### Validation
 
 A 386-accession x 2-split A/B against 0.4.2, with `fasterq-dump` as reference:
-609 rows unchanged, 145 fixed, **1 regression** — a false positive in the new
+611 rows unchanged, 145 fixed, **1 regression** — a false positive in the new
 base-count check on PacBio archives with a CONSENSUS table, fixed before
 release. Every other new check held across the full breadth.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,60 @@
 # Changelog
 
-## Unreleased
+## 0.5.0 (2026-08-02)
+
+### Upgrade note
+
+Three things change. The first two affect output; the third affects whether a
+run succeeds at all.
+
+**1. `--split-files` filenames change for single-read runs.** Archives storing
+one read per spot now produce `ACC.fastq`, matching `fasterq-dump`, where
+earlier releases produced `ACC_1.fastq`. Read content is unchanged, and
+`--split-3` / `--split-spot` already matched.
+
+This is the widest-reaching change: **123 of 386** accessions in a random SRA
+sample are single-layout, so roughly a third of `--split-files` conversions
+produce a differently-named file, and a pipeline globbing `${ACC}_1.fastq`
+will find nothing. Runs with two or more *stored* reads are unaffected,
+including when only one survives filtering — DRR004435, whose 2 bp adapter is
+dropped, still writes `DRR004435_2.fastq`.
+
+**2. Output content changes on some archives. Re-convert anything you hold
+that was produced by 0.4.2 or earlier from these classes.**
+
+| class | symptom before | accessions |
+|---|---|---|
+| `latf-load` on `NCBI:align:tbl:seq#1` | **half of all bases missing** | 5 |
+| srf-load-era Illumina (`izip` quality) | every quality byte wrong | 4 |
+| `q4` Illumina schema (4-channel log-odds) | every quality byte wrong | 1 |
+| deduplicated ALTREAD page maps | `N` emitted as a confident basecall | 2 |
+
+**12 of 386** sampled accessions (~3%) are affected, concentrated in older DDBJ
+(`DRR`) submissions; modern Illumina runs are not. All four classes produced
+correct spot counts, correct read names and a zero exit code, so nothing
+downstream would have flagged them.
+
+`sracha vdb dump -C READ` output also changes: it now applies the ALTREAD
+ambiguity mask and so matches `vdb-dump` rather than showing the physical
+column.
+
+**3. Strict integrity checking can now refuse archives it previously
+converted.** Five new checks compare the decode against itself and against the
+archive's own recorded totals, and they are fatal under the default strict
+mode. An archive whose decode is wrong in a way sracha cannot fix now fails
+instead of writing plausible-looking output. `--no-strict` restores the
+previous behaviour and downgrades every counter to a warning.
+
+This is deliberate: refusing to convert is recoverable, silently wrong data in
+a published dataset is not. If you hit a refusal on an archive you need, please
+open an issue with the accession.
+
+### Validation
+
+A 386-accession x 2-split A/B against 0.4.2, with `fasterq-dump` as reference:
+609 rows unchanged, 145 fixed, **1 regression** — a false positive in the new
+base-count check on PacBio archives with a CONSENSUS table, fixed before
+release. Every other new check held across the full breadth.
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "sracha"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "sracha-core"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "sracha-vdb"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "byteorder",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/sracha", "crates/sracha-core", "crates/sracha-vdb"]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.95"
 repository = "https://github.com/rnabioco/sracha-rs"


### PR DESCRIPTION
Version bump and release notes for 0.5.0. No code changes — `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md` only.

## What is in it

Four silent-corruption bugs fixed, all sharing a signature: correct sequences, correct spot counts, correct read names, zero exit code, wrong data.

| | |
|---|---|
| #101 | page maps read `data_offset[]` as repeat counts |
| #111 | srf-load-era `izip` quality decoded through the wrong codec |
| #113 | `q4` 4-channel log-odds quality never decoded |
| #118 | `latf-load` archives emitted **half their bases** |

Plus five integrity checks (#115, #117, #121, #122), the `--split-files` naming fix (#103), the `vdb dump` ALTREAD mask (#104), the ABI SOLiD error message (#109), and a distilled 36-archive validation corpus.

## Validation

386-accession × 2-split A/B against 0.4.2 with `fasterq-dump` as reference: **609 unchanged, 145 fixed, 1 regression** — a false positive in the new base-count check on PacBio archives with a CONSENSUS table, which that run found and #123 fixed.

`main` has moved twice since that corpus ran (#123, #125). Neither changes conversion output — #123 rescopes a metadata lookup, #125 reorders a refusal check — and I confirmed byte-identical output for both across Illumina, PacBio, Nanopore and cSRA archives. So the corpus result transfers, but it did not run against this exact commit.

## Deliberately not included

#124 (quality-value verification against `STATS/QUALITY`) and #107/#108 (corpus `vdb dump` coverage and cost tracking) are in flight for 0.5.1. #124 adds another strict-fatal check, and the last one of those had a false positive that only a full corpus run caught — it should get the same treatment before shipping rather than riding along here.