### PR TITLE
feat(validation): add a vdb-dump leg and per-accession cost to ab_corpus.sh (#107, #108)

### DIFF
--- a/validation/ab_corpus.sh
+++ b/validation/ab_corpus.sh
@@ -16,6 +16,30 @@
 #   REGRESSED    baseline agreed with fasterq-dump, candidate does not
 #   STILL_BROKEN neither agrees with fasterq-dump
 #
+# Three legs, selected with --legs (default: fastq,dump):
+#
+#   fastq  the three-way FASTQ diff above; one row per --splits entry
+#   dump   `sracha vdb dump` for a pinned row window, per column, against
+#          `vdb-dump` on the same rows (#107). Recorded as split `vdb-dump`,
+#          same verdict vocabulary. This is the only leg that reaches cSRA
+#          and the legacy platforms, which `sracha fastq` refuses outright.
+#          On by default: it measured ~15 s wall and ~2 s CPU per accession
+#          on local archives, against minutes for a full decode, and a check
+#          that has to be opted into is the check #104 walked past. Drop it
+#          with --legs fastq (or --no-fasterq, which says there is no
+#          sra-tools here and takes vdb-dump with it).
+#   probe  a short prefix decode timed for cost only (#108). Recorded as
+#          split `cost-probe`, verdicts COST_OK / SLOWER / FASTER. Off by
+#          default: the fastq leg's own timings are free, since both binaries
+#          have to run anyway, and answer the same question for any run that
+#          is doing the FASTQ diff. The probe earns its keep as `--legs probe`
+#          -- a cost-only sweep that skips the diff entirely.
+#
+# The fastq and probe legs are timed with /usr/bin/time and the wall/user/sys
+# of each invocation lands in results.tsv. Compare CPU (user+sys), never wall:
+# on a shared cluster the same binary on the same archive varies ~2x in wall
+# purely from load, while CPU repeats to within a few percent.
+#
 # Usage:
 #   # build the two binaries first (they cannot both live at target/release)
 #   git worktree add /tmp/sracha-base main
@@ -27,7 +51,21 @@
 #       --candidate target/release/sracha \
 #       -a hits.txt
 #
+#   # cheap cost-only sweep: no FASTQ diff, ~20 s of decode per accession
+#   bash validation/ab_corpus.sh --legs probe --sra-dir /path/to/archives \
+#       --baseline OLD --candidate NEW -a hits.txt
+#
 #   bash validation/ab_corpus.sh --summary --resume-dir DIR
+#
+# Options beyond the originals:
+#   --legs L1,L2       legs to run (default fastq,dump)
+#   --sra-dir D1:D2    use DIR/<acc>.sra if present instead of fetching
+#   --dump-rows N      rows in the dump window (default 300)
+#   --dump-columns C   columns the dump leg compares
+#   --dump-table T     table to dump from (default: the archive's default)
+#   --probe-bytes N    output bytes the cost probe decodes (default 200000000)
+#   --cost-threshold R flag a row above this candidate/baseline CPU ratio (1.20)
+#   --cost-min-delta S ...and only when the absolute gap exceeds S seconds (0.5)
 #
 # Results: validation/ab-corpus-results/<YYYYMMDD-HHMMSS>/
 #   accessions.txt, results.tsv, logs/<ACC>.<split>.log (non-UNCHANGED only)
@@ -52,6 +90,27 @@ TMP=""
 PARTITION="rna"
 JOB_NAME="sracha-ab-corpus"
 WORK_DIR=""
+LEGS="fastq,dump"
+SRA_DIRS=""
+DUMP_ROWS=300
+# Columns whose sracha and vdb-dump renderings can be reconciled exactly --
+# see canon_sracha/canon_vdbdump for the per-column normalisation, which was
+# established by running both tools rather than reasoning about the schema.
+# ALTREAD and CSREAD are deliberately absent: vdb-dump does not expose them as
+# readable columns, and sracha renders them as raw hex. ALTREAD is still
+# covered, indirectly and more usefully, through READ -- folding its N-mask
+# into the basecalls is exactly what #104 got wrong.
+DUMP_COLUMNS="READ,QUALITY,X,Y,READ_LEN,READ_START,SPOT_GROUP,RD_FILTER,SPOT_FILTER"
+DUMP_TABLE=""
+PROBE_BYTES=200000000
+COST_THRESHOLD=1.20
+# Absolute floor beneath the ratio, calibrated against a run of the same
+# binary against itself: the worst same-binary CPU gap over 22 timed rows was
+# 0.36 s, so 0.5 s clears the measured noise with headroom while still
+# flagging a 2x regression on an archive that decodes in a second. It has to
+# be an absolute gap and not a ratio alone -- a 0.05 s archive that takes
+# 0.07 s is a 1.4x ratio and means nothing.
+COST_MIN_DELTA=0.5
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -59,6 +118,14 @@ while [[ $# -gt 0 ]]; do
         --candidate) CANDIDATE="$2"; shift 2 ;;
         -a|--accessions) ACCESSIONS_FILE="$2"; shift 2 ;;
         --splits) SPLITS="$2"; shift 2 ;;
+        --legs) LEGS="$2"; shift 2 ;;
+        --sra-dir) SRA_DIRS="$2"; shift 2 ;;
+        --dump-rows) DUMP_ROWS="$2"; shift 2 ;;
+        --dump-columns) DUMP_COLUMNS="$2"; shift 2 ;;
+        --dump-table) DUMP_TABLE="$2"; shift 2 ;;
+        --probe-bytes) PROBE_BYTES="$2"; shift 2 ;;
+        --cost-threshold) COST_THRESHOLD="$2"; shift 2 ;;
+        --cost-min-delta) COST_MIN_DELTA="$2"; shift 2 ;;
         --timeout) TIMEOUT_MIN="$2"; shift 2 ;;
         --resume-dir) RESUME_DIR="$2"; shift 2 ;;
         --sbatch) SBATCH_SUBMIT=1; shift ;;
@@ -71,10 +138,21 @@ while [[ $# -gt 0 ]]; do
         --tmp) TMP="$2"; shift 2 ;;
         --partition) PARTITION="$2"; shift 2 ;;
         --work-dir) WORK_DIR="$2"; shift 2 ;;
-        -h|--help) sed -n '3,32p' "$0"; exit 0 ;;
+        -h|--help) sed -n '3,71p' "$0"; exit 0 ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
     esac
 done
