### PR TITLE
docs: bring docs and `--help` in line with 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Fast SRA downloader and FASTQ converter, written in pure Rust.
 - **Split modes** -- split-3, split-files, split-spot, interleaved
 - **Resumable downloads** -- picks up where it left off
 - **Stdout streaming** -- `-Z` pipes FASTQ straight into downstream tools
-- **Integrity checks** -- MD5 verification on download and decode
-- **Platform support** -- Illumina, BGISEQ/DNBSEQ, Element, Ultima, PacBio, Nanopore (legacy 454 and Ion Torrent are not supported)
+- **Integrity checks** -- MD5 verification on download and decode, plus strict
+  checks that refuse to write records sracha cannot vouch for (`--no-strict`
+  downgrades them to warnings; `--verify` additionally checks quality *values*
+  against the archive's recorded histogram)
+- **Platform support** -- Illumina, BGISEQ/DNBSEQ, Element, Ultima, PacBio, Nanopore (legacy 454, SOLiD, Ion Torrent, Helicos and Capillary are declined with a clear error)
 - **Single static binary** -- no Python, no C dependencies
 
 ## Quick start

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -346,11 +346,13 @@ pub struct FastqArgs {
     pub no_progress: bool,
 
     /// Disable strict integrity checking. By default, sracha fails on any
-    /// data-integrity anomaly it cannot silently fall back on (quality length
-    /// mismatch, invalid quality bytes, quality overruns, paired-spot
-    /// violations); pass this flag to downgrade those failures to warnings.
-    /// Benign-fallback counters (SRA-lite all-zero quality blobs and
-    /// truncated-spot recovery) stay informational either way.
+    /// data-integrity anomaly it cannot silently fall back on: quality or
+    /// sequence streams that do not correspond to each other, decoded bases
+    /// or spots that disagree with the archive's own recorded totals,
+    /// invalid quality bytes, quality overruns, and paired-spot violations.
+    /// Pass this flag to downgrade those failures to warnings. Benign-fallback
+    /// counters (SRA-lite all-zero quality blobs and truncated-spot recovery)
+    /// stay informational either way.
     #[arg(long, help_heading = "Advanced")]
     pub no_strict: bool,
 
@@ -506,11 +508,13 @@ pub struct GetArgs {
     pub prefer_sdl: bool,
 
     /// Disable strict integrity checking. By default, sracha fails on any
-    /// data-integrity anomaly it cannot silently fall back on (quality length
-    /// mismatch, invalid quality bytes, quality overruns, paired-spot
-    /// violations); pass this flag to downgrade those failures to warnings.
-    /// Benign-fallback counters (SRA-lite all-zero quality blobs and
-    /// truncated-spot recovery) stay informational either way.
+    /// data-integrity anomaly it cannot silently fall back on: quality or
+    /// sequence streams that do not correspond to each other, decoded bases
+    /// or spots that disagree with the archive's own recorded totals,
+    /// invalid quality bytes, quality overruns, and paired-spot violations.
+    /// Pass this flag to downgrade those failures to warnings. Benign-fallback
+    /// counters (SRA-lite all-zero quality blobs and truncated-spot recovery)
+    /// stay informational either way.
     #[arg(long, help_heading = "Advanced")]
     pub no_strict: bool,
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -109,7 +109,7 @@ sracha get [OPTIONS] [ACCESSION]...
 | `--prefetch-depth <N>` | `2` | Number of accessions to download ahead of the decoder. Larger values hide slow networks behind decode at the cost of one extra temp SRA file per step. Multi-accession `get` only |
 | `--keep-sra` | | Keep the downloaded SRA file in the output directory instead of deleting it after decode |
 | `--no-progress` | | Disable progress bar |
-| `--no-strict` | | Downgrade strict-fatal data-integrity anomalies (quality length mismatch, invalid quality bytes, quality overruns, paired-spot violations) from hard failures to warnings. Strict is the default. Benign-fallback counters (SRA-lite all-zero quality blobs, truncated-spot recovery) stay informational either way |
+| `--no-strict` | | Downgrade strict-fatal data-integrity anomalies from hard failures to warnings. Strict mode fails when the quality and sequence streams do not correspond, when decoded bases or spots disagree with the archive's own recorded totals, or on invalid quality bytes, quality overruns and paired-spot violations. Strict is the default. Benign-fallback counters (SRA-lite all-zero quality blobs, truncated-spot recovery) stay informational either way |
 | `--verify` | | Also check decoded quality *values* against the archive's `STATS/QUALITY` histogram. Every other quality check compares lengths, so this is the only one that notices a decode emitting the right number of plausible quality bytes at the wrong values. Costs one increment per base; skipped where quality is synthesized rather than decoded (SRA-Lite, `--fasta`) |
 
 ---
@@ -192,7 +192,7 @@ sracha fastq [OPTIONS] <INPUT>...
 | `--folder-per-accession` | | Place each accession's outputs inside its own `<output-dir>/<accession>/` subdirectory |
 | `-f, --force` | | Overwrite existing files |
 | `--no-progress` | | Disable progress bar |
-| `--no-strict` | | Downgrade strict-fatal data-integrity anomalies (quality length mismatch, invalid quality bytes, quality overruns, paired-spot violations) from hard failures to warnings. Strict is the default. Benign-fallback counters (SRA-lite all-zero quality blobs, truncated-spot recovery) stay informational either way |
+| `--no-strict` | | Downgrade strict-fatal data-integrity anomalies from hard failures to warnings. Strict mode fails when the quality and sequence streams do not correspond, when decoded bases or spots disagree with the archive's own recorded totals, or on invalid quality bytes, quality overruns and paired-spot violations. Strict is the default. Benign-fallback counters (SRA-lite all-zero quality blobs, truncated-spot recovery) stay informational either way |
 | `--verify` | | Also check decoded quality *values* against the archive's `STATS/QUALITY` histogram. Every other quality check compares lengths, so this is the only one that notices a decode emitting the right number of plausible quality bytes at the wrong values. Costs one increment per base; skipped where quality is synthesized rather than decoded (SRA-Lite, `--fasta`) |
 
 ---
@@ -376,6 +376,12 @@ Dump row-level data for the chosen columns. Values are typed by a
 name-based heuristic (READ as bases, READ_LEN as an array, and so on);
 unrecognized columns render as hex.
 
+`-C READ` renders the *logical* READ column — the 2na basecalls with the
+ALTREAD ambiguity mask applied — so ambiguous positions show as `N` and the
+output matches `vdb-dump`. Releases before 0.5.0 showed the physical column
+without the mask, which disagreed with `vdb-dump` wherever a submitter
+recorded an ambiguity.
+
 ```
 sracha vdb dump <SOURCE> [-T TABLE] [-C COLUMNS] [-x COLUMNS] [-R ROWS] [-f FORMAT]
 ```
@@ -434,7 +440,7 @@ How common `fasterq-dump` / `fastq-dump` options map to sracha:
 | `-O, --outdir <DIR>` | `-O, --output-dir <DIR>` | Same |
 | `-e, --threads <N>` | `-t, --threads <N>` | Decode + compression threads |
 | `--split-3` | `--split split-3` | Default in both |
-| `--split-files` | `--split split-files` | One file per read slot; skipped reads still consume their number |
+| `--split-files` | `--split split-files` | One file per read slot; skipped reads still consume their number. An archive storing a single read per spot writes a bare `ACC.fastq`, with no `_1` suffix |
 | `--split-spot` | `--split split-spot` | All reads of a spot in one file |
 | `--concatenate-reads` / no split | `--split interleaved` | Single interleaved stream |
 | `-Z, --stdout` | `-Z, --stdout` | Interleaved FASTQ to stdout |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,10 +97,17 @@ filereport alongside the NCBI info table.
 
 ## Data integrity
 
-Strict integrity checking is on by default. sracha fails the run when it
-detects quality length mismatches, invalid quality bytes, quality
-overruns, or paired-spot violations in the decoded data. Pass
-`--no-strict` to downgrade these anomalies to warnings and keep going:
+Strict integrity checking is on by default. sracha fails the run rather than
+write output it cannot vouch for. It refuses when the quality and sequence
+streams do not correspond to each other, when the decoded bases or spot count
+disagree with the totals the archive itself records, or on invalid quality
+bytes, quality overruns and paired-spot violations.
+
+The last of those matter most: several decoders have shipped bugs that produced
+correct spot counts, correct read names and a zero exit code alongside wrong
+data, and comparing against the archive's own recorded totals is what catches
+that class. Pass `--no-strict` to downgrade these anomalies to warnings and
+keep going:
 
 ```bash
 sracha get SRR28588231 --no-strict
@@ -153,13 +160,17 @@ Quality scores will be uniform: Q30 for pass-filter reads, Q3 for rejects.
 | Mode | Flag | Output |
 |------|------|--------|
 | split-3 (default) | `--split split-3` | `_1.fastq.gz`, `_2.fastq.gz`, plus `.fastq.gz` for spots with fewer than two biological reads |
-| split-files | `--split split-files` | one file per read slot: `_1.fastq.gz`, `_2.fastq.gz`, ... |
+| split-files | `--split split-files` | one file per read slot: `_1.fastq.gz`, `_2.fastq.gz`, ... — but a bare `.fastq.gz` when the archive stores a single read per spot |
 | split-spot | `--split split-spot` | single file |
 | interleaved | `--split interleaved` | single file, R1/R2 alternating |
 
 In `split-files` the number comes from the read's slot in the spot, matching
 fasterq-dump: if a spot's first read is empty or technical, its second read
-still goes to `_2.fastq.gz` and no `_1.fastq.gz` is written. `split-3`
+still goes to `_2.fastq.gz` and no `_1.fastq.gz` is written. The suffix is
+dropped entirely when the archive stores only one read per spot — that run
+writes `ACC.fastq.gz`, again matching fasterq-dump. The decision keys off the
+number of reads the archive *stores*, not how many survive filtering, so a
+two-read spot whose first read is a dropped adapter still writes `_2`. `split-3`
 instead numbers only the reads it writes, so the same spot's lone read lands
 in the unpaired `.fastq.gz`.
 


### PR DESCRIPTION
An audit of the docs against the code found four of 0.5.0's user-visible changes had shipped with no doc update. One turned out not to be a docs bug.

## The `--help` text was itself stale

`--no-strict`'s doc comment in `crates/sracha/src/cli.rs` enumerated **four** strict-fatal anomalies. `IntegrityDiag::any_strict_fatal` now lists **nine**. So `sracha fastq --help` was wrong, and `docs/cli.md` was faithfully mirroring the stale string — fixing only the docs would have left the two agreeing on the wrong thing.

Fixed at the source in both `fastq` and `get`, then propagated to `docs/cli.md` and `docs/getting-started.md`.

This matters more than a typical doc nit: the 0.5.0 upgrade note tells users strict mode can now refuse archives it previously converted, and `--help` is where they will look first.

## Also corrected

| where | was | now |
|---|---|---|
| `docs/getting-started.md:156`, `docs/cli.md:437` | `--split-files` → "one file per read slot: `_1`, `_2`, …" | notes that an archive storing one read per spot writes a bare `ACC.fastq` |
| `README.md:21`, `docs/getting-started.md:5` | "legacy 454 and Ion Torrent are not supported" | names SOLiD, Helicos and Capillary too |
| `docs/cli.md` `vdb dump` | silent on output change | records that `-C READ` renders the logical ALTREAD-masked column and matches `vdb-dump` |
| `README.md:20` | "Integrity checks — MD5 verification" | mentions strict mode and `--verify` |

The split-files item is the significant one: it affects roughly a third of runs and is exactly what breaks a pipeline globbing `${ACC}_1.fastq`. I also stated the rule positively, since no doc said it — the suffix keys off the read count the archive *stores*, not how many survive filtering, which is why a two-read spot whose first read is a dropped adapter still writes `_2`.

## Deliberately not changed

**Bioconda/BioContainers pins still read 0.4.2** (`README.md:139,143`, `docs/index.md:95,99,115,116`). The README itself documents that those tags lag a release by a day or two while the image builds. They want bumping once the 0.5.0 image publishes and its build-hash suffix is known — guessing the hash now would be worse than leaving them stale, so this needs a follow-up once the container lands.

**No `sracha-stats.jsonl` schema section.** The file gained seven keys this release, but no doc has ever documented its schema, so there is nothing stale — only an absent doc. Worth writing, but that is a new section rather than a correction.

**Validation tooling is undocumented** — `validation/corpus.tsv`, `corpus.sh`, and `ab_corpus.sh`'s new `--legs`/cost options appear in no doc. Same judgement: an omission, not a staleness bug, and a larger piece of work.

744 tests pass; clippy and `fmt` clean.