+
+leg_enabled() { [[ ",$LEGS," == *",$1,"* ]]; }
+RUN_FASTQ_LEG=0; leg_enabled fastq && RUN_FASTQ_LEG=1
+RUN_DUMP_LEG=0;  leg_enabled dump  && RUN_DUMP_LEG=1
+RUN_PROBE_LEG=0; leg_enabled probe && RUN_PROBE_LEG=1
+if (( ! RUN_FASTQ_LEG && ! RUN_DUMP_LEG && ! RUN_PROBE_LEG )); then
+    echo "--legs '$LEGS' selects nothing; valid legs: fastq, dump, probe" >&2; exit 2
+fi
+# The dump leg's reference is vdb-dump, which ships with fasterq-dump. Asking
+# for --no-fasterq means "no sra-tools here", so honour that for both.
+(( RUN_FASTERQ )) || RUN_DUMP_LEG=0
 
 # ---------- paths ----------
 if [[ -n "${SLURM_SUBMIT_DIR:-}" ]]; then
@@ -100,8 +178,12 @@ RESULTS_TSV="$RESULTS_DIR/results.tsv"
 RESULTS_LOCK="$RESULTS_DIR/results.lock"
 ACC_LIST="$RESULTS_DIR/accessions.txt"
 
+# Timing columns are appended after `note` rather than slotted in beside the
+# comparison columns: field numbers 1-10 keep their existing meaning, so every
+# awk one-liner written against an older results.tsv still works.
+RESULTS_COLUMNS=19
 if [[ ! -f "$RESULTS_TSV" ]]; then
-    printf 'accession\tsplit\tverdict\tbaseline_files\tcandidate_files\tfasterq_files\tbase_vs_cand\tcand_vs_fasterq\tbase_vs_fasterq\tnote\n' > "$RESULTS_TSV"
+    printf 'accession\tsplit\tverdict\tbaseline_files\tcandidate_files\tfasterq_files\tbase_vs_cand\tcand_vs_fasterq\tbase_vs_fasterq\tnote\tbase_wall\tbase_user\tbase_sys\tcand_wall\tcand_user\tcand_sys\tref_wall\tref_user\tref_sys\n' > "$RESULTS_TSV"
 fi
 
 print_summary() {
@@ -112,7 +194,37 @@ print_summary() {
     }' "$RESULTS_TSV" | sort
     echo
     echo "  non-UNCHANGED rows:"
-    awk -F'\t' 'NR>1 && $3 != "UNCHANGED" {printf "    %-14s %-12s %-14s %s\n", $1, $2, $3, $10}' "$RESULTS_TSV"
+    awk -F'\t' 'NR>1 && $2 != "cost-probe" && $3 != "UNCHANGED" {printf "    %-14s %-12s %-14s %s\n", $1, $2, $3, $10}' "$RESULTS_TSV"
+    echo
+    print_cost_summary
+}
+
+# Cost report. Ratios are candidate CPU / baseline CPU, where CPU is
+# user+sys. Wall is recorded too but never compared: it tracks cluster load,
+# not the binary. A row is flagged only when it clears both the ratio
+# threshold and an absolute delta, so a 0.05 s archive that happened to take
+# 0.07 s does not read as a 40% regression. Every row's ratio is in the note
+# column regardless of whether it was flagged.
+print_cost_summary() {
+    echo "  cost (CPU = user+sys seconds; ratio = candidate/baseline, flagged above ${COST_THRESHOLD}x and +${COST_MIN_DELTA}s):"
+    awk -F'\t' -v thr="$COST_THRESHOLD" -v mind="$COST_MIN_DELTA" '
+        NR > 1 {
+            if ($12 == "-" || $15 == "-" || $12 == "" || $15 == "") next
+            b = $12 + $13; c = $15 + $16
+            if (b <= 0) next
+            n++; tb += b; tc += c
+            r = c / b
+            if (r > thr && c - b > mind)      { flag = "SLOWER" }
+            else if (r < 1/thr && b - c > mind) { flag = "FASTER" }
+            else                                { next }
+            printf "    %-14s %-12s %9.2f %9.2f  %5.2fx  %s\n", $1, $2, b, c, r, flag
+            flagged++
+        }
+        END {
+            if (n == 0) { print "    (no timings recorded)"; exit }
+            if (!flagged) printf "    none flagged\n"
+            printf "    ---- %d timed rows: baseline %.1f s CPU, candidate %.1f s CPU, overall %.3fx\n", n, tb, tc, tc / tb
+        }' "$RESULTS_TSV"
 }
 
 [[ "$SUMMARY_ONLY" == "1" ]] && { print_summary; exit 0; }
@@ -141,6 +253,7 @@ if [[ "$SBATCH_SUBMIT" == "1" ]]; then
 
     echo "results dir : $RESULTS_DIR"
     echo "accessions  : $TOTAL   splits: $SPLITS"
+    echo "legs        : $LEGS"
     echo "baseline    : $BASELINE"
     echo "candidate   : $CANDIDATE"
     echo "partition   : $PARTITION   concurrency: $CONCURRENCY"
@@ -159,10 +272,15 @@ if [[ "$SBATCH_SUBMIT" == "1" ]]; then
     [[ -n "$TMP" ]] && SBATCH_ARGS+=(--tmp="$TMP")
 
     FORWARD=(--resume-dir "$RESULTS_DIR" --baseline "$BASELINE" --candidate "$CANDIDATE"
-             --splits "$SPLITS" --timeout "$TIMEOUT_MIN")
+             --splits "$SPLITS" --timeout "$TIMEOUT_MIN" --legs "$LEGS"
+             --dump-rows "$DUMP_ROWS" --dump-columns "$DUMP_COLUMNS"
+             --probe-bytes "$PROBE_BYTES"
+             --cost-threshold "$COST_THRESHOLD" --cost-min-delta "$COST_MIN_DELTA")
     (( RUN_FASTERQ )) || FORWARD+=(--no-fasterq)
     (( KEEP_INTERMEDIATES )) && FORWARD+=(--keep-intermediates)
     [[ -n "$WORK_DIR" ]] && FORWARD+=(--work-dir "$WORK_DIR")
+    [[ -n "$SRA_DIRS" ]] && FORWARD+=(--sra-dir "$SRA_DIRS")
+    [[ -n "$DUMP_TABLE" ]] && FORWARD+=(--dump-table "$DUMP_TABLE")
 
     JOB_ID=$(sbatch "${SBATCH_ARGS[@]}" "$SCRIPT_SELF" "${FORWARD[@]}")
     echo "submitted array job $JOB_ID"
@@ -173,6 +291,7 @@ fi
 
 # ---------- tooling ----------
 FASTERQ_DUMP=""
+VDB_DUMP=""
 if (( RUN_FASTERQ )); then
     if ! command -v fasterq-dump >/dev/null 2>&1; then
         if declare -F module >/dev/null 2>&1 || [[ -f /etc/profile.d/modules.sh ]]; then
@@ -183,6 +302,20 @@ if (( RUN_FASTERQ )); then
     fi
     FASTERQ_DUMP="$(command -v fasterq-dump || true)"
     [[ -z "$FASTERQ_DUMP" ]] && { echo "fasterq-dump not found. Try: module load sratoolkit/3.2.1, or pass --no-fasterq" >&2; exit 1; }
+    VDB_DUMP="$(command -v vdb-dump || true)"
+fi
+if (( RUN_DUMP_LEG )) && [[ -z "$VDB_DUMP" ]]; then
+    echo "vdb-dump not found; the dump leg has no reference. Try: module load sratoolkit/3.2.1, or drop 'dump' from --legs" >&2
+    exit 1
+fi
+
+# /usr/bin/time, not the bash `time` keyword: the keyword cannot write to a
+# file, and a trailing `2>&1` on the keyword's output silently merges the
+# timing into the tool's log where it is never seen again.
+TIME_BIN=""
+[[ -x /usr/bin/time ]] && TIME_BIN=/usr/bin/time
+if (( RUN_PROBE_LEG )) && [[ -z "$TIME_BIN" ]]; then
+    echo "/usr/bin/time not found; the probe leg measures nothing without it" >&2; exit 1
 fi
 
 [[ -z "$WORK_DIR" ]] && WORK_DIR="${TMPDIR:-/tmp}/sracha-ab-corpus.${SLURM_ARRAY_JOB_ID:-$$}.${SLURM_ARRAY_TASK_ID:-0}"
@@ -190,20 +323,53 @@ mkdir -p "$WORK_DIR"
 CURRENT_ACC=""
 cleanup_current() {
     [[ "$KEEP_INTERMEDIATES" == "1" || -z "$CURRENT_ACC" ]] && return
-    rm -rf "${WORK_DIR:?}/sra/$CURRENT_ACC" "${WORK_DIR:?}/out/$CURRENT_ACC"
+    rm -rf "${WORK_DIR:?}/sra/$CURRENT_ACC" "${WORK_DIR:?}/out/$CURRENT_ACC" \
+           "${WORK_DIR:?}/dump/$CURRENT_ACC"
 }
 trap 'cleanup_current; rm -rf "${WORK_DIR:?}"; exit 130' INT TERM
 trap 'cleanup_current; [[ "$KEEP_INTERMEDIATES" == "1" ]] || rm -rf "${WORK_DIR:?}"' EXIT
 
+# Pad short calls with `-` so the existing ten-argument call sites keep
+# working now that the row carries timing columns as well.
+_record_line() {
+    local -a f=("$@")
+    while (( ${#f[@]} < RESULTS_COLUMNS )); do f+=("-"); done
+    local IFS=$'\t'
+    printf '%s\n' "${f[*]}"
+}
 if command -v flock >/dev/null 2>&1; then
     record() {
         flock -x 200
-        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$@" >> "$RESULTS_TSV"
+        _record_line "$@" >> "$RESULTS_TSV"
         flock -u 200
     } 200>"$RESULTS_LOCK"
 else
-    record() { printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$@" >> "$RESULTS_TSV"; }
+    record() { _record_line "$@" >> "$RESULTS_TSV"; }
 fi
+
+# ---------- timing ----------
+# Run a command under /usr/bin/time, leaving "wall user sys" in $1. The -o
+# form is not optional: without it the timing goes to stderr, and every call
+# site here redirects stderr into the tool's log.
+timed() {
+    local tf="$1"; shift
+    rm -f "$tf"
+    if [[ -n "$TIME_BIN" ]]; then
+        "$TIME_BIN" -f '%e %U %S' -o "$tf" "$@"
+    else
+        "$@"
+    fi
+}
+
+# Echo "wall user sys", or "- - -" when nothing usable was captured. On a
+# non-zero exit /usr/bin/time prepends "Command exited with non-zero status
+# N", so match the format line rather than taking the first line.
+read_time() {
+    local tf="$1"
+    [[ -s "$tf" ]] || { printf -- '- - -'; return; }
+    awk '/^[0-9.]+ [0-9.]+ [0-9.]+$/ {w=$1; u=$2; s=$3}
+         END {if (w == "") printf "- - -"; else printf "%s %s %s", w, u, s}' "$tf"
+}
 
 # Sorted list of FASTQ basenames a tool produced. The file *set* is half the
 # answer here -- slot-based numbering means a run can legitimately emit _2 and
@@ -246,9 +412,262 @@ compare_dirs() {
 }
 
 run_tool() {
-    local bin="$1" sra="$2" out="$3" split="$4" log="$5"
+    local bin="$1" sra="$2" out="$3" split="$4" log="$5" tf="${6:-/dev/null}"
     mkdir -p "$out"
-    timeout "${TIMEOUT_MIN}m" "$bin" fastq "$sra" --split "$split" --no-gzip -O "$out" -f --no-progress >>"$log" 2>&1
+    # /usr/bin/time wraps `timeout`, not the other way round: if the timeout
+    # fires it kills the tool and `time` still records what it saw. Inverted,
+    # the timeout would kill `time` before it wrote anything.
+    timed "$tf" timeout "${TIMEOUT_MIN}m" \
+        "$bin" fastq "$sra" --split "$split" --no-gzip -O "$out" -f --no-progress >>"$log" 2>&1
+}
+
+# ---------- vdb dump leg (#107) ----------
+#
+# The FASTQ legs never touch `sracha vdb dump`, which is how #104 (READ
+# dropping ALTREAD's N-mask) survived a 369-accession A/B. This leg dumps a
+# pinned row window per column from both binaries and diffs each against
+# vdb-dump over the same rows.
+#
+# Things that are easy to get wrong here, each found by running it rather
+# than by reading the schema (the third is at strip_row_id, where it bites):
+#
+#   * rows are addressed by ROW ID, not by ordinal. `id-range` reports a
+#     first-row well above 1 on plenty of archives, and both tools clamp -R
+#     to the column's actual range, so the window is computed from the
+#     reported first-row rather than assumed to start at 1. The range comes
+#     from vdb-dump so that the window is not defined by the thing under test.
+#
+#   * the two tools render the same column differently. The normalisation
+#     below was established by running them side by side, not from the
+#     schema: READ agrees byte for byte under -f tab, QUALITY does not
+#     (vdb-dump prints Phred integers, sracha prints Phred+33 ASCII), and the
+#     array columns disagree only on the separator.
+
+# Strip sracha's leading row-id field, then undo its CSV quoting.
+#
+# `cut -f2-` is wrong for the first part: it passes a line with no delimiter
+# through whole, which would turn an empty cell into a copy of the row id.
+#
+# The second part is not cosmetic. sracha's delimited writer wraps a text cell
+# in double quotes and doubles any interior quote whenever the value contains
+# one; vdb-dump never quotes. Phred+33 maps quality 1 to '"', so on SRR000001
+# 84 of the first 300 QUALITY rows carry a quote and every one of them looked
+# like a decode mismatch until the quoting was undone. Nothing else can
+# produce a leading quote here -- the delimiter is a tab and neither Phred+33
+# nor DNA contains one -- so a cell that starts with '"' is a quoted cell.
+strip_row_id() {
+    awk '{
+        i = index($0, "\t")
+        s = (i ? substr($0, i + 1) : "")
+        if (substr(s, 1, 1) == "\"") { s = substr(s, 2, length(s) - 2); gsub(/""/, "\"", s) }
+        print s
+    }'
+}
+
+canon_sracha() {
+    case "$1" in
+        READ_LEN|READ_START|RD_FILTER|READ_FILTER)
+            strip_row_id | tr ';' ',' ;;
+        *)  strip_row_id ;;
+    esac
+}
+
+canon_vdbdump() {
+    case "$1" in
+        QUALITY)
+            # "34, 34, 38" -> "CCG". LC_ALL=C keeps %c single-byte.
+            LC_ALL=C awk -F', ' '
+                NF == 1 && $1 == "" {print ""; next}
+                {s = ""; for (i = 1; i <= NF; i++) s = s sprintf("%c", $i + 33); print s}' ;;
+        RD_FILTER|READ_FILTER)
+            # vdb-dump prints the INSDC:SRA:read_filter enum by name.
+            sed -e 's/SRA_READ_FILTER_PASS/0/g' -e 's/SRA_READ_FILTER_REJECT/1/g' \
+                -e 's/SRA_READ_FILTER_CRITERIA/2/g' -e 's/SRA_READ_FILTER_REDACTED/3/g' \
+                -e 's/, /,/g' ;;
+        READ_LEN|READ_START)
+            sed 's/, /,/g' ;;
+        *)  cat ;;
+    esac
+}
+
+# Dump one column from one sracha binary into $4. Exit status is the tool's.
+sracha_dump() {
+    local bin="$1" sra="$2" col="$3" out="$4" rows="$5" log="$6"
+    local -a targs=()
+    [[ -n "$DUMP_TABLE" ]] && targs=(-T "$DUMP_TABLE")
+    if "$bin" vdb dump "$sra" "${targs[@]}" -C "$col" -R "$rows" -f tab 2>>"$log" \
+        | canon_sracha "$col" > "$out"; then return 0; fi
+    # A physical archive may store quality under ORIGINAL_QUALITY; vdb-dump
+    # only ever exposes the logical QUALITY, so retry under the other name
+    # before concluding the column is missing.
+    if [[ "$col" == "QUALITY" ]]; then
+        "$bin" vdb dump "$sra" "${targs[@]}" -C ORIGINAL_QUALITY -R "$rows" -f tab 2>>"$log" \
+            | canon_sracha "$col" > "$out"
+        return $?
+    fi
+    return 1
+}
+
+vdbdump_column() {
+    local sra="$1" col="$2" out="$3" rows="$4" log="$5"
+    local -a targs=()
+    [[ -n "$DUMP_TABLE" ]] && targs=(-T "$DUMP_TABLE")
+    "$VDB_DUMP" "$sra" "${targs[@]}" -C "$col" -R "$rows" -f tab 2>>"$log" \
+        | canon_vdbdump "$col" > "$out"
+}
+
+dump_leg() {
+    local acc="$1" sra="$2"
+    local log="$RESULTS_DIR/logs/${acc}.vdb-dump.log"
+    : > "$log"
+    local dir="$WORK_DIR/dump/$acc"
+    rm -rf "$dir"; mkdir -p "$dir"
+
+    local -a targs=()
+    [[ -n "$DUMP_TABLE" ]] && targs=(-T "$DUMP_TABLE")
+    local range first count
+    range=$("$VDB_DUMP" "$sra" "${targs[@]}" -r 2>>"$log")
+    first=$(sed -n 's/.*first-row *= *\([0-9,]*\).*/\1/p' <<<"$range" | tr -d ',')
+    count=$(sed -n 's/.*row-count *= *\([0-9,]*\).*/\1/p' <<<"$range" | tr -d ',')
+    if [[ -z "$first" || -z "$count" ]] || (( count == 0 )); then
+        record "$acc" "vdb-dump" VDBDUMP_FAILED - - - - - - "no id-range from vdb-dump, see logs/${acc}.vdb-dump.log"
+        return
+    fi
+    local want="$DUMP_ROWS"
+    (( want > count )) && want="$count"
+    local rows="${first}-$(( first + want - 1 ))"
+    echo "# window: rows $rows (first-row=$first row-count=$count)" >> "$log"
+
+    local compared="" skipped="" bvc_detail="" cvr_detail="" bvr_detail=""
+    local col brc crc
+    local -a dump_cols
+    IFS=',' read -r -a dump_cols <<< "$DUMP_COLUMNS"
+    for col in "${dump_cols[@]}"; do
+        [[ -z "$col" ]] && continue
+        if ! vdbdump_column "$sra" "$col" "$dir/$col.ref" "$rows" "$log" || [[ ! -s "$dir/$col.ref" ]]; then
+            skipped="${skipped}${col}:no-reference "; continue
+        fi
+        brc=0; crc=0
+        sracha_dump "$BASELINE" "$sra" "$col" "$dir/$col.base" "$rows" "$log" || brc=$?
+        sracha_dump "$CANDIDATE" "$sra" "$col" "$dir/$col.cand" "$rows" "$log" || crc=$?
+        if (( brc != 0 && crc != 0 )); then
+            # Neither binary reads it: a column this archive does not have,
+            # or one sracha does not render. Not a finding, so do not let it
+            # masquerade as agreement either.
+            skipped="${skipped}${col}:unsupported "; continue
+        fi
+        compared="${compared}${col},"
+        if (( crc != 0 )) || ! cmp -s "$dir/$col.cand" "$dir/$col.ref"; then
+            cvr_detail="${cvr_detail}${col} "
+        fi
+        if (( brc != 0 )) || ! cmp -s "$dir/$col.base" "$dir/$col.ref"; then
+            bvr_detail="${bvr_detail}${col} "
+        fi
+        if (( brc != crc )) || ! cmp -s "$dir/$col.base" "$dir/$col.cand"; then
+            bvc_detail="${bvc_detail}${col} "
+        fi
+    done
+
+    if [[ -z "$compared" ]]; then
+        record "$acc" "vdb-dump" DUMP_SKIP - - - - - - "no comparable columns (${skipped:-none tried})"
+        rm -rf "$dir"; return
+    fi
+
+    local bvc="IDENTICAL" cvr="IDENTICAL" bvr="IDENTICAL"
+    [[ -n "$bvc_detail" ]] && bvc="DIFFER:${bvc_detail% }"
+    [[ -n "$cvr_detail" ]] && cvr="DIFFER:${cvr_detail% }"
+    [[ -n "$bvr_detail" ]] && bvr="DIFFER:${bvr_detail% }"
+
+    local verdict
+    if   [[ "$cvr" == IDENTICAL && "$bvr" != IDENTICAL ]]; then verdict=FIXED
+    elif [[ "$cvr" != IDENTICAL && "$bvr" == IDENTICAL ]]; then verdict=REGRESSED
+    elif [[ "$cvr" != IDENTICAL ]]; then                        verdict=STILL_BROKEN
+    elif [[ "$bvc" == IDENTICAL ]]; then                        verdict=UNCHANGED
+    else                                                        verdict=CHANGED_OK
+    fi
+
+    record "$acc" "vdb-dump" "$verdict" "${compared%,}" "${compared%,}" "${compared%,}" \
+        "$bvc" "$cvr" "$bvr" "rows=$rows${skipped:+ skipped: ${skipped% }}"
+    [[ "$verdict" == "UNCHANGED" ]] && rm -f "$log"
+    rm -rf "$dir"
+}
+
+# ---------- cost probe leg (#108) ----------
+#
+# A full decode of a large archive is minutes; the cost signal shows up in
+# seconds. Decoding to stdout through `head -c` stops at a fixed output
+# prefix, which makes the measurement the same size of work on every archive
+# and cheap enough to run on every row. sracha dies of SIGPIPE when head
+# closes (rc 141) -- that is the intended end of the probe, not a failure.
+#
+# -Z implies uncompressed, so this times decode and formatting without the
+# compressor, which is what a decoder change moves.
+cost_probe() {
+    local bin="$1" sra="$2" tf="$3" log="$4"
+    timed "$tf" timeout "${TIMEOUT_MIN}m" \
+        "$bin" fastq "$sra" --split interleaved -Z --no-progress 2>>"$log" \
+        | head -c "$PROBE_BYTES" > /dev/null
+    local rc=${PIPESTATUS[0]}
+    (( rc == 141 )) && rc=0
+    return "$rc"
+}
+
+probe_leg() {
+    local acc="$1" sra="$2"
+    local log="$RESULTS_DIR/logs/${acc}.cost-probe.log"
+    : > "$log"
+    local brc=0 crc=0
+    cost_probe "$BASELINE"  "$sra" "$WORK_DIR/probe.base.time" "$log" || brc=$?
+    cost_probe "$CANDIDATE" "$sra" "$WORK_DIR/probe.cand.time" "$log" || crc=$?
+    local bt ct
+    bt=$(read_time "$WORK_DIR/probe.base.time")
+    ct=$(read_time "$WORK_DIR/probe.cand.time")
+
+    if (( brc != 0 || crc != 0 )); then
+        # shellcheck disable=SC2086  # $bt/$ct are "wall user sys" triples
+        record "$acc" "cost-probe" COST_FAILED - - - - - - \
+            "probe rc base=$brc cand=$crc, see logs/${acc}.cost-probe.log" $bt $ct - - -
+        return
+    fi
+
+    local verdict
+    verdict=$(awk -v b="$bt" -v c="$ct" -v thr="$COST_THRESHOLD" -v mind="$COST_MIN_DELTA" '
+        BEGIN {
+            split(b, x, " "); split(c, y, " ")
+            if (x[2] == "-" || y[2] == "-") { print "COST_FAILED"; exit }
+            bc = x[2] + x[3]; cc = y[2] + y[3]
+            if (bc <= 0) { print "COST_FAILED"; exit }
+            r = cc / bc
+            if (r > thr && cc - bc > mind)        print "SLOWER"
+            else if (r < 1/thr && bc - cc > mind) print "FASTER"
+            else                                  print "COST_OK"
+        }')
+    local note
+    note=$(awk -v b="$bt" -v c="$ct" -v n="$PROBE_BYTES" 'BEGIN {
+        split(b, x, " "); split(c, y, " ")
+        bc = x[2] + x[3]; cc = y[2] + y[3]
+        printf "cpu %.2f -> %.2f (%.2fx) over %s output bytes", bc, cc, (bc > 0 ? cc / bc : 0), n
+    }')
+
+    # shellcheck disable=SC2086  # $bt/$ct are "wall user sys" triples
+    record "$acc" "cost-probe" "$verdict" - - - - - - "$note" $bt $ct - - -
+    [[ "$verdict" == "COST_OK" ]] && rm -f "$log"
+}
+
+# Look for an already-downloaded archive under --sra-dir before fetching.
+# Re-downloading the corpus on every harness change is the slowest part of a
+# development loop and none of it tests anything the harness is measuring.
+local_archive() {
+    local acc="$1" d p
+    local -a dirs
+    [[ -n "$SRA_DIRS" ]] || return 1
+    IFS=':' read -r -a dirs <<< "$SRA_DIRS"
+    for d in "${dirs[@]}"; do
+        for p in "$d/$acc.sra" "$d/$acc.sralite" "$d/$acc/$acc.sra" "$d/$acc/$acc.sralite"; do
+            [[ -f "$p" ]] && { echo "$p"; return 0; }
+        done
+    done
+    return 1
 }
 
 process_accession() {
@@ -257,27 +676,33 @@ process_accession() {
     local sra_dir="$WORK_DIR/sra/$acc"
     mkdir -p "$sra_dir"
 
-    local fetch_log="$RESULTS_DIR/logs/${acc}.fetch.log"
-    : > "$fetch_log"
-    # Fetch once with the candidate; download path is not what is under test.
-    local fetch_rc=0
-    timeout "${TIMEOUT_MIN}m" "$CANDIDATE" fetch "$acc" -O "$sra_dir" --no-progress >>"$fetch_log" 2>&1 || fetch_rc=$?
-    if (( fetch_rc != 0 )); then
-        # Capture rc on the same line as the call: a bare `local s` in between
-        # would reset $? to local's own (zero) status and lose the 124.
-        local s=ERROR_FETCH
-        (( fetch_rc == 124 )) && s=TIMEOUT
-        record "$acc" "-" "$s" - - - - - - "fetch failed (rc=$fetch_rc), see logs/${acc}.fetch.log"
-        cleanup_current; return
-    fi
-    rm -f "$fetch_log"
-
     local sra
-    sra=$(find "$sra_dir" -maxdepth 2 -type f \( -name '*.sra' -o -name '*.sralite' \) | head -1)
+    sra=$(local_archive "$acc" || true)
+    if [[ -z "$sra" ]]; then
+        local fetch_log="$RESULTS_DIR/logs/${acc}.fetch.log"
+        : > "$fetch_log"
+        # Fetch once with the candidate; download path is not what is under test.
+        local fetch_rc=0
+        timeout "${TIMEOUT_MIN}m" "$CANDIDATE" fetch "$acc" -O "$sra_dir" --no-progress >>"$fetch_log" 2>&1 || fetch_rc=$?
+        if (( fetch_rc != 0 )); then
+            # Capture rc on the same line as the call: a bare `local s` in between
+            # would reset $? to local's own (zero) status and lose the 124.
+            local s=ERROR_FETCH
+            (( fetch_rc == 124 )) && s=TIMEOUT
+            record "$acc" "-" "$s" - - - - - - "fetch failed (rc=$fetch_rc), see logs/${acc}.fetch.log"
+            cleanup_current; return
+        fi
+        rm -f "$fetch_log"
+        sra=$(find "$sra_dir" -maxdepth 2 -type f \( -name '*.sra' -o -name '*.sralite' \) | head -1)
+    fi
     if [[ -z "$sra" ]]; then
         record "$acc" "-" ERROR_FETCH - - - - - - "no archive after fetch"
         cleanup_current; return
     fi
+
+    (( RUN_DUMP_LEG ))  && dump_leg  "$acc" "$sra"
+    (( RUN_PROBE_LEG )) && probe_leg "$acc" "$sra"
+    if (( ! RUN_FASTQ_LEG )); then cleanup_current; return; fi
 
     local split
     IFS=',' read -r -a split_arr <<< "$SPLITS"
@@ -287,9 +712,15 @@ process_accession() {
         local base_out="$WORK_DIR/out/$acc/base" cand_out="$WORK_DIR/out/$acc/cand" fq_out="$WORK_DIR/out/$acc/fq"
         rm -rf "$WORK_DIR/out/$acc"; mkdir -p "$base_out" "$cand_out" "$fq_out"
 
+        # Timing is free here: both binaries have to run for the diff anyway,
+        # so wrapping them costs nothing and turns "did the bytes change" into
+        # "did the bytes change, and what did they cost".
+        local base_tf="$WORK_DIR/base.time" cand_tf="$WORK_DIR/cand.time" fq_tf="$WORK_DIR/fq.time"
         local base_rc=0 cand_rc=0
-        run_tool "$BASELINE" "$sra" "$base_out" "$split" "$log" || base_rc=$?
-        run_tool "$CANDIDATE" "$sra" "$cand_out" "$split" "$log" || cand_rc=$?
+        run_tool "$BASELINE" "$sra" "$base_out" "$split" "$log" "$base_tf" || base_rc=$?
+        run_tool "$CANDIDATE" "$sra" "$cand_out" "$split" "$log" "$cand_tf" || cand_rc=$?
+        local bt ct ft
+        bt=$(read_time "$base_tf"); ct=$(read_time "$cand_tf"); ft="- - -"
 
         # A run both binaries refuse (aligned cSRA, unsupported platform) is
         # handled, not a finding -- record and move on.
@@ -311,7 +742,9 @@ process_accession() {
 
         local fq_rc=0 fq_files="-" cand_fq="-" base_fq="-"
         if (( RUN_FASTERQ )); then
-            timeout "${TIMEOUT_MIN}m" "$FASTERQ_DUMP" "$sra" "--${split}" -O "$fq_out" -f -t "$fq_out/tmp" >>"$log" 2>&1 || fq_rc=$?
+            timed "$fq_tf" timeout "${TIMEOUT_MIN}m" \
+                "$FASTERQ_DUMP" "$sra" "--${split}" -O "$fq_out" -f -t "$fq_out/tmp" >>"$log" 2>&1 || fq_rc=$?
+            ft=$(read_time "$fq_tf")
             rm -rf "$fq_out/tmp"
         fi
 
@@ -342,9 +775,10 @@ process_accession() {
         else verdict=STILL_BROKEN
         fi
 
+        # shellcheck disable=SC2086  # $bt/$ct/$ft are "wall user sys" triples
         record "$acc" "$split" "$verdict" \
             "$(file_set "$base_out")" "$(file_set "$cand_out")" "$fq_files" \
-            "$bvc" "$cand_fq" "$base_fq" "-"
+            "$bvc" "$cand_fq" "$base_fq" "-" $bt $ct $ft
 
         [[ "$verdict" == "UNCHANGED" ]] && rm -f "$log"
         rm -rf "$WORK_DIR/out/$acc"

--- a/validation/corpus.tsv
+++ b/validation/corpus.tsv
@@ -11,12 +11,15 @@
 #
 # Not every row exercises the FASTQ decoder. `sracha fastq` declines cSRA and
 # the legacy platforms — 454, Ion Torrent, capillary — and cannot read ABI
-# SOLiD colorspace at all (#109). Those five rows check that both binaries
-# decline identically (verdict REJECT_CSRA / REJECT_PLATFORM / REJECTED_BOTH
-# in ab_corpus.sh); reach their decode paths with `sracha vdb dump` instead.
-# Treating a REJECT as decode coverage is the mistake this note exists to
-# prevent, and the `covers` column says so per row rather than leaving it to
-# be inferred from the platform.
+# SOLiD colorspace at all (#109). Those five rows produce only a REJECT
+# verdict from the FASTQ leg (REJECT_CSRA / REJECT_PLATFORM / REJECTED_BOTH),
+# which says the two binaries decline identically and nothing about decode.
+# Their decode paths are reached by ab_corpus.sh's `vdb dump` leg, which runs
+# by default and diffs a row window against vdb-dump — on SRR000001 that is
+# READ, QUALITY, X, Y, READ_LEN and READ_START where the FASTQ leg sees
+# nothing at all. Treating a REJECT as decode coverage is the mistake this
+# note exists to prevent, and the `covers` column says so per row rather than
+# leaving it to be inferred from the platform.
 #
 # Usage:
 #   awk -F'\t' '$2=="core" && !/^#/ {print $1}' validation/corpus.tsv > core.txt


### PR DESCRIPTION
Fixes #107
Fixes #108

`ab_corpus.sh` diffs FASTQ bytes and records nothing else, so two classes of defect walk through it: anything in `sracha vdb dump` (never run by the harness — how #104 survived a 369-accession A/B), and anything that costs CPU without changing bytes (how #101's first cut shipped a 2.4x decode regression past 738 clean rows). Both are one file, so they are one PR.

## What changed

`--legs fastq,dump,probe` selects the legs; default `fastq,dump`.

**dump leg (#107)** — per accession, dump a pinned row window per column from both binaries and diff each against `vdb-dump` over the same rows. Recorded as split `vdb-dump` with the existing verdict vocabulary, so `--summary` needs no changes. Compares READ, QUALITY, X, Y, READ_LEN, READ_START, SPOT_GROUP, RD_FILTER, SPOT_FILTER where each is available.

**cost (#108)** — `/usr/bin/time -f '%e %U %S' -o FILE` wraps every fastq and probe invocation; wall/user/sys land in nine columns **appended after `note`**, so fields 1-10 keep their meaning and existing awk still works. `--summary` gained a cost section that flags rows on **CPU** (user+sys) ratio. The optional `probe` leg is the issue's cheap sweep: `--split interleaved -Z | head -c 200000000`.

**`--sra-dir A:B`** — use an already-downloaded `DIR/<acc>.sra` instead of fetching.

## Verification

Eight local archives (DRR032355, DRR035760, DRR050631, DRR004435, SRR33907345, SRR28588231, SRR38892122, SRR000001), two splits, all three legs, sra-tools 3.2.1 on compute18. Defect binaries were built with a single reverted hunk.

### Control — same binary as baseline and candidate

```
  cost-probe/COST_OK               7
  cost-probe/COST_FAILED           1     <- SRR000001, `sracha fastq` refuses 454
  split-3/UNCHANGED                7
  split-files/UNCHANGED            7
  split-3/REJECT_PLATFORM          1
  split-files/REJECT_PLATFORM      1
  vdb-dump/UNCHANGED               8
  total rows: 32

  cost (CPU = user+sys seconds; ratio = candidate/baseline, flagged above 1.20x and +0.5s):
    none flagged
    ---- 22 timed rows: baseline 74.8 s CPU, candidate 75.1 s CPU, overall 1.004x
```

Re-run after rebasing onto 0.5.0: same result, 21 timed rows at 1.000x. Zero false positives.

### #107 — the dump leg catches a defect the FASTQ leg cannot see

Candidate binary with `apply_read_n_mask` stubbed out, i.e. #104 rebuilt. Confirmed effective first: on DRR032355 rows 1-300 the clean binary emits 116 rows containing an ambiguity code, the defect binary 0.

```
  vdb-dump/REGRESSED               5
  vdb-dump/UNCHANGED               3
  split-3/UNCHANGED                7     <- the FASTQ leg sees nothing
  split-files/UNCHANGED            7
```

```
DRR032355    vdb-dump  REGRESSED  base_vs_cand=DIFFER:READ  cand_vs_ref=DIFFER:READ  base_vs_ref=IDENTICAL
DRR050631    vdb-dump  REGRESSED  base_vs_cand=DIFFER:READ  cand_vs_ref=DIFFER:READ  base_vs_ref=IDENTICAL
DRR004435    vdb-dump  REGRESSED  base_vs_cand=DIFFER:READ  cand_vs_ref=DIFFER:READ  base_vs_ref=IDENTICAL
SRR28588231  vdb-dump  REGRESSED  base_vs_cand=DIFFER:READ  cand_vs_ref=DIFFER:READ  base_vs_ref=IDENTICAL
SRR000001    vdb-dump  REGRESSED  base_vs_cand=DIFFER:READ  cand_vs_ref=DIFFER:READ  base_vs_ref=IDENTICAL
```

Baseline still IDENTICAL to vdb-dump on all 8; the 3 UNCHANGED archives carry no ambiguity in a 300-row window. SRR000001 is 454 — the FASTQ leg produces only `REJECT_PLATFORM` there, so those six compared columns are coverage that did not exist before.

The leg also found a genuine cross-tool difference on its **first** run, before it was correct: sracha's delimited writer CSV-quotes a text cell containing `"`, and Phred+33 maps quality 1 to `"`, so 84 of SRR000001's first 300 QUALITY rows read as decode mismatches until the quoting was undone. That is why the normalisation is derived empirically and written down.

### #108 — the cost leg distinguishes two binaries of genuinely different cost

Candidate binary with per-record busywork in `append_fastq_record`. Output byte-identical everywhere (14/14 fastq and 8/8 dump UNCHANGED); 17 rows flagged.

```
  cost (CPU = user+sys seconds; ratio = candidate/baseline, flagged above 1.20x and +0.5s):
    DRR032355      cost-probe        0.83      1.77   2.13x  SLOWER
    DRR032355      split-files       1.44      3.38   2.35x  SLOWER
    DRR032355      split-3           1.44      3.37   2.34x  SLOWER
    DRR035760      cost-probe        0.99      1.64   1.66x  SLOWER
    DRR035760      split-files       1.76      3.64   2.07x  SLOWER
    DRR035760      split-3           1.78      3.64   2.04x  SLOWER
    DRR050631      cost-probe        0.90      1.70   1.89x  SLOWER
    DRR050631      split-files       1.63      3.38   2.07x  SLOWER
    DRR050631      split-3           1.62      3.38   2.09x  SLOWER
    DRR004435      cost-probe        4.34      5.64   1.30x  SLOWER
    DRR004435      split-files      26.65     43.21   1.62x  SLOWER
    DRR004435      split-3          26.57     43.14   1.62x  SLOWER
    SRR33907345    cost-probe        1.29      3.17   2.46x  SLOWER
    SRR33907345    split-files       1.38      3.25   2.36x  SLOWER
    SRR33907345    split-3           1.39      3.24   2.33x  SLOWER
    SRR28588231    cost-probe        0.35      0.86   2.46x  SLOWER
    SRR28588231    split-3           0.34      0.87   2.56x  SLOWER
    ---- 22 timed rows: baseline 75.2 s CPU, candidate 130.6 s CPU, overall 1.736x
```

The probe reproduces the full decode's magnitude in a fraction of the time — SRR33907345 2.46x probe vs 2.36x full decode.

**Reproducible.** Two independent runs of that pair, per-row CPU ratios:

```
accession|split               run1 base/cand    run2 base/cand    ratios
DRR004435|split-files         26.83    43.32    26.68    42.99    1.61x 1.61x  (-0.2%)
DRR004435|split-3             26.72    42.73    26.25    42.83    1.60x 1.63x  (+2.1%)
DRR032355|split-files          1.45     3.35     1.45     3.37    2.31x 2.32x  (+0.6%)
DRR032355|split-3              1.43     3.36     1.45     3.37    2.35x 2.32x  (-1.1%)
DRR035760|split-files          1.79     3.64     1.77     3.64    2.03x 2.06x  (+1.1%)
DRR050631|split-files          1.63     3.37     1.64     3.39    2.07x 2.07x  (+0.0%)
SRR33907345|split-files        1.39     3.27     1.36     3.23    2.35x 2.38x  (+0.9%)
SRR33907345|cost-probe         1.32     3.18     1.31     3.15    2.41x 2.40x  (-0.2%)
SRR38892122|split-files        0.06     0.15     0.05     0.16    2.50x 3.20x  (+28.0%)   <- 0.05 s archive
```

Ratios repeat within 2.8% on every archive above 0.3 s CPU and within 7.6% on the probe rows. The only wild row decodes in 0.05 s, which is precisely the range the absolute floor suppresses.

**Why CPU, not wall.** Same binary, same archive, two independent runs on the same node:

```
mean |drift|: wall 12.0%  cpu 2.0%   worst: wall 44.0%  cpu 8.7%  (n=18)
```

DRR032355 split-3 moved 1.00 s to 1.44 s wall (+44%) while its CPU moved 1.43 to 1.45 (+1.4%).

### Full results.tsv from the control run

<details>
<summary>32 rows, 19 columns (timing columns appended after <code>note</code>)</summary>

```
accession	split	verdict	base_vs_cand	cand_vs_ref	base_vs_ref	note	base_wall/user/sys	cand_wall/user/sys	ref_wall/user/sys
DRR032355	vdb-dump	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	rows=1-300	-	-	-
DRR032355	cost-probe	COST_OK	-	-	-	cpu 0.79 -> 0.80 (1.01x)	0.24 0.65 0.14	0.22 0.64 0.16	-
DRR032355	split-files	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	1.31 1.14 0.29	1.37 1.15 0.30	5.72 6.25 3.51
DRR032355	split-3	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	1.33 1.16 0.28	1.43 1.17 0.27	3.85 6.39 1.47
DRR035760	vdb-dump	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	rows=1-300	-	-	-
DRR035760	cost-probe	COST_OK	-	-	-	cpu 0.94 -> 0.96 (1.02x)	0.31 0.77 0.17	0.26 0.79 0.17	-
DRR035760	split-files	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	1.31 1.48 0.28	1.34 1.46 0.29	6.89 11.56 4.07
DRR035760	split-3	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	1.23 1.44 0.32	1.22 1.44 0.32	4.99 11.25 1.38
DRR050631	vdb-dump	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	rows=1-300	-	-	-
DRR050631	cost-probe	COST_OK	-	-	-	cpu 0.90 -> 0.93 (1.03x)	0.27 0.74 0.16	0.20 0.75 0.18	-
DRR050631	split-files	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	1.40 1.33 0.29	1.63 1.33 0.31	4.55 9.19 1.54
DRR050631	split-3	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	1.23 1.33 0.30	1.34 1.33 0.31	4.53 9.75 1.48
DRR004435	vdb-dump	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	rows=1-300	-	-	-
DRR004435	cost-probe	COST_OK	-	-	-	cpu 4.16 -> 3.95 (0.95x)	0.66 3.43 0.73	0.64 3.22 0.73	-
DRR004435	split-files	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	8.09 22.53 3.90	7.85 22.86 3.93	32.98 86.70 5.81
DRR004435	split-3	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	9.21 22.56 4.10	7.95 22.58 4.09	32.21 89.06 6.22
SRR33907345	vdb-dump	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	rows=1-300	-	-	-
SRR33907345	cost-probe	COST_OK	-	-	-	cpu 1.32 -> 1.32 (1.00x)	0.32 0.80 0.52	0.33 0.81 0.51	-
SRR33907345	split-files	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	0.71 0.76 0.62	0.71 0.77 0.60	3.03 3.85 0.99
SRR33907345	split-3	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	0.68 0.79 0.57	0.72 0.79 0.58	2.67 4.06 0.99
SRR28588231	vdb-dump	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	rows=1-300	-	-	-
SRR28588231	cost-probe	COST_OK	-	-	-	cpu 0.35 -> 0.34 (0.97x)	0.15 0.18 0.17	0.15 0.18 0.16	-
SRR28588231	split-files	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	0.23 0.18 0.16	0.22 0.18 0.18	1.74 1.30 0.74
SRR28588231	split-3	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	0.21 0.17 0.18	0.22 0.17 0.19	1.75 1.28 0.78
SRR38892122	vdb-dump	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	rows=1-300	-	-	-
SRR38892122	cost-probe	COST_OK	-	-	-	cpu 0.06 -> 0.06 (1.00x)	0.07 0.02 0.04	0.07 0.03 0.03	-
SRR38892122	split-files	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	0.08 0.02 0.03	0.09 0.03 0.04	1.43 0.24 0.10
SRR38892122	split-3	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	-	0.09 0.02 0.04	0.09 0.02 0.03	1.42 0.25 0.08
SRR000001	vdb-dump	UNCHANGED	IDENTICAL	IDENTICAL	IDENTICAL	rows=1-300 (READ,QUALITY,X,Y,READ_LEN,READ_START)	-	-	-
SRR000001	cost-probe	COST_FAILED	-	-	-	probe rc base=1 cand=1	0.04 0.00 0.01	0.04 0.00 0.01	-
SRR000001	split-files	REJECT_PLATFORM	-	-	-	both binaries exited non-zero	-	-	-
SRR000001	split-3	REJECT_PLATFORM	-	-	-	both binaries exited non-zero	-	-	-
```

Trimmed here for width: the real file carries `baseline_files`, `candidate_files`, `fasterq_files` and the full per-column skip list too. `ref_*` is fasterq-dump, which comes free — DRR004435 split-3 reads 26.7 s CPU for sracha against 95.3 s for fasterq-dump.

</details>

## Judgement calls, stated

- **The dump leg defaults on.** ~15 s wall and ~2 s CPU per accession against minutes for a full decode; it is the only coverage the refused corpus rows will ever get; and a check that must be opted into is the check #104 walked past. `--legs fastq` restores the old behaviour exactly, and `--no-fasterq` already means "no sra-tools here" so it takes vdb-dump with it.
- **The probe leg defaults off.** The fastq leg's timings are free — both binaries run for the diff anyway — and answer the same question for any run doing the diff. The probe earns its keep as `--legs probe`, a cost-only sweep.
- **ALTREAD and CSREAD are not compared.** vdb-dump does not expose them as readable columns and sracha renders them as hex. ALTREAD is covered through READ instead, which is where #104 actually went wrong.
- **A skip is not agreement.** A column is skipped when vdb-dump has no reference or when neither binary reads it, and the reason is in the row.
- **Unverified: cSRA.** No cSRA archive was available locally, so the leg's behaviour on PRIMARY_ALIGNMENT/REFERENCE has not been exercised. 454 is verified and is the other shape `sracha fastq` refuses.
- **`--dump-rows 300` is a window, not a proof.** Three of the eight archives carry no ambiguity in their first 300 rows and stayed UNCHANGED under the #104 defect. The window is a sampling trade; `--dump-rows` widens it.
