### PR TITLE
feat(csra): decode aligned cSRA with external reference bases (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Decode aligned cSRA whose reference bases live outside the archive (#74).
+  Runs aligned to a public assembly keep only the chunk layout in
+  `REFERENCE`; the bases are fetched from NCBI refseq objects named by
+  `SEQ_ID` and cached in `~/.cache/sracha/refseq` (override with
+  `--refseq-cache` or `$SRACHA_REFSEQ_DIR`) for reuse across runs. Also
+  handles fully-aligned archives, which store no `SEQUENCE.CMP_READ` at all.
+
+### Fixes
+
+- `sracha get` now routes reference-compressed cSRA through the cSRA decoder.
+  Only `sracha fastq` did, so `get` on an aligned run died in the plain
+  cursor's cSRA rejection even when the archive was decodable.
+- `sracha info` on a split cSRA no longer errors: detection was sidecar-aware
+  but the cursor open was not.
+
 ## 0.5.0 (2026-08-02)
 
 ### Upgrade note

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,37 @@
   `--refseq-cache` or `$SRACHA_REFSEQ_DIR`) for reuse across runs. Also
   handles fully-aligned archives, which store no `SEQUENCE.CMP_READ` at all.
 
+### Upgrade note
+
+**Re-convert aligned (cSRA) output produced by 0.5.0 or earlier.** Archives
+that store their unaligned bases as `CMP_READ` + `CMP_ALTREAD` had every
+ambiguity code emitted as a confident `A` — 2na cannot represent `N` and the
+mask was ignored. On SRR622461 that was ~1.7% of reads, including
+fully-unaligned spots that came out as 100 `A`s instead of 100 `N`s. Spot
+counts, read counts and qualities were all correct and the exit code was
+zero, so nothing downstream would have flagged it.
+
 ### Fixes
 
+- Restore ambiguity codes in the unaligned half of a cSRA read
+  (`SEQUENCE.CMP_ALTREAD`) — see the upgrade note.
 - `sracha get` now routes reference-compressed cSRA through the cSRA decoder.
   Only `sracha fastq` did, so `get` on an aligned run died in the plain
   cursor's cSRA rejection even when the archive was decodable.
+- Size an alignment's reference projection from `REF_OFFSET` rather than the
+  stored `REF_LEN`, and by the reference cursor's peak rather than its close.
+  Soft-clipped archives failed with "ref cursor N outside ref_read (N)".
+- Wrap spans that cross the origin of a circular reference (the
+  mitochondrion), and return a short span at the end of a linear one instead
+  of failing.
+- Don't consume a `REF_OFFSET` per flag during a BAM `B` (back-up) operation.
+- cSRA deflines now carry the synthesized spot id, matching `fasterq-dump`
+  and sracha's own unaligned path.
 - `sracha info` on a split cSRA no longer errors: detection was sidecar-aware
   but the cursor open was not.
+- cSRA decode no longer holds the entire FASTQ output in memory before
+  writing (7.7 GiB resident on a 1 GiB archive; now streams in bounded
+  batches).
 
 ## 0.5.0 (2026-08-02)
 

--- a/crates/sracha-core/benches/decode.rs
+++ b/crates/sracha-core/benches/decode.rs
@@ -62,6 +62,8 @@ fn config(out: &std::path::Path, threads: usize, compression: CompressionMode) -
         metadata_md5: None,
         metadata_size: None,
         metadata_service: None,
+        refseq_paths: Vec::new(),
+        refseq_cache_dir: None,
     }
 }
 

--- a/crates/sracha-core/src/fastq/mod.rs
+++ b/crates/sracha-core/src/fastq/mod.rs
@@ -759,8 +759,11 @@ fn route_segments_to_slots(
 ) -> Vec<(OutputSlot, FastqRecord)> {
     let mut results = Vec::with_capacity(segments.len());
     let format = |seg: &ReadSegment<'_>| {
+        // cSRA's SEQUENCE table carries no NAME column, so fasterq-dump
+        // synthesizes the spot id as the name (`DSD_FASTQ_SYN_NAME`) rather
+        // than omitting the field — same rule the plain decode path applies
+        // in `blob_decode`. `spot_name` is the spot number here.
         if let Some(tmpl) = config.seq_defline.as_ref() {
-            // cSRA has no NAME column, so `$sn` resolves to empty here.
             let mut data = Vec::new();
             append_record_templated(
                 &mut data,
@@ -769,14 +772,20 @@ fn route_segments_to_slots(
                 run_name,
                 spot_name,
                 seg.mate_idx,
-                None,
+                Some(spot_name),
                 seg.sequence,
                 seg.quality,
                 None,
             );
             FastqRecord { data }
         } else {
-            format_read(run_name, spot_name, None, seg.sequence, seg.quality)
+            format_read(
+                run_name,
+                spot_name,
+                Some(spot_name),
+                seg.sequence,
+                seg.quality,
+            )
         }
     };
 
@@ -954,8 +963,9 @@ mod tests {
         assert_eq!(results.len(), 1);
         let data = &results[0].1.data;
         let text = std::str::from_utf8(data).unwrap();
-        // No NAME column → fasterq-dump omits the name field (no spot-id repeat).
-        assert!(text.starts_with("@SRR123456.42 length=4\n"));
+        // No NAME column → fasterq-dump synthesizes the spot id as the
+        // name field (DSD_FASTQ_SYN_NAME), rather than omitting it.
+        assert!(text.starts_with("@SRR123456.42 42 length=4\n"));
     }
 
     #[test]
@@ -967,8 +977,8 @@ mod tests {
         assert_eq!(results.len(), 2);
         let r1 = std::str::from_utf8(&results[0].1.data).unwrap();
         let r2 = std::str::from_utf8(&results[1].1.data).unwrap();
-        assert!(r1.starts_with("@SRR999.99 length=4\n"));
-        assert!(r2.starts_with("@SRR999.99 length=4\n"));
+        assert!(r1.starts_with("@SRR999.99 99 length=4\n"));
+        assert!(r2.starts_with("@SRR999.99 99 length=4\n"));
     }
 
     #[test]
@@ -982,7 +992,7 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         let text = std::str::from_utf8(&results[0].1.data).unwrap();
-        assert_eq!(text, "@SRR1.1 length=4\nACGT\n+SRR1.1 length=4\nIIII\n");
+        assert_eq!(text, "@SRR1.1 1 length=4\nACGT\n+SRR1.1 1 length=4\nIIII\n");
     }
 
     // -----------------------------------------------------------------------
@@ -1147,10 +1157,16 @@ mod tests {
         let r1 = std::str::from_utf8(&results[0].1.data).unwrap();
         let r2 = std::str::from_utf8(&results[1].1.data).unwrap();
 
-        assert_eq!(r1, "@SRR1.10 length=4\nAACC\n+SRR1.10 length=4\nIIII\n");
+        assert_eq!(
+            r1,
+            "@SRR1.10 10 length=4\nAACC\n+SRR1.10 10 length=4\nIIII\n"
+        );
         // N-masking is now handled in the pipeline layer, not format_read.
         // Bases pass through unchanged regardless of quality.
-        assert_eq!(r2, "@SRR1.10 length=4\nGGTT\n+SRR1.10 length=4\n!!!!\n");
+        assert_eq!(
+            r2,
+            "@SRR1.10 10 length=4\nGGTT\n+SRR1.10 10 length=4\n!!!!\n"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1666,7 +1682,7 @@ mod tests {
         let results = format_spot(&spot, "SRR1", &config);
 
         let text = std::str::from_utf8(&results[0].1.data).unwrap();
-        assert!(text.starts_with("@SRR1.spot.123_abc length=4\n"));
+        assert!(text.starts_with("@SRR1.spot.123_abc spot.123_abc length=4\n"));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/sracha-core/src/pipeline/config.rs
+++ b/crates/sracha-core/src/pipeline/config.rs
@@ -87,6 +87,17 @@ pub struct PipelineConfig {
     /// Mirror service label (e.g. `s3`, `gs`, `ncbi`) recorded into the
     /// metadata sidecar.
     pub metadata_service: Option<String>,
+    /// External reference objects already materialised on local disk, as
+    /// `(REFERENCE.SEQ_ID, path)`. Populated by
+    /// [`prepare_external_refseqs`] before decode so the sync decode path
+    /// never touches the network.
+    ///
+    /// [`prepare_external_refseqs`]: crate::pipeline::refseq::prepare_external_refseqs
+    pub refseq_paths: Vec<(String, PathBuf)>,
+    /// Override for the shared external-reference cache directory
+    /// (`--refseq-cache`). `None` uses `$SRACHA_REFSEQ_DIR` or the
+    /// platform cache dir.
+    pub refseq_cache_dir: Option<PathBuf>,
 }
 
 impl PipelineConfig {
@@ -154,6 +165,8 @@ mod tests {
             metadata_md5: None,
             metadata_size: None,
             metadata_service: None,
+            refseq_paths: Vec::new(),
+            refseq_cache_dir: None,
         }
     }
 

--- a/crates/sracha-core/src/pipeline/marker.rs
+++ b/crates/sracha-core/src/pipeline/marker.rs
@@ -326,6 +326,8 @@ mod tests {
             metadata_md5: None,
             metadata_size: None,
             metadata_service: None,
+            refseq_paths: Vec::new(),
+            refseq_cache_dir: None,
         }
     }
 

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -48,6 +48,7 @@ pub use config::{PipelineConfig, PipelineStats};
 
 mod blob_decode;
 mod marker;
+pub mod refseq;
 mod validate;
 use blob_decode::{
     BlobDecodeCtx, RawBlobData, decode_blob_to_fastq, decode_raw, decode_zip_encoding,
@@ -280,10 +281,31 @@ fn wrap_blob_integrity(accession: &str, err: Error) -> Error {
     }
 }
 
+/// Return the canonical `.sra.vdbcache` sidecar path if it exists on disk
+/// next to `sra_path`. Both cSRA dispatch sites (`run_fastq` for local
+/// files, `decode_sra` for `sracha get`) need the same probe.
+fn csra_vdbcache_path(sra_path: &std::path::Path) -> Option<PathBuf> {
+    let candidate = crate::vdb::csra::vdbcache_sidecar_path(sra_path);
+    candidate.exists().then_some(candidate)
+}
+
 /// Select the best mirror URL for downloading.
 ///
 /// Prefers cloud mirrors (s3, gs) over NCBI on-premises servers because
 /// cloud CDNs are typically much faster for parallel chunked downloads.
+/// Mirror preference by service label — lower sorts first.
+/// Cloud mirrors beat NCBI on-premises for parallel chunked downloads.
+/// Shared with the external-reference fetcher so both rank identically.
+pub(crate) fn mirror_priority(service: &str) -> u8 {
+    match service {
+        "s3" | "s3-direct" => 0,
+        "gs" => 1,
+        s if s.contains("sra-ncbi") => 2,
+        "ncbi" => 3,
+        _ => 4,
+    }
+}
+
 fn select_mirror(resolved: &ResolvedAccession) -> Result<String> {
     let mirrors = &resolved.sra_file.mirrors;
     if mirrors.is_empty() {
@@ -293,21 +315,9 @@ fn select_mirror(resolved: &ResolvedAccession) -> Result<String> {
         });
     }
 
-    // Prefer cloud mirrors — much faster for parallel downloads.
-    // Priority: s3 > gs > sra-ncbi > ncbi > any
-    let priority = |s: &str| -> u8 {
-        match s {
-            "s3" | "s3-direct" => 0,
-            "gs" => 1,
-            s if s.contains("sra-ncbi") => 2,
-            "ncbi" => 3,
-            _ => 4,
-        }
-    };
-
     let best = mirrors
         .iter()
-        .min_by_key(|m| priority(m.service.as_str()))
+        .min_by_key(|m| mirror_priority(m.service.as_str()))
         .unwrap();
 
     tracing::debug!(
@@ -1212,20 +1222,13 @@ pub fn run_fastq(
             .to_string()
     });
 
-    // Reference-compressed cSRA dispatch: archives with SEQUENCE.CMP_READ
-    // plus sibling PRIMARY_ALIGNMENT + REFERENCE tables can't decode
-    // through the regular VdbCursor (it reads physical READ only); route
-    // them through CsraCursor's splice. v1 handles one uncompressed output
-    // file and ignores split / compression / stdout flags — a follow-up
-    // will port CsraCursor to the batched pipeline.
-    let vdbcache_candidate = crate::vdb::csra::vdbcache_sidecar_path(sra_path);
-    let vdbcache_for_probe = if vdbcache_candidate.exists() {
-        Some(vdbcache_candidate.as_path())
-    } else {
-        None
-    };
-    if crate::vdb::csra::looks_like_decodable_csra(sra_path, vdbcache_for_probe).unwrap_or(false) {
-        return run_fastq_csra(sra_path, &acc, config, vdbcache_for_probe);
+    // Reference-compressed cSRA dispatch: archives whose bases live in
+    // PRIMARY_ALIGNMENT + REFERENCE rather than a physical SEQUENCE.READ
+    // can't decode through the regular VdbCursor; route them through
+    // CsraCursor's splice.
+    let vdbcache = csra_vdbcache_path(sra_path);
+    if crate::vdb::csra::looks_like_decodable_csra(sra_path, vdbcache.as_deref()).unwrap_or(false) {
+        return run_fastq_csra(sra_path, &acc, config, vdbcache.as_deref());
     }
 
     // Detect SRA-lite by checking if the quality column is absent.
@@ -1394,6 +1397,18 @@ fn run_fastq_csra(
     use crate::vdb::kar::KarArchive;
     use crate::vdb::restore::fourna_to_ascii;
 
+    // External reference objects, opened once and shared by every decode
+    // worker: the mmaps are immutable, and each worker gets its own blob
+    // caches via `RefSeqReaders`. `config.refseq_paths` is populated by
+    // `refseq::prepare_external_refseqs` before decode starts.
+    let refseqs: Option<Arc<crate::vdb::refseq::RefSeqStore>> = if config.refseq_paths.is_empty() {
+        None
+    } else {
+        Some(Arc::new(crate::vdb::refseq::RefSeqStore::open(
+            &config.refseq_paths,
+        )?))
+    };
+
     let file = std::fs::File::open(sra_path)?;
     let mut archive = KarArchive::open(std::io::BufReader::new(file))?;
     // Open the vdbcache sidecar when present. Each decode worker opens
@@ -1412,7 +1427,12 @@ fn run_fastq_csra(
                 (Some(a), Some(p)) => Some((a, p)),
                 _ => None,
             };
-        match CsraCursor::open_any(&mut archive, sra_path, vdbcache_for_open) {
+        match CsraCursor::open_with_refseqs(
+            &mut archive,
+            sra_path,
+            vdbcache_for_open,
+            refseqs.as_ref(),
+        ) {
             Ok(c) => c,
             // Known-unsupported cSRA shape (external refseq, static READ_LEN).
             // Surface a distinct error carrying the accession so the CLI can
@@ -1527,7 +1547,9 @@ fn run_fastq_csra(
                     (Some(a), Some(p)) => Some((a, p)),
                     _ => None,
                 };
-            CsraCursor::open_any(&mut archive, sra_path, cache_opt)?
+            // `refseqs` is an Arc of already-opened mmaps: cheap to share,
+            // and each worker's `RefSeqReaders` view is built fresh here.
+            CsraCursor::open_with_refseqs(&mut archive, sra_path, cache_opt, refseqs.as_ref())?
         };
         let mut per_slot: HashMap<OutputSlot, (Vec<u8>, u64)> = HashMap::new();
         let mut itoa_buf = itoa::Buffer::new();
@@ -1607,27 +1629,35 @@ fn run_fastq_csra(
             .num_threads(num_threads)
             .build()
             .map_err(|e| Error::Pipeline(format!("cSRA threadpool: {e}")))?;
-        let results: Vec<Result<Vec<SlotChunk>>> = pool.install(|| {
-            chunks
-                .par_iter()
-                .map(|(s, e)| decode_chunk(*s, *e))
-                .collect()
-        });
-        for (chunk_res, (s, e)) in results.into_iter().zip(chunks.iter()) {
-            let chunk = chunk_res?;
-            spots_read += (e - s) as u64;
-            for (slot, bytes, records) in chunk {
-                if let Some(ref mut sw) = stdout_writer {
-                    sw.write_all(&bytes).map_err(Error::Io)?;
-                } else {
-                    get_writer(slot, &mut writers, &mut output_paths)?;
-                    writers
-                        .get_mut(&slot)
-                        .unwrap()
-                        .write_all(&bytes)
-                        .map_err(Error::Io)?;
+        // Decode a bounded batch of chunks at a time and drain it before
+        // starting the next. Collecting every chunk first would hold the
+        // entire FASTQ output in memory — fine for a 12 MB test fixture,
+        // several GB on a real run. Four chunks per thread keeps every
+        // worker fed while capping the buffer at tens of MB.
+        let batch = num_threads.saturating_mul(4).max(1);
+        for window in chunks.chunks(batch) {
+            let results: Vec<Result<Vec<SlotChunk>>> = pool.install(|| {
+                window
+                    .par_iter()
+                    .map(|(s, e)| decode_chunk(*s, *e))
+                    .collect()
+            });
+            for (chunk_res, (s, e)) in results.into_iter().zip(window.iter()) {
+                let chunk = chunk_res?;
+                spots_read += (e - s) as u64;
+                for (slot, bytes, records) in chunk {
+                    if let Some(ref mut sw) = stdout_writer {
+                        sw.write_all(&bytes).map_err(Error::Io)?;
+                    } else {
+                        get_writer(slot, &mut writers, &mut output_paths)?;
+                        writers
+                            .get_mut(&slot)
+                            .unwrap()
+                            .write_all(&bytes)
+                            .map_err(Error::Io)?;
+                    }
+                    reads_written += records;
                 }
-                reads_written += records;
             }
         }
     } else {
@@ -2114,13 +2144,31 @@ pub fn decode_sra(downloaded: &DownloadedSra, config: &PipelineConfig) -> Result
     }
 
     let diag = Arc::new(IntegrityDiag::default());
-    let (spots_read, reads_written, mut output_files) = match decode_and_write(
-        &downloaded.temp_path,
-        &downloaded.accession,
-        config,
-        downloaded.is_lite,
-        &diag,
-    ) {
+    // Reference-compressed cSRA needs CsraCursor, exactly as `run_fastq`
+    // does for local files. Without this, `sracha get` on an aligned run
+    // fell through to VdbCursor and died in `reject_if_csra`.
+    let vdbcache = csra_vdbcache_path(&downloaded.temp_path);
+    let decoded =
+        if crate::vdb::csra::looks_like_decodable_csra(&downloaded.temp_path, vdbcache.as_deref())
+            .unwrap_or(false)
+        {
+            run_fastq_csra(
+                &downloaded.temp_path,
+                &downloaded.accession,
+                config,
+                vdbcache.as_deref(),
+            )
+            .map(|s| (s.spots_read, s.reads_written, s.output_files))
+        } else {
+            decode_and_write(
+                &downloaded.temp_path,
+                &downloaded.accession,
+                config,
+                downloaded.is_lite,
+                &diag,
+            )
+        };
+    let (spots_read, reads_written, mut output_files) = match decoded {
         Ok(result) => result,
         Err(Error::Cancelled { output_files }) => {
             // Delete completion marker (may not exist yet).
@@ -2367,6 +2415,8 @@ mod tests {
             metadata_md5: None,
             metadata_size: None,
             metadata_service: None,
+            refseq_paths: Vec::new(),
+            refseq_cache_dir: None,
         }
     }
 

--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -1411,6 +1411,14 @@ fn run_fastq_csra(
 
     let file = std::fs::File::open(sra_path)?;
     let mut archive = KarArchive::open(std::io::BufReader::new(file))?;
+    // Read the REFERENCE chunk layout once for the whole accession. Workers
+    // build a cursor per chunk, so anything archive-sized has to be hoisted
+    // out of that path or it dominates the decode.
+    let shared = crate::vdb::csra::CsraShared {
+        refseqs,
+        reference: crate::vdb::reference::ReferenceLayout::open(&mut archive, sra_path)?
+            .map(Arc::new),
+    };
     // Open the vdbcache sidecar when present. Each decode worker opens
     // its own copy below (mmap/file handles are not Send across rayon
     // threads), so the top-level one is only used for the SEQUENCE
@@ -1427,12 +1435,8 @@ fn run_fastq_csra(
                 (Some(a), Some(p)) => Some((a, p)),
                 _ => None,
             };
-        match CsraCursor::open_with_refseqs(
-            &mut archive,
-            sra_path,
-            vdbcache_for_open,
-            refseqs.as_ref(),
-        ) {
+        match CsraCursor::open_with_shared(&mut archive, sra_path, vdbcache_for_open, Some(&shared))
+        {
             Ok(c) => c,
             // Known-unsupported cSRA shape (external refseq, static READ_LEN).
             // Surface a distinct error carrying the accession so the CLI can
@@ -1547,9 +1551,10 @@ fn run_fastq_csra(
                     (Some(a), Some(p)) => Some((a, p)),
                     _ => None,
                 };
-            // `refseqs` is an Arc of already-opened mmaps: cheap to share,
-            // and each worker's `RefSeqReaders` view is built fresh here.
-            CsraCursor::open_with_refseqs(&mut archive, sra_path, cache_opt, refseqs.as_ref())?
+            // `shared` holds Arcs of already-opened mmaps and the parsed
+            // REFERENCE layout: cheap to clone into each chunk, where only
+            // the per-worker blob caches get built fresh.
+            CsraCursor::open_with_shared(&mut archive, sra_path, cache_opt, Some(&shared))?
         };
         let mut per_slot: HashMap<OutputSlot, (Vec<u8>, u64)> = HashMap::new();
         let mut itoa_buf = itoa::Buffer::new();

--- a/crates/sracha-core/src/pipeline/refseq.rs
+++ b/crates/sracha-core/src/pipeline/refseq.rs
@@ -1,0 +1,290 @@
+//! Fetching external reference sequences for cSRA decode.
+//!
+//! Runs aligned to a public assembly keep only the chunk layout in their
+//! REFERENCE table; the bases live in separate NCBI refseq objects named by
+//! `REFERENCE.SEQ_ID` (e.g. `CM000663.1` = GRCh37 chr1). This module
+//! resolves those accessions through SDL, downloads them into a shared
+//! on-disk cache, and hands `sracha-vdb` local paths — the vdb crate never
+//! does network I/O itself.
+//!
+//! The cache is deliberately *outside* the output directory: one GRCh37 set
+//! (~780 MB across 24 objects) serves every human cSRA the user decodes.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::sync::Semaphore;
+
+use crate::download::{DownloadConfig, TransferRetryPolicy, download_file_with_retries};
+use crate::error::{Error, Result};
+use crate::pipeline::PipelineConfig;
+use crate::sdl::{FormatPreference, ResolvedFile, SdlClient, resolved_file_from_sdl};
+use crate::vdb::kar::KarArchive;
+use crate::vdb::refseq::{ExternalRefNeed, external_refs_needed, is_safe_seq_id};
+
+/// KAR magic; refseq objects are KAR archives like any other SRA object.
+const KAR_MAGIC: &[u8] = b"NCBI.sra";
+
+/// How many refseq objects to download at once. Each download already fans
+/// out over `config.connections` range requests, so a low number here keeps
+/// NCBI happy without leaving bandwidth on the table.
+const REFSEQ_DOWNLOAD_CONCURRENCY: usize = 2;
+
+/// Resolve the directory external refseq objects are cached in.
+///
+/// `--refseq-cache` wins, then `$SRACHA_REFSEQ_DIR`, then the platform
+/// cache dir. Never inside the output directory — the whole point is reuse
+/// across accessions and runs.
+pub fn refseq_cache_dir(override_dir: Option<&Path>) -> Result<PathBuf> {
+    if let Some(dir) = override_dir {
+        return Ok(dir.to_path_buf());
+    }
+    if let Some(dir) = std::env::var_os("SRACHA_REFSEQ_DIR") {
+        return Ok(PathBuf::from(dir));
+    }
+    let base = if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
+        PathBuf::from(xdg)
+    } else if let Some(home) = std::env::var_os("HOME") {
+        if cfg!(target_os = "macos") {
+            PathBuf::from(home).join("Library/Caches")
+        } else {
+            PathBuf::from(home).join(".cache")
+        }
+    } else {
+        return Err(Error::Pipeline(
+            "cannot locate a cache directory for external references — set \
+             --refseq-cache or SRACHA_REFSEQ_DIR"
+                .into(),
+        ));
+    };
+    Ok(base.join("sracha").join("refseq"))
+}
+
+/// Discover, fetch, and return the local paths of every external reference
+/// object `sra_path` needs.
+///
+/// Returns an empty vec when the archive embeds its reference bases (or
+/// isn't a cSRA at all), so callers can invoke this unconditionally before
+/// decode. Runs entirely in the async layer: rayon decode workers only ever
+/// see local files.
+pub async fn prepare_external_refseqs(
+    sra_path: &Path,
+    vdbcache_path: Option<&Path>,
+    config: &PipelineConfig,
+) -> Result<Vec<(String, PathBuf)>> {
+    let needs = {
+        let sra_path = sra_path.to_path_buf();
+        let vdbcache_path = vdbcache_path.map(Path::to_path_buf);
+        tokio::task::spawn_blocking(move || scan_needs(&sra_path, vdbcache_path.as_deref()))
+            .await
+            .map_err(|e| Error::Pipeline(format!("refseq scan panicked: {e}")))??
+    };
+
+    // Chunks that are entirely Ns address nothing external.
+    let needs: Vec<ExternalRefNeed> = needs.into_iter().filter(|n| !n.all_n).collect();
+    if needs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    for need in &needs {
+        if !is_safe_seq_id(&need.seq_id) {
+            return Err(Error::Pipeline(format!(
+                "refusing to fetch reference with unsafe SEQ_ID {:?}",
+                need.seq_id
+            )));
+        }
+    }
+
+    let cache = refseq_cache_dir(config.refseq_cache_dir.as_deref())?;
+    std::fs::create_dir_all(&cache).map_err(Error::Io)?;
+
+    let client = SdlClient::with_client(
+        config
+            .http_client
+            .clone()
+            .unwrap_or_else(crate::http::default_client),
+    );
+    let accessions: Vec<String> = needs.iter().map(|n| n.seq_id.clone()).collect();
+    // Use the raw batched call, not `resolve_many`: refseq accessions have
+    // no EUtils RunInfo, and the completeness-aware retry loop would burn
+    // its whole backoff schedule waiting for metadata that never arrives.
+    let response = client.resolve(&accessions, FormatPreference::Sra).await?;
+
+    let mut resolved: Vec<(String, ResolvedFile)> = Vec::new();
+    let mut unresolved: Vec<String> = Vec::new();
+    for acc in &accessions {
+        let file = response
+            .results
+            .iter()
+            .find(|r| r.bundle.as_deref() == Some(acc.as_str()))
+            .and_then(|r| r.find_sra_file())
+            .and_then(|f| resolved_file_from_sdl(f).ok())
+            .filter(|f| !f.mirrors.is_empty());
+        match file {
+            Some(f) => resolved.push((acc.clone(), f)),
+            None => unresolved.push(acc.clone()),
+        }
+    }
+
+    // A cached copy is as good as a resolvable one — stay usable offline.
+    let unresolved: Vec<String> = unresolved
+        .into_iter()
+        .filter(|acc| !cache.join(acc).exists())
+        .collect();
+    if !unresolved.is_empty() {
+        return Err(Error::Pipeline(format!(
+            "cannot locate {} external reference object(s) ({}) — they are \
+             not in {} and SDL has no record of them",
+            unresolved.len(),
+            unresolved.join(", "),
+            cache.display(),
+        )));
+    }
+
+    let to_fetch: Vec<(String, ResolvedFile)> = resolved
+        .iter()
+        .filter(|(acc, f)| !is_cached(&cache.join(acc), f.size))
+        .cloned()
+        .collect();
+
+    if !to_fetch.is_empty() {
+        let total: u64 = to_fetch.iter().map(|(_, f)| f.size).sum();
+        eprintln!(
+            "  fetching {} external reference object(s) ({}) into {}",
+            to_fetch.len(),
+            crate::util::format_size(total),
+            cache.display(),
+        );
+        fetch_all(&to_fetch, &cache, config).await?;
+    }
+
+    Ok(resolved
+        .into_iter()
+        .map(|(acc, _)| {
+            let path = cache.join(&acc);
+            (acc, path)
+        })
+        .collect())
+}
+
+/// Scan the archive (or its vdbcache, when REFERENCE lives there) for the
+/// external references it needs.
+fn scan_needs(sra_path: &Path, vdbcache_path: Option<&Path>) -> Result<Vec<ExternalRefNeed>> {
+    let open = |p: &Path| -> Result<Vec<ExternalRefNeed>> {
+        let file = std::fs::File::open(p)?;
+        let mut archive = KarArchive::open(std::io::BufReader::new(file))?;
+        Ok(external_refs_needed(&mut archive, p)?)
+    };
+    let from_main = open(sra_path)?;
+    if !from_main.is_empty() {
+        return Ok(from_main);
+    }
+    match vdbcache_path {
+        Some(p) => open(p),
+        None => Ok(from_main),
+    }
+}
+
+/// Is this cache entry usable without re-downloading? Size match plus KAR
+/// magic — a full md5 of ~780 MB on every run costs more than it catches.
+/// `--verify` forces the download path, which does check md5.
+fn is_cached(path: &Path, expected_size: u64) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if expected_size > 0 && meta.len() != expected_size {
+        return false;
+    }
+    let mut buf = [0u8; 8];
+    use std::io::Read;
+    let Ok(mut f) = std::fs::File::open(path) else {
+        return false;
+    };
+    f.read_exact(&mut buf).is_ok() && buf == KAR_MAGIC
+}
+
+async fn fetch_all(
+    files: &[(String, ResolvedFile)],
+    cache: &Path,
+    config: &PipelineConfig,
+) -> Result<()> {
+    let sem = Arc::new(Semaphore::new(REFSEQ_DOWNLOAD_CONCURRENCY));
+    let mut tasks = Vec::with_capacity(files.len());
+
+    for (acc, file) in files {
+        let permit = sem
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|e| Error::Pipeline(format!("refseq download semaphore closed: {e}")))?;
+        let acc = acc.clone();
+        let file = file.clone();
+        let cache = cache.to_path_buf();
+        let dl_config = DownloadConfig {
+            connections: config.connections,
+            chunk_size: 0,
+            force: false,
+            validate: file.md5.is_some(),
+            // Per-object bars would interleave unreadably; the one-line
+            // summary above already tells the user what is happening.
+            progress: false,
+            resume: config.resume,
+            auto_scale_connections: true,
+            client: config.http_client.clone(),
+            expected_prefix: Some(KAR_MAGIC.to_vec()),
+        };
+        tasks.push(tokio::spawn(async move {
+            let _permit = permit;
+            let urls = mirror_urls(&file);
+            // Download to a sibling `.partial` and rename on success, so a
+            // reader never sees a truncated object and an interrupted run
+            // leaves a resumable file rather than a poisoned cache entry.
+            let partial = cache.join(format!("{acc}.partial"));
+            let final_path = cache.join(&acc);
+            download_file_with_retries(
+                &urls,
+                file.size,
+                file.md5.as_deref(),
+                &partial,
+                &dl_config,
+                &TransferRetryPolicy::default(),
+            )
+            .await
+            .map_err(|e| Error::Pipeline(format!("external reference {acc}: {e}")))?;
+            std::fs::rename(&partial, &final_path).map_err(Error::Io)?;
+            let sidecar = crate::download::progress_path(&partial);
+            let _ = std::fs::remove_file(&sidecar);
+            Ok::<(), Error>(())
+        }));
+    }
+
+    for task in tasks {
+        task.await
+            .map_err(|e| Error::Pipeline(format!("refseq download panicked: {e}")))??;
+    }
+    Ok(())
+}
+
+/// Mirror URLs for a resolved file, cloud first — same preference order
+/// `select_mirror` applies to the main SRA object.
+fn mirror_urls(file: &ResolvedFile) -> Vec<String> {
+    let mut mirrors: Vec<_> = file.mirrors.iter().collect();
+    mirrors.sort_by_key(|m| crate::pipeline::mirror_priority(&m.service));
+    mirrors.into_iter().map(|m| m.url.clone()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_dir_prefers_explicit_override() {
+        let explicit = PathBuf::from("/tmp/explicit");
+        assert_eq!(refseq_cache_dir(Some(&explicit)).unwrap(), explicit);
+    }
+
+    #[test]
+    fn missing_cache_entry_is_not_reused() {
+        assert!(!is_cached(Path::new("/nonexistent/CM000663.1"), 100));
+    }
+}

--- a/crates/sracha-core/src/sdl/mod.rs
+++ b/crates/sracha-core/src/sdl/mod.rs
@@ -811,7 +811,7 @@ fn parse_run_accessions_from_csv(body: &str) -> Vec<String> {
 }
 
 /// Extract a [`ResolvedFile`] from an [`SdlFile`] response entry.
-fn resolved_file_from_sdl(sdl_file: &SdlFile) -> Result<ResolvedFile> {
+pub(crate) fn resolved_file_from_sdl(sdl_file: &SdlFile) -> Result<ResolvedFile> {
     let mirrors: Vec<ResolvedMirror> = sdl_file
         .locations
         .iter()

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -1028,7 +1028,9 @@ fn csra_align_restore_read_row_1() {
     let read_len = row.has_mismatch.len();
     assert_eq!(read_len, 36185);
 
-    let ref_read = refs.fetch_span(row.global_ref_start, row.ref_len).unwrap();
+    let ref_read = refs
+        .fetch_span(row.global_ref_start, row.ref_span())
+        .unwrap();
     let bases = align_restore_read(
         &ref_read,
         &row.has_mismatch,
@@ -1088,7 +1090,7 @@ fn csra_seq_restore_read_row_1() {
         &read_types,
         |alignment_id| {
             let row = align.read_row(alignment_id)?;
-            let ref_read = refs.fetch_span(row.global_ref_start, row.ref_len)?;
+            let ref_read = refs.fetch_span(row.global_ref_start, row.ref_span())?;
             align_restore_read(
                 &ref_read,
                 &row.has_mismatch,

--- a/crates/sracha-core/tests/pipeline.rs
+++ b/crates/sracha-core/tests/pipeline.rs
@@ -377,6 +377,8 @@ fn test_config(
         metadata_md5: None,
         metadata_size: None,
         metadata_service: None,
+        refseq_paths: Vec::new(),
+        refseq_cache_dir: None,
     }
 }
 

--- a/crates/sracha-vdb/src/alignment.rs
+++ b/crates/sracha-vdb/src/alignment.rs
@@ -26,7 +26,6 @@ use crate::kdb::ColumnReader;
 #[derive(Debug, Clone)]
 pub struct AlignmentRow {
     pub global_ref_start: u64,
-    pub ref_len: u32,
     /// One byte per base of the final reconstructed read; `1` at positions
     /// that differ from the reference, `0` otherwise.
     pub has_mismatch: Vec<u8>,
@@ -44,16 +43,38 @@ impl AlignmentRow {
     ///
     /// Not the stored `REF_LEN`. The align schema feeds
     /// `align_restore_read` a projection sized by `out_ref_len_internal`
-    /// (`align.vschema:510`), which is `NCBI:align:get_ref_len #2` —
-    /// `read_len + sum(ref_offset)` (`libs/axf/cigar.c:1976`). `REF_LEN`
-    /// prefers the stored column and only falls back to that expression,
-    /// so on archives with soft clipping the two differ and the stored
-    /// value is short. Fully-aligned runs have them coincide, which is why
-    /// this went unnoticed until a clipped archive turned up.
+    /// (`align.vschema:510`), which `REF_LEN` only falls back to — so on
+    /// clipped archives the stored value is short.
+    ///
+    /// This is the running *peak* of the reference cursor, not the closing
+    /// sum. `NCBI:align:get_ref_len #2` (`cigar.c:1976`) uses the sum,
+    /// which is right whenever the cursor never reaches further than it
+    /// ends up; version 1 keeps the peak for exactly the case where it
+    /// does (`cigar.c:1925-1940`), and a deletion followed by an insertion
+    /// is that case — the cursor touches `read_len + 1` while the offsets
+    /// sum to `read_len - 1`. Over-estimating only fetches a few unused
+    /// bases; under-estimating fails the decode.
     pub fn ref_span(&self) -> u32 {
-        let sum: i64 = self.ref_offset.iter().map(|&o| i64::from(o)).sum();
-        let span = self.has_mismatch.len() as i64 + sum;
-        span.max(0) as u32
+        // Mirrors `align_restore_read`'s cursor exactly, back-up guard and
+        // all, and takes the high-water mark of the index it reads.
+        let mut rri: i64 = 0;
+        let mut bi: i64 = 0;
+        let mut oi = 0usize;
+        let mut needed: i64 = 0;
+        for di in 0..self.has_mismatch.len() {
+            if self.has_ref_offset.get(di).copied().unwrap_or(0) != 0
+                && bi >= 0
+                && let Some(&off) = self.ref_offset.get(oi)
+            {
+                bi = i64::from(off);
+                rri += bi;
+                oi += 1;
+            }
+            needed = needed.max(rri + 1);
+            rri += 1;
+            bi += 1;
+        }
+        needed.max(0) as u32
     }
 }
 
@@ -127,8 +148,11 @@ impl AlignmentCursor {
     /// rows within the same blob amortise the decode over thousands of
     /// reads rather than re-running deflate / irzip per row.
     pub fn read_row(&self, row_id: i64) -> Result<AlignmentRow> {
+        // REF_LEN is deliberately not read: the restore sizes its
+        // reference projection from `AlignmentRow::ref_span` instead, so
+        // reading the stored column would be a sixth random column read
+        // per alignment for a value nothing consumes.
         let global_ref_start = self.global_ref_start.read_scalar_i64(row_id)? as u64;
-        let ref_len = self.ref_len.read_scalar_u32(row_id)?;
         let has_mismatch = self.has_mismatch.read_bool_row(row_id)?;
         let has_ref_offset = self.has_ref_offset.read_bool_row(row_id)?;
         let mismatch = self.mismatch.read_byte_row(row_id)?;
@@ -136,7 +160,6 @@ impl AlignmentCursor {
 
         Ok(AlignmentRow {
             global_ref_start,
-            ref_len,
             has_mismatch,
             has_ref_offset,
             mismatch,
@@ -149,41 +172,60 @@ impl AlignmentCursor {
 mod ref_span_tests {
     use super::AlignmentRow;
 
-    fn row(read_len: usize, offsets: Vec<i32>) -> AlignmentRow {
+    /// `at` places each offset at a read position, setting HAS_REF_OFFSET.
+    fn row(read_len: usize, at: &[(usize, i32)]) -> AlignmentRow {
+        let mut has_ref_offset = vec![0u8; read_len];
+        let mut ref_offset = Vec::new();
+        for &(pos, off) in at {
+            has_ref_offset[pos] = 1;
+            ref_offset.push(off);
+        }
         AlignmentRow {
             global_ref_start: 0,
-            ref_len: 0,
             has_mismatch: vec![0; read_len],
-            has_ref_offset: vec![0; read_len],
+            has_ref_offset,
             mismatch: Vec::new(),
-            ref_offset: offsets,
+            ref_offset,
         }
+    }
+
+    fn closing_sum(r: &AlignmentRow) -> i64 {
+        r.has_mismatch.len() as i64 + r.ref_offset.iter().map(|&o| i64::from(o)).sum::<i64>()
     }
 
     /// No indels: the projection is exactly the read length.
     #[test]
     fn ungapped_span_is_read_len() {
-        assert_eq!(row(100, vec![]).ref_span(), 100);
+        assert_eq!(row(100, &[]).ref_span(), 100);
     }
 
-    /// A deletion widens the reference projection past the read length —
-    /// this is the case where a stored REF_LEN that only covers the
-    /// unclipped span leaves the restore walking off the end.
+    /// A deletion widens the reference projection past the read length.
     #[test]
     fn deletion_widens_span() {
-        assert_eq!(row(100, vec![5]).ref_span(), 105);
+        assert_eq!(row(100, &[(50, 5)]).ref_span(), 105);
     }
 
     /// An insertion narrows it.
     #[test]
     fn insertion_narrows_span() {
-        assert_eq!(row(100, vec![-3]).ref_span(), 97);
+        assert_eq!(row(100, &[(50, -3)]).ref_span(), 97);
+    }
+
+    /// A large insertion near the end leaves the cursor's high-water mark
+    /// far above where it closes. Sizing the projection by the closing sum
+    /// — what `get_ref_len #2` computes — reads past the end partway
+    /// through. This is the shape that broke SRR622461.
+    #[test]
+    fn peak_reach_beats_closing_sum() {
+        let r = row(100, &[(95, -50)]);
+        assert_eq!(closing_sum(&r), 50);
+        assert_eq!(r.ref_span(), 95);
     }
 
     /// Offsets that would drive it negative clamp at zero rather than
     /// wrapping into a huge unsigned span.
     #[test]
     fn over_shortening_clamps_to_zero() {
-        assert_eq!(row(10, vec![-50]).ref_span(), 0);
+        assert_eq!(row(10, &[(0, -50)]).ref_span(), 0);
     }
 }

--- a/crates/sracha-vdb/src/alignment.rs
+++ b/crates/sracha-vdb/src/alignment.rs
@@ -39,6 +39,24 @@ pub struct AlignmentRow {
     pub ref_offset: Vec<i32>,
 }
 
+impl AlignmentRow {
+    /// How many reference bases the restore actually walks.
+    ///
+    /// Not the stored `REF_LEN`. The align schema feeds
+    /// `align_restore_read` a projection sized by `out_ref_len_internal`
+    /// (`align.vschema:510`), which is `NCBI:align:get_ref_len #2` —
+    /// `read_len + sum(ref_offset)` (`libs/axf/cigar.c:1976`). `REF_LEN`
+    /// prefers the stored column and only falls back to that expression,
+    /// so on archives with soft clipping the two differ and the stored
+    /// value is short. Fully-aligned runs have them coincide, which is why
+    /// this went unnoticed until a clipped archive turned up.
+    pub fn ref_span(&self) -> u32 {
+        let sum: i64 = self.ref_offset.iter().map(|&o| i64::from(o)).sum();
+        let span = self.has_mismatch.len() as i64 + sum;
+        span.max(0) as u32
+    }
+}
+
 /// Handle to the PRIMARY_ALIGNMENT table columns we consume during cSRA decode.
 pub struct AlignmentCursor {
     global_ref_start: CachedColumn,
@@ -124,5 +142,48 @@ impl AlignmentCursor {
             mismatch,
             ref_offset,
         })
+    }
+}
+
+#[cfg(test)]
+mod ref_span_tests {
+    use super::AlignmentRow;
+
+    fn row(read_len: usize, offsets: Vec<i32>) -> AlignmentRow {
+        AlignmentRow {
+            global_ref_start: 0,
+            ref_len: 0,
+            has_mismatch: vec![0; read_len],
+            has_ref_offset: vec![0; read_len],
+            mismatch: Vec::new(),
+            ref_offset: offsets,
+        }
+    }
+
+    /// No indels: the projection is exactly the read length.
+    #[test]
+    fn ungapped_span_is_read_len() {
+        assert_eq!(row(100, vec![]).ref_span(), 100);
+    }
+
+    /// A deletion widens the reference projection past the read length —
+    /// this is the case where a stored REF_LEN that only covers the
+    /// unclipped span leaves the restore walking off the end.
+    #[test]
+    fn deletion_widens_span() {
+        assert_eq!(row(100, vec![5]).ref_span(), 105);
+    }
+
+    /// An insertion narrows it.
+    #[test]
+    fn insertion_narrows_span() {
+        assert_eq!(row(100, vec![-3]).ref_span(), 97);
+    }
+
+    /// Offsets that would drive it negative clamp at zero rather than
+    /// wrapping into a huge unsigned span.
+    #[test]
+    fn over_shortening_clamps_to_zero() {
+        assert_eq!(row(10, vec![-50]).ref_span(), 0);
     }
 }

--- a/crates/sracha-vdb/src/alignment.rs
+++ b/crates/sracha-vdb/src/alignment.rs
@@ -88,15 +88,15 @@ impl AlignmentCursor {
         let row_count = global_ref_start.row_count();
 
         Ok(Self {
-            global_ref_start: CachedColumn::new(
+            global_ref_start: CachedColumn::new_random(
                 global_ref_start,
                 ColumnKind::Irzip { elem_bits: 64 },
             ),
-            ref_len: CachedColumn::new(ref_len, ColumnKind::Irzip { elem_bits: 32 }),
-            has_mismatch: CachedColumn::new(has_mismatch, ColumnKind::Zip),
-            has_ref_offset: CachedColumn::new(has_ref_offset, ColumnKind::Zip),
-            mismatch: CachedColumn::new(mismatch, ColumnKind::Zip),
-            ref_offset: CachedColumn::new(ref_offset, ColumnKind::Irzip { elem_bits: 32 }),
+            ref_len: CachedColumn::new_random(ref_len, ColumnKind::Irzip { elem_bits: 32 }),
+            has_mismatch: CachedColumn::new_random(has_mismatch, ColumnKind::Zip),
+            has_ref_offset: CachedColumn::new_random(has_ref_offset, ColumnKind::Zip),
+            mismatch: CachedColumn::new_random(mismatch, ColumnKind::Zip),
+            ref_offset: CachedColumn::new_random(ref_offset, ColumnKind::Irzip { elem_bits: 32 }),
             row_count,
             first_row,
         })

--- a/crates/sracha-vdb/src/alignment.rs
+++ b/crates/sracha-vdb/src/alignment.rs
@@ -88,15 +88,15 @@ impl AlignmentCursor {
         let row_count = global_ref_start.row_count();
 
         Ok(Self {
-            global_ref_start: CachedColumn::new_random(
+            global_ref_start: CachedColumn::new(
                 global_ref_start,
                 ColumnKind::Irzip { elem_bits: 64 },
             ),
-            ref_len: CachedColumn::new_random(ref_len, ColumnKind::Irzip { elem_bits: 32 }),
-            has_mismatch: CachedColumn::new_random(has_mismatch, ColumnKind::Zip),
-            has_ref_offset: CachedColumn::new_random(has_ref_offset, ColumnKind::Zip),
-            mismatch: CachedColumn::new_random(mismatch, ColumnKind::Zip),
-            ref_offset: CachedColumn::new_random(ref_offset, ColumnKind::Irzip { elem_bits: 32 }),
+            ref_len: CachedColumn::new(ref_len, ColumnKind::Irzip { elem_bits: 32 }),
+            has_mismatch: CachedColumn::new(has_mismatch, ColumnKind::Zip),
+            has_ref_offset: CachedColumn::new(has_ref_offset, ColumnKind::Zip),
+            mismatch: CachedColumn::new(mismatch, ColumnKind::Zip),
+            ref_offset: CachedColumn::new(ref_offset, ColumnKind::Irzip { elem_bits: 32 }),
             row_count,
             first_row,
         })

--- a/crates/sracha-vdb/src/blob.rs
+++ b/crates/sracha-vdb/src/blob.rs
@@ -360,6 +360,25 @@ impl PageMap {
         self.row_extents_range(0, self.total_rows() as usize)
     }
 
+    /// One row's extent, without materialising the rest of the blob.
+    ///
+    /// Costs one step per length run crossed (see `LengthRunCursor`), not
+    /// one per row, so random single-row reads should use this rather than
+    /// expanding every extent to index one of them.
+    pub fn extent_at(&self, row: usize) -> Result<RowExtent> {
+        let mut found = None;
+        self.for_each_row_extent(row, 1, |_, e| {
+            found = Some(e);
+            Ok(())
+        })?;
+        found.ok_or_else(|| {
+            Error::Format(format!(
+                "page_map: row {row} outside blob of {} rows",
+                self.total_rows()
+            ))
+        })
+    }
+
     /// [`row_extents`](Self::row_extents) for the window `[skip, skip + take)`.
     pub fn row_extents_range(&self, skip: usize, take: usize) -> Result<Vec<RowExtent>> {
         let mut out = Vec::with_capacity(take.min(self.total_rows() as usize));

--- a/crates/sracha-vdb/src/blob.rs
+++ b/crates/sracha-vdb/src/blob.rs
@@ -360,25 +360,6 @@ impl PageMap {
         self.row_extents_range(0, self.total_rows() as usize)
     }
 
-    /// One row's extent, without materialising the rest of the blob.
-    ///
-    /// Costs one step per length run crossed (see `LengthRunCursor`), not
-    /// one per row, so random single-row reads should use this rather than
-    /// expanding every extent to index one of them.
-    pub fn extent_at(&self, row: usize) -> Result<RowExtent> {
-        let mut found = None;
-        self.for_each_row_extent(row, 1, |_, e| {
-            found = Some(e);
-            Ok(())
-        })?;
-        found.ok_or_else(|| {
-            Error::Format(format!(
-                "page_map: row {row} outside blob of {} rows",
-                self.total_rows()
-            ))
-        })
-    }
-
     /// [`row_extents`](Self::row_extents) for the window `[skip, skip + take)`.
     pub fn row_extents_range(&self, skip: usize, take: usize) -> Result<Vec<RowExtent>> {
         let mut out = Vec::with_capacity(take.min(self.total_rows() as usize));

--- a/crates/sracha-vdb/src/cache.rs
+++ b/crates/sracha-vdb/src/cache.rs
@@ -61,10 +61,16 @@ impl DecodedColumnBlob {
     /// With no page map every row is one element wide at its own index.
     pub fn extent(&self, logical_offset: usize) -> Result<RowExtent> {
         if self.extents.is_empty() {
-            return Ok(RowExtent {
-                offset: logical_offset as u32,
-                len: 1,
-            });
+            // Random-access columns skip the eager expansion; ask the page
+            // map for just this row. Without a page map there is nothing to
+            // consult and every row is one element wide at its own index.
+            return match &self.page_map {
+                Some(pm) => pm.extent_at(logical_offset),
+                None => Ok(RowExtent {
+                    offset: logical_offset as u32,
+                    len: 1,
+                }),
+            };
         }
         self.extents.get(logical_offset).copied().ok_or_else(|| {
             Error::Format(format!(
@@ -82,12 +88,39 @@ impl DecodedColumnBlob {
 pub(crate) struct CachedColumn {
     col: Arc<ColumnReader>,
     kind: ColumnKind,
+    /// Skip expanding every row extent when a blob is decoded, and look up
+    /// rows one at a time instead.
+    ///
+    /// Blobs here hold thousands of rows, and cSRA reads them at random
+    /// (alignments arrive in spot order but sit in reference order), so a
+    /// blob is typically decoded to serve a single row. Expanding all of
+    /// its extents to index one was 70% of decode time. Sequential
+    /// consumers — the plain pipeline — keep the eager expansion, which is
+    /// cheaper once several rows of a blob get read.
+    random_access: bool,
     cache: RefCell<Option<DecodedColumnBlob>>,
 }
 
 impl CachedColumn {
     pub fn new(col: ColumnReader, kind: ColumnKind) -> Self {
         Self::from_shared(Arc::new(col), kind)
+    }
+
+    /// As [`new`](Self::new), for a column whose rows are read in random
+    /// order. See the `random_access` field.
+    pub fn new_random(col: ColumnReader, kind: ColumnKind) -> Self {
+        Self {
+            random_access: true,
+            ..Self::from_shared(Arc::new(col), kind)
+        }
+    }
+
+    /// As [`from_shared`](Self::from_shared), for random-order reads.
+    pub fn from_shared_random(col: Arc<ColumnReader>, kind: ColumnKind) -> Self {
+        Self {
+            random_access: true,
+            ..Self::from_shared(col, kind)
+        }
     }
 
     /// Wrap a `ColumnReader` that is already shared. External refseq
@@ -98,6 +131,7 @@ impl CachedColumn {
         Self {
             col,
             kind,
+            random_access: false,
             cache: RefCell::new(None),
         }
     }
@@ -141,11 +175,15 @@ impl CachedColumn {
         };
         let page_map = decoded.page_map;
         let row_length = decoded.row_length;
-        let extents = page_map
-            .as_ref()
-            .map(|pm| pm.row_extents())
-            .transpose()?
-            .unwrap_or_default();
+        let extents = if self.random_access {
+            Vec::new()
+        } else {
+            page_map
+                .as_ref()
+                .map(|pm| pm.row_extents())
+                .transpose()?
+                .unwrap_or_default()
+        };
 
         *self.cache.borrow_mut() = Some(DecodedColumnBlob {
             start_id,

--- a/crates/sracha-vdb/src/cache.rs
+++ b/crates/sracha-vdb/src/cache.rs
@@ -61,16 +61,10 @@ impl DecodedColumnBlob {
     /// With no page map every row is one element wide at its own index.
     pub fn extent(&self, logical_offset: usize) -> Result<RowExtent> {
         if self.extents.is_empty() {
-            // Random-access columns skip the eager expansion; ask the page
-            // map for just this row. Without a page map there is nothing to
-            // consult and every row is one element wide at its own index.
-            return match &self.page_map {
-                Some(pm) => pm.extent_at(logical_offset),
-                None => Ok(RowExtent {
-                    offset: logical_offset as u32,
-                    len: 1,
-                }),
-            };
+            return Ok(RowExtent {
+                offset: logical_offset as u32,
+                len: 1,
+            });
         }
         self.extents.get(logical_offset).copied().ok_or_else(|| {
             Error::Format(format!(
@@ -88,39 +82,12 @@ impl DecodedColumnBlob {
 pub(crate) struct CachedColumn {
     col: Arc<ColumnReader>,
     kind: ColumnKind,
-    /// Skip expanding every row extent when a blob is decoded, and look up
-    /// rows one at a time instead.
-    ///
-    /// Blobs here hold thousands of rows, and cSRA reads them at random
-    /// (alignments arrive in spot order but sit in reference order), so a
-    /// blob is typically decoded to serve a single row. Expanding all of
-    /// its extents to index one was 70% of decode time. Sequential
-    /// consumers — the plain pipeline — keep the eager expansion, which is
-    /// cheaper once several rows of a blob get read.
-    random_access: bool,
     cache: RefCell<Option<DecodedColumnBlob>>,
 }
 
 impl CachedColumn {
     pub fn new(col: ColumnReader, kind: ColumnKind) -> Self {
         Self::from_shared(Arc::new(col), kind)
-    }
-
-    /// As [`new`](Self::new), for a column whose rows are read in random
-    /// order. See the `random_access` field.
-    pub fn new_random(col: ColumnReader, kind: ColumnKind) -> Self {
-        Self {
-            random_access: true,
-            ..Self::from_shared(Arc::new(col), kind)
-        }
-    }
-
-    /// As [`from_shared`](Self::from_shared), for random-order reads.
-    pub fn from_shared_random(col: Arc<ColumnReader>, kind: ColumnKind) -> Self {
-        Self {
-            random_access: true,
-            ..Self::from_shared(col, kind)
-        }
     }
 
     /// Wrap a `ColumnReader` that is already shared. External refseq
@@ -131,7 +98,6 @@ impl CachedColumn {
         Self {
             col,
             kind,
-            random_access: false,
             cache: RefCell::new(None),
         }
     }
@@ -175,15 +141,11 @@ impl CachedColumn {
         };
         let page_map = decoded.page_map;
         let row_length = decoded.row_length;
-        let extents = if self.random_access {
-            Vec::new()
-        } else {
-            page_map
-                .as_ref()
-                .map(|pm| pm.row_extents())
-                .transpose()?
-                .unwrap_or_default()
-        };
+        let extents = page_map
+            .as_ref()
+            .map(|pm| pm.row_extents())
+            .transpose()?
+            .unwrap_or_default();
 
         *self.cache.borrow_mut() = Some(DecodedColumnBlob {
             start_id,

--- a/crates/sracha-vdb/src/cache.rs
+++ b/crates/sracha-vdb/src/cache.rs
@@ -323,31 +323,24 @@ impl CachedColumn {
     /// (one nibble per byte). Used for `REFERENCE.CMP_READ` and
     /// `SEQUENCE.CMP_READ`.
     pub fn read_2na_row(&self, row_id: i64) -> Result<Vec<u8>> {
+        self.read_2na_range(row_id, 0, usize::MAX)
+    }
+
+    /// `take` bases of a 2na row starting `skip` bases into it.
+    ///
+    /// Callers that want a short span out of a wide row should use this
+    /// rather than slicing [`read_2na_row`](Self::read_2na_row): a refseq
+    /// chunk is 5,000 bases and an alignment typically needs ~100, so
+    /// unpacking the whole row throws away 98% of the work. `take` is
+    /// clamped to what the row actually holds.
+    pub fn read_2na_range(&self, row_id: i64, skip: usize, take: usize) -> Result<Vec<u8>> {
         debug_assert!(matches!(self.kind, ColumnKind::TwoNa));
         self.with_blob(row_id, |blob, logical_offset| {
-            // Two storage shapes. Variable-length rows (SEQUENCE/REFERENCE
-            // CMP_READ) carry a page map with per-row extents. Fixed-width
-            // rows (a refseq object's READ) are stored as v1 blobs with no
-            // page map at all — rows sit back to back at `row_length`
-            // bases each. The final row of a column is short, so clamp to
-            // what the payload actually holds.
-            let (start_bases, len_bases) = match (&blob.page_map, blob.row_length) {
-                (Some(_), _) => {
-                    let extent = blob.extent(logical_offset)?;
-                    (extent.offset as usize, extent.len as usize)
-                }
-                (None, Some(row_length)) => {
-                    let width = row_length as usize;
-                    let start = logical_offset * width;
-                    let available = (blob.bytes.len() * 8 / 2).saturating_sub(start);
-                    (start, width.min(available))
-                }
-                (None, None) => {
-                    return Err(Error::Format(
-                        "2na column: neither a page map nor a fixed row length".into(),
-                    ));
-                }
-            };
+            let (start_bases, len_bases) = two_na_extent(blob, logical_offset)?;
+            // Narrow to the requested window before doing any unpacking.
+            let skipped = skip.min(len_bases);
+            let start_bases = start_bases + skipped;
+            let len_bases = (len_bases - skipped).min(take);
             if len_bases == 0 {
                 return Ok(Vec::new());
             }
@@ -370,6 +363,41 @@ impl CachedColumn {
             }
             Ok(out)
         })
+    }
+
+    /// Bases in a 2na row, without unpacking any of them. Callers need
+    /// this to place a right-aligned ALTREAD mask when they are only
+    /// reading part of the row.
+    pub fn two_na_row_len(&self, row_id: i64) -> Result<usize> {
+        debug_assert!(matches!(self.kind, ColumnKind::TwoNa));
+        self.with_blob(row_id, |blob, logical_offset| {
+            Ok(two_na_extent(blob, logical_offset)?.1)
+        })
+    }
+}
+
+/// Where a 2na row sits in its decoded blob, as `(first base, base count)`.
+///
+/// Two storage shapes. Variable-length rows (SEQUENCE/REFERENCE CMP_READ)
+/// carry a page map with per-row extents. Fixed-width rows (a refseq
+/// object's READ) are v1 blobs with no page map at all — rows sit back to
+/// back at `row_length` bases each. A column's final row is short, so
+/// clamp to what the payload actually holds.
+fn two_na_extent(blob: &DecodedColumnBlob, logical_offset: usize) -> Result<(usize, usize)> {
+    match (&blob.page_map, blob.row_length) {
+        (Some(_), _) => {
+            let extent = blob.extent(logical_offset)?;
+            Ok((extent.offset as usize, extent.len as usize))
+        }
+        (None, Some(row_length)) => {
+            let width = row_length as usize;
+            let start = logical_offset * width;
+            let available = (blob.bytes.len() * 8 / 2).saturating_sub(start);
+            Ok((start, width.min(available)))
+        }
+        (None, None) => Err(Error::Format(
+            "2na column: neither a page map nor a fixed row length".into(),
+        )),
     }
 }
 

--- a/crates/sracha-vdb/src/cache.rs
+++ b/crates/sracha-vdb/src/cache.rs
@@ -9,6 +9,7 @@
 //! hot-path row lookups are O(1) once the blob is warm.
 
 use std::cell::RefCell;
+use std::sync::Arc;
 
 use crate::blob::{self, DecodedBlob, PageMap, RowExtent};
 use crate::error::{Error, Result};
@@ -48,6 +49,10 @@ pub(crate) struct DecodedColumnBlob {
     /// for bit-packed rows, bytes for byte rows, elements for integer rows,
     /// bases for 2na rows.
     pub extents: Vec<RowExtent>,
+    /// Fixed elements-per-row declared by a v1 blob header. v1 blobs carry
+    /// no page map because every row is the same width — refseq `READ`
+    /// columns are stored this way (one `MAX_SEQ_LEN` chunk per row).
+    pub row_length: Option<u64>,
 }
 
 impl DecodedColumnBlob {
@@ -75,13 +80,21 @@ impl DecodedColumnBlob {
 /// Not thread-safe — expects to be owned by a single-threaded consumer
 /// (cSRA decode spawns one `CsraCursor` per rayon worker).
 pub(crate) struct CachedColumn {
-    col: ColumnReader,
+    col: Arc<ColumnReader>,
     kind: ColumnKind,
     cache: RefCell<Option<DecodedColumnBlob>>,
 }
 
 impl CachedColumn {
     pub fn new(col: ColumnReader, kind: ColumnKind) -> Self {
+        Self::from_shared(Arc::new(col), kind)
+    }
+
+    /// Wrap a `ColumnReader` that is already shared. External refseq
+    /// objects are opened once per accession and read by every decode
+    /// worker, so the mmap is shared while each worker keeps its own
+    /// single-slot blob cache (which is `RefCell`, hence not `Sync`).
+    pub fn from_shared(col: Arc<ColumnReader>, kind: ColumnKind) -> Self {
         Self {
             col,
             kind,
@@ -127,6 +140,7 @@ impl CachedColumn {
             ColumnKind::TwoNa => decoded.data.to_vec(),
         };
         let page_map = decoded.page_map;
+        let row_length = decoded.row_length;
         let extents = page_map
             .as_ref()
             .map(|pm| pm.row_extents())
@@ -138,6 +152,7 @@ impl CachedColumn {
             bytes,
             page_map,
             extents,
+            row_length,
         });
 
         let borrow = self.cache.borrow();
@@ -310,16 +325,33 @@ impl CachedColumn {
     pub fn read_2na_row(&self, row_id: i64) -> Result<Vec<u8>> {
         debug_assert!(matches!(self.kind, ColumnKind::TwoNa));
         self.with_blob(row_id, |blob, logical_offset| {
-            let pm = blob.page_map.as_ref().ok_or_else(|| {
-                Error::Format("2na column: page_map required for record boundaries".into())
-            })?;
-            let _ = pm; // presence-only check; extents already cached.
-            let extent = blob.extent(logical_offset)?;
-            let len_bases = extent.len as usize;
+            // Two storage shapes. Variable-length rows (SEQUENCE/REFERENCE
+            // CMP_READ) carry a page map with per-row extents. Fixed-width
+            // rows (a refseq object's READ) are stored as v1 blobs with no
+            // page map at all — rows sit back to back at `row_length`
+            // bases each. The final row of a column is short, so clamp to
+            // what the payload actually holds.
+            let (start_bases, len_bases) = match (&blob.page_map, blob.row_length) {
+                (Some(_), _) => {
+                    let extent = blob.extent(logical_offset)?;
+                    (extent.offset as usize, extent.len as usize)
+                }
+                (None, Some(row_length)) => {
+                    let width = row_length as usize;
+                    let start = logical_offset * width;
+                    let available = (blob.bytes.len() * 8 / 2).saturating_sub(start);
+                    (start, width.min(available))
+                }
+                (None, None) => {
+                    return Err(Error::Format(
+                        "2na column: neither a page map nor a fixed row length".into(),
+                    ));
+                }
+            };
             if len_bases == 0 {
                 return Ok(Vec::new());
             }
-            let start_bits = (extent.offset as usize) * 2;
+            let start_bits = start_bases * 2;
 
             // 2na → 4na nibble lookup. Bases are MSB-first within each
             // byte (verified by cross-check against vdb-dump on
@@ -503,6 +535,7 @@ mod tests {
             bytes: Vec::new(),
             page_map: None,
             extents: Vec::new(),
+            row_length: None,
         };
         assert_eq!(blob.extent(0).unwrap(), RowExtent { offset: 0, len: 1 });
         assert_eq!(blob.extent(42).unwrap(), RowExtent { offset: 42, len: 1 });
@@ -519,6 +552,7 @@ mod tests {
                 RowExtent { offset: 0, len: 3 },
                 RowExtent { offset: 3, len: 3 },
             ],
+            row_length: None,
         };
         assert_eq!(blob.extent(0).unwrap(), RowExtent { offset: 0, len: 3 });
         assert_eq!(blob.extent(2).unwrap(), RowExtent { offset: 3, len: 3 });

--- a/crates/sracha-vdb/src/csra.rs
+++ b/crates/sracha-vdb/src/csra.rs
@@ -9,6 +9,7 @@
 
 use std::io::{Read, Seek};
 use std::path::Path;
+use std::sync::Arc;
 
 use crate::alignment::AlignmentCursor;
 use crate::cache::{CachedColumn, ColumnKind};
@@ -17,6 +18,7 @@ use crate::inspect;
 use crate::kar::KarArchive;
 use crate::kdb::ColumnReader;
 use crate::reference::ReferenceCursor;
+use crate::refseq::RefSeqStore;
 use crate::restore::{align_restore_read, seq_restore_read};
 
 /// Given a `.sra` path, return the canonical `.sra.vdbcache` sibling path
@@ -40,12 +42,15 @@ pub(crate) fn archive_has_table<R: Read + Seek>(archive: &KarArchive<R>, table: 
         .any(|k| k == &exact || k.ends_with(&suffix))
 }
 
-fn archive_has_seq_cmp_read<R: Read + Seek>(archive: &KarArchive<R>) -> bool {
-    let exact = "tbl/SEQUENCE/col/CMP_READ";
-    let nested = "/tbl/SEQUENCE/col/CMP_READ";
+/// Does the KAR TOC contain `tbl/SEQUENCE/col/{col}` (at the archive root
+/// or nested under a single accession prefix)? Cheap TOC scan — no column
+/// open — so callers can branch on archive shape before doing any work.
+fn archive_has_seq_col<R: Read + Seek>(archive: &KarArchive<R>, col: &str) -> bool {
+    let exact = format!("tbl/SEQUENCE/col/{col}");
+    let nested = format!("/tbl/SEQUENCE/col/{col}");
     archive.entries().keys().any(|k| {
-        k == exact
-            || k.ends_with(nested)
+        k == &exact
+            || k.ends_with(&nested)
             || k.starts_with(&format!("{exact}/"))
             || k.contains(&format!("{nested}/"))
     })
@@ -69,11 +74,13 @@ fn archive_has_reference_cmp_read<R: Read + Seek>(archive: &KarArchive<R>) -> bo
 
 /// Inspect the KAR archive at `sra_path` (and optional `.vdbcache`
 /// sidecar) and return true if the pair looks like a reference-
-/// compressed cSRA decodable by `CsraCursor`. `SEQUENCE/col/CMP_READ`
-/// must live in the main archive (the SEQUENCE half is never
-/// sidecar'd). `PRIMARY_ALIGNMENT` and `REFERENCE` may live in either
-/// archive — older monolithic cSRA (VDB-3418) keeps them in main,
-/// modern NCBI uploads split them into `.sra.vdbcache`.
+/// compressed cSRA decodable by `CsraCursor`. The SEQUENCE half always
+/// lives in the main archive (it is never sidecar'd) and must carry
+/// either `CMP_READ` (partially-aligned runs keep their unaligned
+/// residue there) or, for fully-aligned runs, `PRIMARY_ALIGNMENT_ID`
+/// with no physical `READ` at all. `PRIMARY_ALIGNMENT` and `REFERENCE`
+/// may live in either archive — older monolithic cSRA (VDB-3418) keeps
+/// them in main, some NCBI uploads split them into `.sra.vdbcache`.
 ///
 /// Pure TOC scan — no column reads — so safe to call up-front from
 /// `pipeline::run_fastq`.
@@ -84,7 +91,15 @@ pub fn looks_like_decodable_csra(sra_path: &Path, vdbcache_path: Option<&Path>) 
         _ => None,
     };
 
-    let has_seq_cmp_read = archive_has_seq_cmp_read(&main);
+    let has_seq_cmp_read = archive_has_seq_col(&main, "CMP_READ");
+    // Fully-aligned runs (e.g. ERR10213669) store no unaligned residue
+    // whatsoever: bam-load emits neither CMP_READ nor a physical READ, and
+    // every base is reconstructed from PRIMARY_ALIGNMENT. Requiring
+    // CMP_READ would skip them; requiring the absence of READ keeps plain
+    // (unaligned) SRA out.
+    let fully_aligned = !has_seq_cmp_read
+        && archive_has_seq_col(&main, "PRIMARY_ALIGNMENT_ID")
+        && !archive_has_seq_col(&main, "READ");
     let has_primary = archive_has_table(&main, "PRIMARY_ALIGNMENT")
         || cache
             .as_ref()
@@ -96,7 +111,7 @@ pub fn looks_like_decodable_csra(sra_path: &Path, vdbcache_path: Option<&Path>) 
             .map(|c| archive_has_table(c, "REFERENCE"))
             .unwrap_or(false);
 
-    Ok(has_seq_cmp_read && has_primary && has_reference)
+    Ok((has_seq_cmp_read || fully_aligned) && has_primary && has_reference)
 }
 
 fn open_kar(path: &Path) -> Result<KarArchive<std::io::BufReader<std::fs::File>>> {
@@ -150,8 +165,9 @@ fn archive_has_seq_column<R: Read + Seek>(
 }
 
 pub struct CsraCursor {
-    // SEQUENCE-side columns
-    cmp_read: CachedColumn,
+    // SEQUENCE-side columns. `cmp_read` is absent on fully-aligned runs,
+    // where no spot has unaligned residue to splice in.
+    cmp_read: Option<CachedColumn>,
     primary_alignment_id: CachedColumn,
     read_len: CachedColumn,
     read_type: CachedColumn,
@@ -199,6 +215,19 @@ impl CsraCursor {
         main_path: &Path,
         vdbcache: Option<(&mut KarArchive<R>, &Path)>,
     ) -> Result<Self> {
+        Self::open_with_refseqs(main, main_path, vdbcache, None)
+    }
+
+    /// As [`open_any`](Self::open_any), plus external reference objects for
+    /// archives whose REFERENCE table carries only the chunk layout and
+    /// leaves the bases in NCBI refseq objects named by `SEQ_ID`. Pass
+    /// `None` when the archive embeds its bases.
+    pub fn open_with_refseqs<R: Read + Seek>(
+        main: &mut KarArchive<R>,
+        main_path: &Path,
+        vdbcache: Option<(&mut KarArchive<R>, &Path)>,
+        refseqs: Option<&Arc<RefSeqStore>>,
+    ) -> Result<Self> {
         // SEQUENCE-side columns always live in the main archive — the
         // vdbcache only carries the alignment + reference halves.
         let col_base = inspect::column_base_path_public(main, Some("SEQUENCE"))?;
@@ -213,18 +242,35 @@ impl CsraCursor {
         if !archive_has_seq_column(main, &col_base, "READ_LEN") {
             return Err(fixed_length_readlen_error());
         }
+        // Reference bases must come from somewhere: embedded CMP_READ in
+        // either archive, or external refseq objects the caller fetched.
+        let have_refseqs = refseqs.is_some_and(|s| !s.is_empty());
         let main_has_ref_cmp_read = archive_has_reference_cmp_read(main);
         let cache_has_ref_cmp_read =
             matches!(&vdbcache, Some((c, _)) if archive_has_reference_cmp_read(c));
-        if !main_has_ref_cmp_read && !cache_has_ref_cmp_read {
+        if !main_has_ref_cmp_read && !cache_has_ref_cmp_read && !have_refseqs {
             return Err(external_refseq_error());
         }
 
-        let cmp_read = open_col(main, "CMP_READ")?;
+        // Absent on fully-aligned runs — `read_spot` then splices from an
+        // empty unaligned buffer, which `seq_restore_read` handles as long
+        // as every read really is aligned (it errors loudly otherwise).
+        let cmp_read = if archive_has_seq_column(main, &col_base, "CMP_READ") {
+            Some(open_col(main, "CMP_READ")?)
+        } else {
+            None
+        };
         let primary_alignment_id = open_col(main, "PRIMARY_ALIGNMENT_ID")?;
         let read_len = open_col(main, "READ_LEN")?;
         let read_type = open_col(main, "READ_TYPE")?;
-        let quality = open_col(main, "QUALITY")?;
+        // Same QUALITY/ORIGINAL_QUALITY duality the plain cursor handles
+        // (see `cursor.rs`); bam-load-produced cSRA often has only the
+        // latter.
+        let quality = if archive_has_seq_column(main, &col_base, "QUALITY") {
+            open_col(main, "QUALITY")?
+        } else {
+            open_col(main, "ORIGINAL_QUALITY")?
+        };
 
         let primary_in_main = archive_has_table(main, "PRIMARY_ALIGNMENT");
         let reference_in_main = archive_has_table(main, "REFERENCE");
@@ -235,11 +281,11 @@ impl CsraCursor {
         // duration of its scope.
         let (alignment, reference) = match vdbcache {
             None => {
-                if !archive_has_reference_cmp_read(main) {
+                if !main_has_ref_cmp_read && !have_refseqs {
                     return Err(external_refseq_error());
                 }
                 let alignment = AlignmentCursor::open(main, main_path)?;
-                let reference = ReferenceCursor::open(main, main_path)?;
+                let reference = ReferenceCursor::open_with_external(main, main_path, refseqs)?;
                 (alignment, reference)
             }
             Some((cache, cache_path)) => {
@@ -254,15 +300,15 @@ impl CsraCursor {
                     ));
                 };
                 let reference = if reference_in_main {
-                    if !archive_has_reference_cmp_read(main) {
+                    if !main_has_ref_cmp_read && !have_refseqs {
                         return Err(external_refseq_error());
                     }
-                    ReferenceCursor::open(main, main_path)?
+                    ReferenceCursor::open_with_external(main, main_path, refseqs)?
                 } else if archive_has_table(cache, "REFERENCE") {
-                    if !archive_has_reference_cmp_read(cache) {
+                    if !archive_has_reference_cmp_read(cache) && !have_refseqs {
                         return Err(external_refseq_error());
                     }
-                    ReferenceCursor::open(cache, cache_path)?
+                    ReferenceCursor::open_with_external(cache, cache_path, refseqs)?
                 } else {
                     return Err(Error::Format(
                         "cSRA: REFERENCE table not found in main archive or vdbcache".into(),
@@ -272,11 +318,13 @@ impl CsraCursor {
             }
         };
 
-        let first_row = cmp_read.first_row_id().unwrap_or(1);
-        let row_count = cmp_read.row_count();
+        // Row extent comes from PRIMARY_ALIGNMENT_ID rather than CMP_READ:
+        // it is the one SEQUENCE column present on every cSRA shape.
+        let first_row = primary_alignment_id.first_row_id().unwrap_or(1);
+        let row_count = primary_alignment_id.row_count();
 
         Ok(Self {
-            cmp_read: CachedColumn::new(cmp_read, ColumnKind::TwoNa),
+            cmp_read: cmp_read.map(|c| CachedColumn::new(c, ColumnKind::TwoNa)),
             primary_alignment_id: CachedColumn::new(
                 primary_alignment_id,
                 ColumnKind::Irzip { elem_bits: 64 },
@@ -375,7 +423,10 @@ impl CsraCursor {
         let align_ids = self.primary_alignment_id.read_i64_row(row_id)?;
         let read_lens = self.read_len.read_u32_row(row_id)?;
         let read_types = self.read_type.read_byte_row(row_id)?;
-        let cmp_read_2na = self.cmp_read.read_2na_row(row_id)?;
+        let cmp_read_2na = match &self.cmp_read {
+            Some(c) => c.read_2na_row(row_id)?,
+            None => Vec::new(),
+        };
         let quality = self.quality.read_byte_row(row_id)?;
 
         if read_lens.len() != align_ids.len() || read_types.len() != align_ids.len() {

--- a/crates/sracha-vdb/src/csra.rs
+++ b/crates/sracha-vdb/src/csra.rs
@@ -182,6 +182,10 @@ pub struct CsraCursor {
     // SEQUENCE-side columns. `cmp_read` is absent on fully-aligned runs,
     // where no spot has unaligned residue to splice in.
     cmp_read: Option<CachedColumn>,
+    /// Ambiguity mask over `cmp_read`, when the archive stores one. 2na
+    /// cannot represent N, so without this the unaligned half of a read
+    /// decodes its Ns as a confident `A`.
+    cmp_altread: Option<CachedColumn>,
     primary_alignment_id: CachedColumn,
     read_len: CachedColumn,
     read_type: CachedColumn,
@@ -277,6 +281,13 @@ impl CsraCursor {
         } else {
             None
         };
+        // `NCBI:align:tbl:cmp_base_space` pairs CMP_READ with CMP_ALTREAD
+        // and bit_ors them; archives without ambiguity codes omit it.
+        let cmp_altread = if archive_has_seq_column(main, &col_base, "CMP_ALTREAD") {
+            Some(open_col(main, "CMP_ALTREAD")?)
+        } else {
+            None
+        };
         let primary_alignment_id = open_col(main, "PRIMARY_ALIGNMENT_ID")?;
         let read_len = open_col(main, "READ_LEN")?;
         let read_type = open_col(main, "READ_TYPE")?;
@@ -343,6 +354,7 @@ impl CsraCursor {
 
         Ok(Self {
             cmp_read: cmp_read.map(|c| CachedColumn::new(c, ColumnKind::TwoNa)),
+            cmp_altread: cmp_altread.map(|c| CachedColumn::new(c, ColumnKind::Zip)),
             primary_alignment_id: CachedColumn::new(
                 primary_alignment_id,
                 ColumnKind::Irzip { elem_bits: 64 },
@@ -441,10 +453,19 @@ impl CsraCursor {
         let align_ids = self.primary_alignment_id.read_i64_row(row_id)?;
         let read_lens = self.read_len.read_u32_row(row_id)?;
         let read_types = self.read_type.read_byte_row(row_id)?;
-        let cmp_read_2na = match &self.cmp_read {
+        let mut cmp_read_2na = match &self.cmp_read {
             Some(c) => c.read_2na_row(row_id)?,
             None => Vec::new(),
         };
+        // Restore ambiguity codes into the unaligned bases before splicing:
+        // 2na has no N, so the mask is the only thing that distinguishes an
+        // uncalled base from an A.
+        if let Some(alt) = &self.cmp_altread
+            && !cmp_read_2na.is_empty()
+        {
+            let mask = alt.read_byte_row(row_id)?;
+            crate::refseq::overlay_altread(&mut cmp_read_2na, &mask);
+        }
         let quality = self.quality.read_byte_row(row_id)?;
 
         if read_lens.len() != align_ids.len() || read_types.len() != align_ids.len() {

--- a/crates/sracha-vdb/src/csra.rs
+++ b/crates/sracha-vdb/src/csra.rs
@@ -450,7 +450,7 @@ impl CsraCursor {
                 let row = self.alignment.read_row(alignment_id)?;
                 let ref_read = self
                     .reference
-                    .fetch_span(row.global_ref_start, row.ref_len)?;
+                    .fetch_span(row.global_ref_start, row.ref_span())?;
                 align_restore_read(
                     &ref_read,
                     &row.has_mismatch,

--- a/crates/sracha-vdb/src/csra.rs
+++ b/crates/sracha-vdb/src/csra.rs
@@ -18,6 +18,7 @@ use crate::inspect;
 use crate::kar::KarArchive;
 use crate::kdb::ColumnReader;
 use crate::reference::ReferenceCursor;
+use crate::reference::ReferenceLayout;
 use crate::refseq::RefSeqStore;
 use crate::restore::{align_restore_read, seq_restore_read};
 
@@ -164,6 +165,19 @@ fn archive_has_seq_column<R: Read + Seek>(
         .any(|k| k == &exact || k.starts_with(&prefix))
 }
 
+/// Per-accession state shared by every cSRA decode worker.
+///
+/// Decode constructs a [`CsraCursor`] per chunk — thousands of times for a
+/// large run — so anything whose cost scales with the archive rather than
+/// the chunk belongs here, built once and shared by `Arc`.
+#[derive(Default, Clone)]
+pub struct CsraShared {
+    /// Locally-materialised external reference objects, keyed by SEQ_ID.
+    pub refseqs: Option<Arc<RefSeqStore>>,
+    /// The REFERENCE table's chunk layout.
+    pub reference: Option<Arc<ReferenceLayout>>,
+}
+
 pub struct CsraCursor {
     // SEQUENCE-side columns. `cmp_read` is absent on fully-aligned runs,
     // where no spot has unaligned residue to splice in.
@@ -215,19 +229,22 @@ impl CsraCursor {
         main_path: &Path,
         vdbcache: Option<(&mut KarArchive<R>, &Path)>,
     ) -> Result<Self> {
-        Self::open_with_refseqs(main, main_path, vdbcache, None)
+        Self::open_with_shared(main, main_path, vdbcache, None)
     }
 
-    /// As [`open_any`](Self::open_any), plus external reference objects for
-    /// archives whose REFERENCE table carries only the chunk layout and
-    /// leaves the bases in NCBI refseq objects named by `SEQ_ID`. Pass
-    /// `None` when the archive embeds its bases.
-    pub fn open_with_refseqs<R: Read + Seek>(
+    /// As [`open_any`](Self::open_any), plus the per-accession state in
+    /// [`CsraShared`] — external reference objects for archives that leave
+    /// their bases in NCBI refseq objects, and the REFERENCE chunk layout.
+    /// Pass `None` for a one-shot open; decode paths should build a
+    /// `CsraShared` once and hand the same one to every worker.
+    pub fn open_with_shared<R: Read + Seek>(
         main: &mut KarArchive<R>,
         main_path: &Path,
         vdbcache: Option<(&mut KarArchive<R>, &Path)>,
-        refseqs: Option<&Arc<RefSeqStore>>,
+        shared: Option<&CsraShared>,
     ) -> Result<Self> {
+        let refseqs = shared.and_then(|s| s.refseqs.as_ref());
+        let layout = shared.and_then(|s| s.reference.as_ref());
         // SEQUENCE-side columns always live in the main archive — the
         // vdbcache only carries the alignment + reference halves.
         let col_base = inspect::column_base_path_public(main, Some("SEQUENCE"))?;
@@ -285,7 +302,8 @@ impl CsraCursor {
                     return Err(external_refseq_error());
                 }
                 let alignment = AlignmentCursor::open(main, main_path)?;
-                let reference = ReferenceCursor::open_with_external(main, main_path, refseqs)?;
+                let reference =
+                    ReferenceCursor::open_with_external(main, main_path, refseqs, layout)?;
                 (alignment, reference)
             }
             Some((cache, cache_path)) => {
@@ -303,12 +321,12 @@ impl CsraCursor {
                     if !main_has_ref_cmp_read && !have_refseqs {
                         return Err(external_refseq_error());
                     }
-                    ReferenceCursor::open_with_external(main, main_path, refseqs)?
+                    ReferenceCursor::open_with_external(main, main_path, refseqs, layout)?
                 } else if archive_has_table(cache, "REFERENCE") {
                     if !archive_has_reference_cmp_read(cache) && !have_refseqs {
                         return Err(external_refseq_error());
                     }
-                    ReferenceCursor::open_with_external(cache, cache_path, refseqs)?
+                    ReferenceCursor::open_with_external(cache, cache_path, refseqs, layout)?
                 } else {
                     return Err(Error::Format(
                         "cSRA: REFERENCE table not found in main archive or vdbcache".into(),

--- a/crates/sracha-vdb/src/lib.rs
+++ b/crates/sracha-vdb/src/lib.rs
@@ -19,6 +19,7 @@ pub mod kdb;
 pub mod metadata;
 pub(crate) mod ptrie;
 pub mod reference;
+pub mod refseq;
 pub mod restore;
 pub mod row_range;
 

--- a/crates/sracha-vdb/src/reference.rs
+++ b/crates/sracha-vdb/src/reference.rs
@@ -109,7 +109,7 @@ impl ReferenceCursor {
         let first_row = seq_len.first_row_id().unwrap_or(1);
         let row_count = seq_len.row_count();
 
-        let cmp_read = cmp_read.map(|c| CachedColumn::new(c, ColumnKind::TwoNa));
+        let cmp_read = cmp_read.map(|c| CachedColumn::new_random(c, ColumnKind::TwoNa));
         let external = refseqs.map(RefSeqReaders::new);
         let layout = match layout {
             Some(l) => l.clone(),
@@ -188,12 +188,17 @@ impl ReferenceCursor {
             remaining -= take;
             offset_in_chunk = 0;
             if remaining > 0 {
-                // Two sequences never share a chunk, and no alignment runs
-                // past the end of its reference — so continuing into a
-                // chunk with a different SEQ_ID means the span (or the
-                // archive) is wrong. Walking on silently would splice
-                // bases from the next chromosome into the read.
-                self.check_same_reference(chunk_row, chunk_row + 1)?;
+                // Stop at the end of this reference and return a short
+                // span, exactly as ncbi-vdb's `ref_sub_select` does — its
+                // read loop is bounded by the reference's `stop_id`
+                // (libs/axf/ref-tbl-sub-select.c:204). A span can overrun
+                // the end when soft clipping widens it; those positions are
+                // mismatches and never read the reference, so the caller
+                // never notices. Splicing in the next chromosome's bases
+                // would silently corrupt the read.
+                if !self.same_reference(chunk_row, chunk_row + 1)? {
+                    break;
+                }
                 chunk_row += 1;
             }
         }
@@ -258,21 +263,18 @@ impl ReferenceCursor {
         Ok(())
     }
 
-    /// Error unless two chunk rows belong to the same reference sequence.
-    /// A no-op on archives without a `SEQ_ID` column (nothing to compare).
-    fn check_same_reference(&self, a: i64, b: i64) -> Result<()> {
+    /// Do two chunk rows belong to the same reference sequence?
+    ///
+    /// Always true on archives with no `SEQ_ID` column (one reference, so
+    /// nothing to cross); false once `b` runs off the end of the table.
+    fn same_reference(&self, a: i64, b: i64) -> Result<bool> {
         if self.layout.seq_id.is_empty() {
-            return Ok(());
+            return Ok(b < self.first_row + self.row_count as i64);
         }
-        let ida = self.layout.seq_id(a, self.first_row)?;
-        let idb = self.layout.seq_id(b, self.first_row)?;
-        if ida != idb {
-            return Err(Error::Format(format!(
-                "reference span crosses the boundary between {ida} (chunk {a}) \
-                 and {idb} (chunk {b})"
-            )));
+        if b >= self.first_row + self.row_count as i64 {
+            return Ok(false);
         }
-        Ok(())
+        Ok(self.layout.seq_id(a, self.first_row)? == self.layout.seq_id(b, self.first_row)?)
     }
 }
 

--- a/crates/sracha-vdb/src/reference.rs
+++ b/crates/sracha-vdb/src/reference.rs
@@ -109,7 +109,7 @@ impl ReferenceCursor {
         let first_row = seq_len.first_row_id().unwrap_or(1);
         let row_count = seq_len.row_count();
 
-        let cmp_read = cmp_read.map(|c| CachedColumn::new_random(c, ColumnKind::TwoNa));
+        let cmp_read = cmp_read.map(|c| CachedColumn::new(c, ColumnKind::TwoNa));
         let external = refseqs.map(RefSeqReaders::new);
         let layout = match layout {
             Some(l) => l.clone(),

--- a/crates/sracha-vdb/src/reference.rs
+++ b/crates/sracha-vdb/src/reference.rs
@@ -12,11 +12,14 @@
 use std::io::{Read, Seek};
 use std::path::Path;
 
+use std::sync::Arc;
+
 use crate::cache::{CachedColumn, ColumnKind};
 use crate::error::{Error, Result};
 use crate::inspect;
 use crate::kar::KarArchive;
 use crate::kdb::ColumnReader;
+use crate::refseq::{BASE_N, RefSeqReaders, RefSeqStore};
 
 /// BAM-load's standard chunk size. REFERENCE rows each hold up to this many
 /// bases (last chunk of a reference may be shorter, recorded in SEQ_LEN).
@@ -25,18 +28,34 @@ use crate::kdb::ColumnReader;
 /// and only fall back to this historical default when neither the column nor
 /// the SEQ_LEN-derived estimate is available — a wrong value silently corrupts
 /// cSRA reads via [`plan_span_start`].
-const DEFAULT_MAX_SEQ_LEN: u32 = 5000;
+pub(crate) const DEFAULT_MAX_SEQ_LEN: u32 = 5000;
 
 /// Upper bound on REFERENCE rows sampled when deriving MAX_SEQ_LEN from
 /// SEQ_LEN, keeping `open()` cheap on references with millions of chunks.
 const MAX_SEQ_LEN_SAMPLE_ROWS: u64 = 256;
 
-/// Handle to the REFERENCE table's CMP_READ + SEQ_LEN columns.
+/// Handle to the REFERENCE table's chunk layout and, where present, its
+/// embedded bases.
+///
+/// Bases come from one of two places, decided per chunk row exactly as
+/// ncbi-vdb's `ref_restore_read` does: the embedded `CMP_READ` column, or
+/// an external refseq object named by `SEQ_ID`. An archive may need both
+/// (`CMP_READ` present but short for some rows), so this is not an
+/// either/or split at the table level.
 pub struct ReferenceCursor {
     /// 2na-packed base bytes per chunk (unpacked to 4na-bin on read).
-    cmp_read: CachedColumn,
+    /// Absent when the run stores no reference bases at all.
+    cmp_read: Option<CachedColumn>,
     /// Real chunk length in bases (≤ `max_seq_len`). Stored as u32 irzip.
     seq_len: CachedColumn,
+    /// External reference accession per chunk. Absent on archives that
+    /// embed everything (e.g. VDB-3418).
+    seq_id: Option<CachedColumn>,
+    /// 1-based start of the chunk within its reference; 0 means "this
+    /// chunk is `SEQ_LEN` Ns" and addresses nothing externally.
+    seq_start: Option<CachedColumn>,
+    /// Locally-materialised refseq objects, when the caller supplied them.
+    external: Option<RefSeqReaders>,
     max_seq_len: u32,
     first_row: i64,
     row_count: u64,
@@ -44,17 +63,35 @@ pub struct ReferenceCursor {
 
 impl ReferenceCursor {
     pub fn open<R: Read + Seek>(archive: &mut KarArchive<R>, sra_path: &Path) -> Result<Self> {
+        Self::open_with_external(archive, sra_path, None)
+    }
+
+    /// Open the REFERENCE table, optionally backed by external refseq
+    /// objects for chunks whose bases are not embedded.
+    pub fn open_with_external<R: Read + Seek>(
+        archive: &mut KarArchive<R>,
+        sra_path: &Path,
+        refseqs: Option<&Arc<RefSeqStore>>,
+    ) -> Result<Self> {
         let col_base = inspect::column_base_path_public(archive, Some("REFERENCE"))?;
         let open = |archive: &mut KarArchive<R>, name: &str| -> Result<ColumnReader> {
             ColumnReader::open(archive, &format!("{col_base}/{name}"), sra_path)
                 .map_err(|e| Error::Format(format!("REFERENCE/{name}: {e}")))
         };
-        let cmp_read = open(archive, "CMP_READ")?;
+        let cmp_read = open(archive, "CMP_READ").ok();
         let seq_len = open(archive, "SEQ_LEN")?;
-        let first_row = cmp_read.first_row_id().unwrap_or(1);
-        let row_count = cmp_read.row_count();
+        let seq_id = open(archive, "SEQ_ID").ok();
+        let seq_start = open(archive, "SEQ_START").ok();
+        // Row extent tracks SEQ_LEN: it is the one column present on every
+        // REFERENCE shape, embedded or external.
+        let first_row = seq_len.first_row_id().unwrap_or(1);
+        let row_count = seq_len.row_count();
 
-        let cmp_read = CachedColumn::new(cmp_read, ColumnKind::TwoNa);
+        let cmp_read = cmp_read.map(|c| CachedColumn::new(c, ColumnKind::TwoNa));
+        let seq_id = seq_id.map(|c| CachedColumn::new(c, ColumnKind::Zip));
+        let seq_start =
+            seq_start.map(|c| CachedColumn::new(c, ColumnKind::Irzip { elem_bits: 32 }));
+        let external = refseqs.map(RefSeqReaders::new);
         let seq_len = CachedColumn::new(seq_len, ColumnKind::Irzip { elem_bits: 32 });
 
         // Resolve the real chunk size instead of assuming 5000. Prefer the
@@ -83,6 +120,9 @@ impl ReferenceCursor {
         Ok(Self {
             cmp_read,
             seq_len,
+            seq_id,
+            seq_start,
+            external,
             max_seq_len,
             first_row,
             row_count,
@@ -120,22 +160,91 @@ impl ReferenceCursor {
                     "reference: offset {offset_in_chunk} past chunk {chunk_row} len {chunk_len}"
                 )));
             }
-            let chunk_bases = self.cmp_read.read_2na_row(chunk_row)?;
-            if chunk_bases.len() != chunk_len {
-                return Err(Error::Format(format!(
-                    "REFERENCE.CMP_READ row {chunk_row}: page_map says {} bases, \
-                     SEQ_LEN says {chunk_len}",
-                    chunk_bases.len()
-                )));
-            }
+            let chunk_bases = self.chunk_bases(chunk_row, chunk_len)?;
             let available = chunk_len - offset_in_chunk;
             let take = remaining.min(available);
             out.extend_from_slice(&chunk_bases[offset_in_chunk..offset_in_chunk + take]);
             remaining -= take;
-            chunk_row += 1;
             offset_in_chunk = 0;
+            if remaining > 0 {
+                // Two sequences never share a chunk, and no alignment runs
+                // past the end of its reference — so continuing into a
+                // chunk with a different SEQ_ID means the span (or the
+                // archive) is wrong. Walking on silently would splice
+                // bases from the next chromosome into the read.
+                self.check_same_reference(chunk_row, chunk_row + 1)?;
+                chunk_row += 1;
+            }
         }
         Ok(out)
+    }
+
+    /// Resolve one chunk row's bases, mirroring ncbi-vdb's
+    /// `ref_restore_read`: prefer embedded `CMP_READ`, pad a short row with
+    /// Ns, treat `SEQ_START == 0` as an all-N chunk, and otherwise fetch
+    /// from the external refseq object named by `SEQ_ID`.
+    fn chunk_bases(&self, chunk_row: i64, chunk_len: usize) -> Result<Vec<u8>> {
+        if let Some(cmp) = &self.cmp_read {
+            let bases = cmp.read_2na_row(chunk_row)?;
+            if bases.len() >= chunk_len {
+                let mut bases = bases;
+                bases.truncate(chunk_len);
+                return Ok(bases);
+            }
+            if !bases.is_empty() {
+                let mut bases = bases;
+                bases.resize(chunk_len, BASE_N);
+                return Ok(bases);
+            }
+        }
+
+        let Some(seq_start_col) = &self.seq_start else {
+            return Err(Error::Format(format!(
+                "REFERENCE row {chunk_row}: no embedded bases and no SEQ_START \
+                 column to locate external ones"
+            )));
+        };
+        let seq_start = seq_start_col.read_scalar_u32(chunk_row)? as u64;
+        if seq_start == 0 {
+            return Ok(vec![BASE_N; chunk_len]);
+        }
+
+        let external = self.external.as_ref().ok_or_else(|| {
+            Error::CsraUnsupported(
+                "cSRA: reference bases are stored externally but no refseq \
+                 objects were provided"
+                    .into(),
+            )
+        })?;
+        let seq_id = self.seq_id_at(chunk_row)?;
+        external.bases_at(&seq_id, seq_start - 1, chunk_len)
+    }
+
+    /// `SEQ_ID` for a chunk row, as a string.
+    fn seq_id_at(&self, chunk_row: i64) -> Result<String> {
+        let col = self.seq_id.as_ref().ok_or_else(|| {
+            Error::Format(format!(
+                "REFERENCE row {chunk_row}: external bases needed but no SEQ_ID column"
+            ))
+        })?;
+        let bytes = col.read_byte_row(chunk_row)?;
+        Ok(String::from_utf8_lossy(&bytes).trim().to_string())
+    }
+
+    /// Error unless two chunk rows belong to the same reference sequence.
+    /// A no-op on archives without a `SEQ_ID` column (nothing to compare).
+    fn check_same_reference(&self, a: i64, b: i64) -> Result<()> {
+        if self.seq_id.is_none() {
+            return Ok(());
+        }
+        let (ida, idb) = (self.seq_id_at(a)?, self.seq_id_at(b)?);
+        if ida != idb {
+            return Err(Error::Format(format!(
+                "reference span crosses the boundary between {ida} (chunk {a}) \
+                 and {idb} (chunk {b})"
+            )));
+        }
+        Ok(())
     }
 }
 

--- a/crates/sracha-vdb/src/reference.rs
+++ b/crates/sracha-vdb/src/reference.rs
@@ -46,14 +46,10 @@ pub struct ReferenceCursor {
     /// 2na-packed base bytes per chunk (unpacked to 4na-bin on read).
     /// Absent when the run stores no reference bases at all.
     cmp_read: Option<CachedColumn>,
-    /// Real chunk length in bases (≤ `max_seq_len`). Stored as u32 irzip.
-    seq_len: CachedColumn,
-    /// External reference accession per chunk. Absent on archives that
-    /// embed everything (e.g. VDB-3418).
-    seq_id: Option<CachedColumn>,
-    /// 1-based start of the chunk within its reference; 0 means "this
-    /// chunk is `SEQ_LEN` Ns" and addresses nothing externally.
-    seq_start: Option<CachedColumn>,
+    /// The chunk layout, held in full (see [`ReferenceLayout`]). Shared:
+    /// decode builds a cursor per chunk, and re-reading this each time
+    /// costs far more than the lookups it saves.
+    layout: Arc<ReferenceLayout>,
     /// Locally-materialised refseq objects, when the caller supplied them.
     external: Option<RefSeqReaders>,
     max_seq_len: u32,
@@ -61,17 +57,45 @@ pub struct ReferenceCursor {
     row_count: u64,
 }
 
+/// The REFERENCE table's chunk layout, read once at open and kept resident.
+///
+/// Alignments arrive in spot order but land at random genome positions, so
+/// these columns are read in random row order — the worst case for a
+/// single-blob cache, whose blobs here hold ~131k rows each. Expanding a
+/// blob's page map to read one row was 44% of decode time. The layout is
+/// small enough to just hold: rows are bounded by genome size divided by
+/// `MAX_SEQ_LEN`, so a whole human genome is ~620k rows, about 7 MB across
+/// the three arrays. The bases themselves stay lazy.
+pub struct ReferenceLayout {
+    /// Real chunk length in bases (≤ `max_seq_len`), one per row.
+    seq_len: Vec<u32>,
+    /// 1-based start of the chunk within its reference; 0 means "this
+    /// chunk is `SEQ_LEN` Ns" and addresses nothing externally. Empty when
+    /// the archive has no SEQ_START column.
+    seq_start: Vec<u32>,
+    /// Index into `seq_id_names` per row. Empty when the archive has no
+    /// SEQ_ID column (it embeds everything, e.g. VDB-3418).
+    seq_id: Vec<u32>,
+    /// Distinct external reference accessions, in first-seen order.
+    seq_id_names: Vec<String>,
+}
+
 impl ReferenceCursor {
     pub fn open<R: Read + Seek>(archive: &mut KarArchive<R>, sra_path: &Path) -> Result<Self> {
-        Self::open_with_external(archive, sra_path, None)
+        Self::open_with_external(archive, sra_path, None, None)
     }
 
     /// Open the REFERENCE table, optionally backed by external refseq
     /// objects for chunks whose bases are not embedded.
+    ///
+    /// Pass `layout` to reuse a [`ReferenceLayout`] built once for the
+    /// accession; without it each cursor reads the layout itself, which is
+    /// only acceptable for one-shot callers like `sracha info`.
     pub fn open_with_external<R: Read + Seek>(
         archive: &mut KarArchive<R>,
         sra_path: &Path,
         refseqs: Option<&Arc<RefSeqStore>>,
+        layout: Option<&Arc<ReferenceLayout>>,
     ) -> Result<Self> {
         let col_base = inspect::column_base_path_public(archive, Some("REFERENCE"))?;
         let open = |archive: &mut KarArchive<R>, name: &str| -> Result<ColumnReader> {
@@ -80,19 +104,19 @@ impl ReferenceCursor {
         };
         let cmp_read = open(archive, "CMP_READ").ok();
         let seq_len = open(archive, "SEQ_LEN")?;
-        let seq_id = open(archive, "SEQ_ID").ok();
-        let seq_start = open(archive, "SEQ_START").ok();
         // Row extent tracks SEQ_LEN: it is the one column present on every
         // REFERENCE shape, embedded or external.
         let first_row = seq_len.first_row_id().unwrap_or(1);
         let row_count = seq_len.row_count();
 
         let cmp_read = cmp_read.map(|c| CachedColumn::new(c, ColumnKind::TwoNa));
-        let seq_id = seq_id.map(|c| CachedColumn::new(c, ColumnKind::Zip));
-        let seq_start =
-            seq_start.map(|c| CachedColumn::new(c, ColumnKind::Irzip { elem_bits: 32 }));
         let external = refseqs.map(RefSeqReaders::new);
-        let seq_len = CachedColumn::new(seq_len, ColumnKind::Irzip { elem_bits: 32 });
+        let layout = match layout {
+            Some(l) => l.clone(),
+            None => Arc::new(ReferenceLayout::open(archive, sra_path)?.ok_or_else(|| {
+                Error::Format("REFERENCE: no SEQ_LEN column to read the layout from".into())
+            })?),
+        };
 
         // Resolve the real chunk size instead of assuming 5000. Prefer the
         // static MAX_SEQ_LEN column; if it is absent/unreadable, derive it from
@@ -110,7 +134,7 @@ impl ReferenceCursor {
                 Err(_) => None,
             };
         let derived = if col_value.is_none() {
-            derive_max_seq_len_from_seq_len(&seq_len, first_row, row_count)
+            derive_max_seq_len_from_seq_len(&layout.seq_len)
         } else {
             None
         };
@@ -119,9 +143,7 @@ impl ReferenceCursor {
 
         Ok(Self {
             cmp_read,
-            seq_len,
-            seq_id,
-            seq_start,
+            layout,
             external,
             max_seq_len,
             first_row,
@@ -154,16 +176,15 @@ impl ReferenceCursor {
 
         let mut out = Vec::with_capacity(ref_len as usize);
         while remaining > 0 {
-            let chunk_len = self.seq_len.read_scalar_u32(chunk_row)? as usize;
+            let chunk_len = self.layout.seq_len(chunk_row, self.first_row)? as usize;
             if offset_in_chunk > chunk_len {
                 return Err(Error::Format(format!(
                     "reference: offset {offset_in_chunk} past chunk {chunk_row} len {chunk_len}"
                 )));
             }
-            let chunk_bases = self.chunk_bases(chunk_row, chunk_len)?;
             let available = chunk_len - offset_in_chunk;
             let take = remaining.min(available);
-            out.extend_from_slice(&chunk_bases[offset_in_chunk..offset_in_chunk + take]);
+            self.chunk_bases_into(&mut out, chunk_row, chunk_len, offset_in_chunk, take)?;
             remaining -= take;
             offset_in_chunk = 0;
             if remaining > 0 {
@@ -183,30 +204,46 @@ impl ReferenceCursor {
     /// `ref_restore_read`: prefer embedded `CMP_READ`, pad a short row with
     /// Ns, treat `SEQ_START == 0` as an all-N chunk, and otherwise fetch
     /// from the external refseq object named by `SEQ_ID`.
-    fn chunk_bases(&self, chunk_row: i64, chunk_len: usize) -> Result<Vec<u8>> {
+    /// Append `take` bases of chunk `chunk_row`, starting `offset` into it,
+    /// mirroring ncbi-vdb's `ref_restore_read`: prefer embedded `CMP_READ`,
+    /// pad a short row with Ns, treat `SEQ_START == 0` as an all-N chunk,
+    /// and otherwise fetch from the external refseq object named by
+    /// `SEQ_ID`.
+    fn chunk_bases_into(
+        &self,
+        out: &mut Vec<u8>,
+        chunk_row: i64,
+        chunk_len: usize,
+        offset: usize,
+        take: usize,
+    ) -> Result<()> {
         if let Some(cmp) = &self.cmp_read {
-            let bases = cmp.read_2na_row(chunk_row)?;
-            if bases.len() >= chunk_len {
-                let mut bases = bases;
-                bases.truncate(chunk_len);
-                return Ok(bases);
+            let stored = cmp.two_na_row_len(chunk_row)?;
+            if stored >= chunk_len {
+                out.extend_from_slice(&cmp.read_2na_range(chunk_row, offset, take)?);
+                return Ok(());
             }
-            if !bases.is_empty() {
-                let mut bases = bases;
-                bases.resize(chunk_len, BASE_N);
-                return Ok(bases);
+            if stored > 0 {
+                // Short row: real bases then N padding out to SEQ_LEN.
+                let real = stored.saturating_sub(offset).min(take);
+                if real > 0 {
+                    out.extend_from_slice(&cmp.read_2na_range(chunk_row, offset, real)?);
+                }
+                out.resize(out.len() + (take - real), BASE_N);
+                return Ok(());
             }
         }
 
-        let Some(seq_start_col) = &self.seq_start else {
+        if self.layout.seq_start.is_empty() {
             return Err(Error::Format(format!(
                 "REFERENCE row {chunk_row}: no embedded bases and no SEQ_START \
                  column to locate external ones"
             )));
-        };
-        let seq_start = seq_start_col.read_scalar_u32(chunk_row)? as u64;
+        }
+        let seq_start = u64::from(self.layout.seq_start(chunk_row, self.first_row)?);
         if seq_start == 0 {
-            return Ok(vec![BASE_N; chunk_len]);
+            out.resize(out.len() + take, BASE_N);
+            return Ok(());
         }
 
         let external = self.external.as_ref().ok_or_else(|| {
@@ -216,28 +253,19 @@ impl ReferenceCursor {
                     .into(),
             )
         })?;
-        let seq_id = self.seq_id_at(chunk_row)?;
-        external.bases_at(&seq_id, seq_start - 1, chunk_len)
-    }
-
-    /// `SEQ_ID` for a chunk row, as a string.
-    fn seq_id_at(&self, chunk_row: i64) -> Result<String> {
-        let col = self.seq_id.as_ref().ok_or_else(|| {
-            Error::Format(format!(
-                "REFERENCE row {chunk_row}: external bases needed but no SEQ_ID column"
-            ))
-        })?;
-        let bytes = col.read_byte_row(chunk_row)?;
-        Ok(String::from_utf8_lossy(&bytes).trim().to_string())
+        let seq_id = self.layout.seq_id(chunk_row, self.first_row)?;
+        out.extend_from_slice(&external.bases_at(seq_id, seq_start - 1 + offset as u64, take)?);
+        Ok(())
     }
 
     /// Error unless two chunk rows belong to the same reference sequence.
     /// A no-op on archives without a `SEQ_ID` column (nothing to compare).
     fn check_same_reference(&self, a: i64, b: i64) -> Result<()> {
-        if self.seq_id.is_none() {
+        if self.layout.seq_id.is_empty() {
             return Ok(());
         }
-        let (ida, idb) = (self.seq_id_at(a)?, self.seq_id_at(b)?);
+        let ida = self.layout.seq_id(a, self.first_row)?;
+        let idb = self.layout.seq_id(b, self.first_row)?;
         if ida != idb {
             return Err(Error::Format(format!(
                 "reference span crosses the boundary between {ida} (chunk {a}) \
@@ -254,22 +282,126 @@ impl ReferenceCursor {
 /// widest SEQ_LEN over a bounded prefix of the table recovers the value as long
 /// as any reference in that prefix spans more than one chunk. Returns `None`
 /// when nothing decodes (caller falls back to [`DEFAULT_MAX_SEQ_LEN`]).
-fn derive_max_seq_len_from_seq_len(
-    seq_len: &CachedColumn,
-    first_row: i64,
-    row_count: u64,
-) -> Option<u32> {
-    if row_count == 0 {
-        return None;
+impl ReferenceLayout {
+    /// Open the REFERENCE layout columns from an archive and read them in.
+    ///
+    /// Build this **once per accession** and share the `Arc`: decode
+    /// workers construct a `ReferenceCursor` per chunk, and re-reading the
+    /// layout each time costs more than the random lookups it replaces.
+    pub fn open<R: Read + Seek>(
+        archive: &mut KarArchive<R>,
+        sra_path: &Path,
+    ) -> Result<Option<Self>> {
+        let Ok(col_base) = inspect::column_base_path_public(archive, Some("REFERENCE")) else {
+            return Ok(None);
+        };
+        let open = |archive: &mut KarArchive<R>, name: &str| -> Option<ColumnReader> {
+            ColumnReader::open(archive, &format!("{col_base}/{name}"), sra_path).ok()
+        };
+        let Some(seq_len) = open(archive, "SEQ_LEN") else {
+            return Ok(None);
+        };
+        let seq_start = open(archive, "SEQ_START");
+        let seq_id = open(archive, "SEQ_ID");
+
+        let first_row = seq_len.first_row_id().unwrap_or(1);
+        let row_count = seq_len.row_count();
+        let seq_len = CachedColumn::new(seq_len, ColumnKind::Irzip { elem_bits: 32 });
+        let seq_start =
+            seq_start.map(|c| CachedColumn::new(c, ColumnKind::Irzip { elem_bits: 32 }));
+        let seq_id = seq_id.map(|c| CachedColumn::new(c, ColumnKind::Zip));
+
+        Ok(Some(Self::load(
+            &seq_len,
+            seq_start.as_ref(),
+            seq_id.as_ref(),
+            first_row,
+            row_count,
+        )?))
     }
-    let sampled = row_count.min(MAX_SEQ_LEN_SAMPLE_ROWS);
-    let end = first_row + sampled as i64;
-    let mut max = 0u32;
-    for row in first_row..end {
-        if let Ok(v) = seq_len.read_scalar_u32(row) {
-            max = max.max(v);
+
+    /// Read the layout columns front to back, so each blob is decoded once.
+    fn load(
+        seq_len_col: &CachedColumn,
+        seq_start_col: Option<&CachedColumn>,
+        seq_id_col: Option<&CachedColumn>,
+        first_row: i64,
+        row_count: u64,
+    ) -> Result<Self> {
+        let n = row_count as usize;
+        let mut seq_len = Vec::with_capacity(n);
+        let mut seq_start = Vec::with_capacity(if seq_start_col.is_some() { n } else { 0 });
+        let mut seq_id = Vec::with_capacity(if seq_id_col.is_some() { n } else { 0 });
+        let mut seq_id_names: Vec<String> = Vec::new();
+        // REFERENCE rows are grouped by SEQ_ID, so remembering the last one
+        // turns the intern lookup into a pointer compare for all but the
+        // handful of rows that start a new reference.
+        let mut last: Option<(String, u32)> = None;
+
+        for row in first_row..first_row + row_count as i64 {
+            seq_len.push(seq_len_col.read_scalar_u32(row)?);
+            if let Some(col) = seq_start_col {
+                seq_start.push(col.read_scalar_u32(row)?);
+            }
+            if let Some(col) = seq_id_col {
+                let bytes = col.read_byte_row(row)?;
+                let name = std::str::from_utf8(&bytes)
+                    .map_err(|e| Error::Format(format!("REFERENCE/SEQ_ID row {row}: {e}")))?
+                    .trim();
+                let idx = match &last {
+                    Some((prev, idx)) if prev == name => *idx,
+                    _ => {
+                        let idx = seq_id_names
+                            .iter()
+                            .position(|n| n == name)
+                            .unwrap_or_else(|| {
+                                seq_id_names.push(name.to_string());
+                                seq_id_names.len() - 1
+                            }) as u32;
+                        last = Some((name.to_string(), idx));
+                        idx
+                    }
+                };
+                seq_id.push(idx);
+            }
         }
+
+        Ok(Self {
+            seq_len,
+            seq_start,
+            seq_id,
+            seq_id_names,
+        })
     }
+
+    fn index(row: i64, first_row: i64, len: usize, what: &str) -> Result<usize> {
+        let idx = row - first_row;
+        if idx < 0 || idx as usize >= len {
+            return Err(Error::Format(format!(
+                "REFERENCE {what}: row {row} outside [{first_row}, {})",
+                first_row + len as i64
+            )));
+        }
+        Ok(idx as usize)
+    }
+
+    fn seq_len(&self, row: i64, first_row: i64) -> Result<u32> {
+        Ok(self.seq_len[Self::index(row, first_row, self.seq_len.len(), "SEQ_LEN")?])
+    }
+
+    fn seq_start(&self, row: i64, first_row: i64) -> Result<u32> {
+        Ok(self.seq_start[Self::index(row, first_row, self.seq_start.len(), "SEQ_START")?])
+    }
+
+    fn seq_id(&self, row: i64, first_row: i64) -> Result<&str> {
+        let i = Self::index(row, first_row, self.seq_id.len(), "SEQ_ID")?;
+        Ok(&self.seq_id_names[self.seq_id[i] as usize])
+    }
+}
+
+fn derive_max_seq_len_from_seq_len(seq_len: &[u32]) -> Option<u32> {
+    let sampled = seq_len.len().min(MAX_SEQ_LEN_SAMPLE_ROWS as usize);
+    let max = seq_len[..sampled].iter().copied().max().unwrap_or(0);
     (max > 0).then_some(max)
 }
 

--- a/crates/sracha-vdb/src/reference.rs
+++ b/crates/sracha-vdb/src/reference.rs
@@ -78,6 +78,10 @@ pub struct ReferenceLayout {
     seq_id: Vec<u32>,
     /// Distinct external reference accessions, in first-seen order.
     seq_id_names: Vec<String>,
+    /// Absolute row where each reference's chunks start, parallel to
+    /// `seq_id_names`. A span that wraps a circular reference restarts
+    /// here.
+    first_row_by_id: Vec<i64>,
 }
 
 impl ReferenceCursor {
@@ -175,6 +179,7 @@ impl ReferenceCursor {
         let mut chunk_row = first_chunk_row;
 
         let mut out = Vec::with_capacity(ref_len as usize);
+        let mut wrapped = false;
         while remaining > 0 {
             let chunk_len = self.layout.seq_len(chunk_row, self.first_row)? as usize;
             if offset_in_chunk > chunk_len {
@@ -188,18 +193,28 @@ impl ReferenceCursor {
             remaining -= take;
             offset_in_chunk = 0;
             if remaining > 0 {
-                // Stop at the end of this reference and return a short
-                // span, exactly as ncbi-vdb's `ref_sub_select` does — its
-                // read loop is bounded by the reference's `stop_id`
-                // (libs/axf/ref-tbl-sub-select.c:204). A span can overrun
-                // the end when soft clipping widens it; those positions are
-                // mismatches and never read the reference, so the caller
-                // never notices. Splicing in the next chromosome's bases
-                // would silently corrupt the read.
-                if !self.same_reference(chunk_row, chunk_row + 1)? {
+                if self.same_reference(chunk_row, chunk_row + 1)? {
+                    chunk_row += 1;
+                } else if !wrapped && self.is_circular_at(chunk_row)? {
+                    // A circular reference — the mitochondrion, plasmids —
+                    // has alignments that span its origin, so running off
+                    // the end means starting over at its first chunk
+                    // (ncbi-vdb does the same,
+                    // libs/axf/ref-tbl-sub-select.c:228). Once only: a span
+                    // longer than the whole reference would otherwise loop.
+                    chunk_row = self.layout.reference_start(chunk_row, self.first_row)?;
+                    wrapped = true;
+                } else {
+                    // End of a linear reference. Return the short span
+                    // rather than failing, exactly as `ref_sub_select`
+                    // does — its read loop is bounded by the reference's
+                    // `stop_id` (ref-tbl-sub-select.c:204). A span can
+                    // overrun when soft clipping widens it, and those
+                    // positions are mismatches that never read the
+                    // reference. Splicing in the next chromosome's bases
+                    // would silently corrupt the read.
                     break;
                 }
-                chunk_row += 1;
             }
         }
         Ok(out)
@@ -261,6 +276,17 @@ impl ReferenceCursor {
         let seq_id = self.layout.seq_id(chunk_row, self.first_row)?;
         out.extend_from_slice(&external.bases_at(seq_id, seq_start - 1 + offset as u64, take)?);
         Ok(())
+    }
+
+    /// Is the reference at `row` circular? Only external refseq objects
+    /// carry the flag; an archive that embeds its bases reports false.
+    fn is_circular_at(&self, row: i64) -> Result<bool> {
+        let (Some(external), false) = (self.external.as_ref(), self.layout.seq_id.is_empty())
+        else {
+            return Ok(false);
+        };
+        let seq_id = self.layout.seq_id(row, self.first_row)?;
+        Ok(external.is_circular(seq_id))
     }
 
     /// Do two chunk rows belong to the same reference sequence?
@@ -335,6 +361,7 @@ impl ReferenceLayout {
         let mut seq_start = Vec::with_capacity(if seq_start_col.is_some() { n } else { 0 });
         let mut seq_id = Vec::with_capacity(if seq_id_col.is_some() { n } else { 0 });
         let mut seq_id_names: Vec<String> = Vec::new();
+        let mut first_row_by_id: Vec<i64> = Vec::new();
         // REFERENCE rows are grouped by SEQ_ID, so remembering the last one
         // turns the intern lookup into a pointer compare for all but the
         // handful of rows that start a new reference.
@@ -358,6 +385,7 @@ impl ReferenceLayout {
                             .position(|n| n == name)
                             .unwrap_or_else(|| {
                                 seq_id_names.push(name.to_string());
+                                first_row_by_id.push(row);
                                 seq_id_names.len() - 1
                             }) as u32;
                         last = Some((name.to_string(), idx));
@@ -373,6 +401,7 @@ impl ReferenceLayout {
             seq_start,
             seq_id,
             seq_id_names,
+            first_row_by_id,
         })
     }
 
@@ -398,6 +427,12 @@ impl ReferenceLayout {
     fn seq_id(&self, row: i64, first_row: i64) -> Result<&str> {
         let i = Self::index(row, first_row, self.seq_id.len(), "SEQ_ID")?;
         Ok(&self.seq_id_names[self.seq_id[i] as usize])
+    }
+
+    /// First chunk row of the reference that `row` belongs to.
+    fn reference_start(&self, row: i64, first_row: i64) -> Result<i64> {
+        let i = Self::index(row, first_row, self.seq_id.len(), "SEQ_ID")?;
+        Ok(self.first_row_by_id[self.seq_id[i] as usize])
     }
 }
 

--- a/crates/sracha-vdb/src/refseq.rs
+++ b/crates/sracha-vdb/src/refseq.rs
@@ -133,11 +133,25 @@ pub struct RefSeqStore {
     objects: HashMap<String, Arc<RefSeqObject>>,
 }
 
+/// Where an opened refseq object keeps its bases.
+enum RefSeqBases {
+    /// Physical `READ` (+ optional `ALTREAD`) columns, chunked at
+    /// `max_seq_len` bases per row. The layout for whole chromosomes.
+    Columns {
+        read: Arc<ColumnReader>,
+        altread: Option<Arc<ColumnReader>>,
+    },
+    /// The whole sequence inlined in static metadata (`col/READ/row`), with
+    /// no physical columns at all. Short references are stored this way —
+    /// GRCh37's unlocalized contigs (`GL000207.1`, 4,262 bp) among them.
+    /// Already unpacked to 4na-bin at open time; these are kilobytes.
+    Inline(Arc<Vec<u8>>),
+}
+
 /// One opened refseq object.
 pub struct RefSeqObject {
     seq_id: String,
-    read: Arc<ColumnReader>,
-    altread: Option<Arc<ColumnReader>>,
+    bases: RefSeqBases,
     max_seq_len: u32,
     first_row: i64,
     row_count: u64,
@@ -177,29 +191,59 @@ impl RefSeqObject {
         let mut archive = KarArchive::open(std::io::BufReader::new(file))?;
         let col_base = inspect::column_base_path_public(&archive, None)?;
 
-        let read = ColumnReader::open(&mut archive, &format!("{col_base}/READ"), path)
-            .map_err(|e| Error::Format(format!("refseq {seq_id}: READ: {e}")))?;
-        let altread = ColumnReader::open(&mut archive, &format!("{col_base}/ALTREAD"), path).ok();
-
-        let first_row = read.first_row_id().unwrap_or(1);
-        let row_count = read.row_count();
-
         // MAX_SEQ_LEN / TOTAL_SEQ_LEN / CIRCULAR are static metadata on a
-        // refseq object, not physical columns.
+        // refseq object, not physical columns — and on short references so
+        // are the bases themselves.
         let meta = inspect::read_table_metadata(&mut archive, None).unwrap_or_default();
         let max_seq_len = meta_u32(&meta, "col/MAX_SEQ_LEN/row")
             .filter(|&v| v > 0)
             .unwrap_or(crate::reference::DEFAULT_MAX_SEQ_LEN);
-        let total_seq_len =
-            meta_u64(&meta, "STATS/TOTAL_SEQ_LEN").unwrap_or(row_count * u64::from(max_seq_len));
         let circular = meta_u32(&meta, "col/CIRCULAR/row")
             .map(|v| v != 0)
             .unwrap_or(false);
 
+        let read = ColumnReader::open(&mut archive, &format!("{col_base}/READ"), path).ok();
+        let (bases, first_row, row_count, default_total) = match read {
+            Some(read) => {
+                let altread =
+                    ColumnReader::open(&mut archive, &format!("{col_base}/ALTREAD"), path).ok();
+                let first_row = read.first_row_id().unwrap_or(1);
+                let row_count = read.row_count();
+                (
+                    RefSeqBases::Columns {
+                        read: Arc::new(read),
+                        altread: altread.map(Arc::new),
+                    },
+                    first_row,
+                    row_count,
+                    row_count * u64::from(max_seq_len),
+                )
+            }
+            None => {
+                let packed = meta_bytes(&meta, "col/READ/row").ok_or_else(|| {
+                    Error::Format(format!(
+                        "refseq {seq_id}: no READ column and no inline bases in metadata"
+                    ))
+                })?;
+                let seq_len = meta_u32(&meta, "col/SEQ_LEN/row")
+                    .filter(|&v| v > 0)
+                    .unwrap_or((packed.len() * 4) as u32) as usize;
+                let mut bases = unpack_2na_to_4na(packed, seq_len);
+                if let Some(mask) = meta_bytes(&meta, "col/ALTREAD/row") {
+                    overlay_altread(&mut bases, mask);
+                }
+                let len = bases.len() as u64;
+                (RefSeqBases::Inline(Arc::new(bases)), 1, 1, len)
+            }
+        };
+
+        let total_seq_len = meta_u64(&meta, "STATS/TOTAL_SEQ_LEN")
+            .filter(|&v| v > 0)
+            .unwrap_or(default_total);
+
         Ok(Self {
             seq_id: seq_id.to_string(),
-            read: Arc::new(read),
-            altread: altread.map(Arc::new),
+            bases,
             max_seq_len,
             first_row,
             row_count,
@@ -207,6 +251,40 @@ impl RefSeqObject {
             circular,
         })
     }
+}
+
+/// 2na-packed bases (2 bits each, MSB-first) to 4na-bin, one nibble per byte.
+fn unpack_2na_to_4na(packed: &[u8], num_bases: usize) -> Vec<u8> {
+    const LUT: [u8; 4] = [0x1, 0x2, 0x4, 0x8]; // A C G T
+    let mut out = Vec::with_capacity(num_bases);
+    for i in 0..num_bases {
+        let bit = i * 2;
+        let Some(byte) = packed.get(bit / 8) else {
+            break;
+        };
+        out.push(LUT[((byte >> (6 - (bit % 8))) & 0x03) as usize]);
+    }
+    out
+}
+
+/// Fold a `trim<ALIGN_LEFT, 0>` 4na mask over the tail of `bases`.
+/// Non-zero nibbles win — this is what keeps ambiguity codes (mostly N)
+/// from decoding as a confident basecall.
+fn overlay_altread(bases: &mut [u8], mask: &[u8]) {
+    let shift = bases.len().saturating_sub(mask.len());
+    for (i, &m) in mask.iter().enumerate() {
+        if m != 0
+            && let Some(slot) = bases.get_mut(shift + i)
+        {
+            *slot = m & 0x0F;
+        }
+    }
+}
+
+/// Raw bytes of a static metadata node, if it holds any.
+fn meta_bytes<'a>(nodes: &'a [crate::metadata::MetaNode], path: &str) -> Option<&'a [u8]> {
+    let v = &crate::metadata::find_meta_node(nodes, path)?.value;
+    (!v.is_empty()).then_some(v.as_slice())
 }
 
 /// Read a little-endian scalar out of the static metadata tree. Values are
@@ -244,15 +322,19 @@ impl RefSeqReaders {
     pub fn new(store: &Arc<RefSeqStore>) -> Self {
         let mut cols = HashMap::with_capacity(store.objects.len());
         for (seq_id, obj) in &store.objects {
-            cols.insert(
-                seq_id.clone(),
-                (
-                    CachedColumn::from_shared(obj.read.clone(), ColumnKind::TwoNa),
-                    obj.altread
-                        .as_ref()
-                        .map(|c| CachedColumn::from_shared(c.clone(), ColumnKind::Zip)),
-                ),
-            );
+            // Inline objects need no per-worker state — their bases are a
+            // shared, already-decoded buffer.
+            if let RefSeqBases::Columns { read, altread } = &obj.bases {
+                cols.insert(
+                    seq_id.clone(),
+                    (
+                        CachedColumn::from_shared(read.clone(), ColumnKind::TwoNa),
+                        altread
+                            .as_ref()
+                            .map(|c| CachedColumn::from_shared(c.clone(), ColumnKind::Zip)),
+                    ),
+                );
+            }
         }
         Self {
             store: store.clone(),
@@ -267,17 +349,32 @@ impl RefSeqReaders {
             .store
             .get(seq_id)
             .ok_or_else(|| Error::Format(format!("refseq {seq_id}: not materialised")))?;
-        let (read, altread) = self
-            .cols
-            .get(seq_id)
-            .ok_or_else(|| Error::Format(format!("refseq {seq_id}: no reader")))?;
 
-        let msl = u64::from(obj.max_seq_len);
         let mut pos = if obj.circular && obj.total_seq_len > 0 {
             pos % obj.total_seq_len
         } else {
             pos
         };
+
+        // Inline objects are one contiguous buffer — no chunk walk needed.
+        if let RefSeqBases::Inline(all) = &obj.bases {
+            let start = pos as usize;
+            let end = start + len;
+            if end > all.len() {
+                return Err(Error::Format(format!(
+                    "refseq {}: [{start}..{end}) past end ({} bases)",
+                    obj.seq_id,
+                    all.len()
+                )));
+            }
+            return Ok(all[start..end].to_vec());
+        }
+
+        let (read, altread) = self
+            .cols
+            .get(seq_id)
+            .ok_or_else(|| Error::Format(format!("refseq {seq_id}: no reader")))?;
+        let msl = u64::from(obj.max_seq_len);
         let mut out = Vec::with_capacity(len);
         while out.len() < len {
             let row = obj.first_row + (pos / msl) as i64;

--- a/crates/sracha-vdb/src/refseq.rs
+++ b/crates/sracha-vdb/src/refseq.rs
@@ -328,10 +328,10 @@ impl RefSeqReaders {
                 cols.insert(
                     seq_id.clone(),
                     (
-                        CachedColumn::from_shared_random(read.clone(), ColumnKind::TwoNa),
+                        CachedColumn::from_shared(read.clone(), ColumnKind::TwoNa),
                         altread
                             .as_ref()
-                            .map(|c| CachedColumn::from_shared_random(c.clone(), ColumnKind::Zip)),
+                            .map(|c| CachedColumn::from_shared(c.clone(), ColumnKind::Zip)),
                     ),
                 );
             }

--- a/crates/sracha-vdb/src/refseq.rs
+++ b/crates/sracha-vdb/src/refseq.rs
@@ -277,7 +277,7 @@ fn unpack_2na_to_4na(packed: &[u8], num_bases: usize) -> Vec<u8> {
 /// Fold a `trim<ALIGN_LEFT, 0>` 4na mask over the tail of `bases`.
 /// Non-zero nibbles win — this is what keeps ambiguity codes (mostly N)
 /// from decoding as a confident basecall.
-fn overlay_altread(bases: &mut [u8], mask: &[u8]) {
+pub(crate) fn overlay_altread(bases: &mut [u8], mask: &[u8]) {
     let shift = bases.len().saturating_sub(mask.len());
     for (i, &m) in mask.iter().enumerate() {
         if m != 0

--- a/crates/sracha-vdb/src/refseq.rs
+++ b/crates/sracha-vdb/src/refseq.rs
@@ -1,0 +1,419 @@
+//! External reference-sequence (refseq) support for cSRA decode.
+//!
+//! Most aligned SRA stores its reference bases inline as
+//! `REFERENCE/col/CMP_READ`. Runs aligned to a public assembly usually do
+//! not: their REFERENCE table keeps only the chunk *layout*
+//! (`SEQ_ID`, `SEQ_START`, `SEQ_LEN`) and the bases live in separate NCBI
+//! refseq objects named by `SEQ_ID` (e.g. `CM000663.1` = GRCh37 chr1).
+//!
+//! This module covers the archive-side half of that: discovering which
+//! objects a run needs ([`external_refs_needed`]) and reading bases out of
+//! them once someone else has put them on local disk ([`RefSeqStore`]).
+//! Fetching is deliberately *not* here — `sracha-vdb` performs no I/O
+//! beyond the filesystem, so `sracha-core` resolves and downloads the
+//! objects and hands back local paths.
+//!
+//! A refseq object is a flat VDB table (`NCBI:refseq:tbl:reference`) whose
+//! bases live in `READ` (2na-packed) overlaid with `ALTREAD` (4na-bin,
+//! left-trimmed and right-aligned). `READ` alone decodes ambiguity codes —
+//! most visibly the telomeric N runs — as `A`, so the overlay is not
+//! optional.
+
+use std::collections::HashMap;
+use std::io::{Read, Seek};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::cache::{CachedColumn, ColumnKind};
+use crate::error::{Error, Result};
+use crate::inspect;
+use crate::kar::KarArchive;
+use crate::kdb::ColumnReader;
+
+/// 4na-bin code for N (all four bases possible).
+pub(crate) const BASE_N: u8 = 0x0F;
+
+/// One external reference object a run needs in order to decode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalRefNeed {
+    /// `REFERENCE.SEQ_ID`, used verbatim as the NCBI accession.
+    pub seq_id: String,
+    /// How many REFERENCE chunk rows name this object.
+    pub chunk_rows: u64,
+    /// Highest 0-based end offset referenced within the object, i.e.
+    /// `max(SEQ_START - 1 + SEQ_LEN)`. Zero when every chunk is all-N.
+    pub max_end: u64,
+    /// Every chunk naming this object has `SEQ_START == 0` — the whole
+    /// span is Ns and no fetch is required.
+    pub all_n: bool,
+}
+
+/// Scan a cSRA archive's REFERENCE table and report which external refseq
+/// objects it needs.
+///
+/// Returns an empty vec when the archive embeds its bases (a `CMP_READ`
+/// column is present) or has no REFERENCE layout columns at all. Reads
+/// only `SEQ_ID`, `SEQ_START` and `SEQ_LEN`, so it is cheap relative to a
+/// decode even on a whole-genome REFERENCE table.
+pub fn external_refs_needed<R: Read + Seek>(
+    archive: &mut KarArchive<R>,
+    sra_path: &Path,
+) -> Result<Vec<ExternalRefNeed>> {
+    let Ok(col_base) = inspect::column_base_path_public(archive, Some("REFERENCE")) else {
+        return Ok(Vec::new());
+    };
+    let open = |archive: &mut KarArchive<R>, name: &str| -> Option<ColumnReader> {
+        ColumnReader::open(archive, &format!("{col_base}/{name}"), sra_path).ok()
+    };
+
+    // Bases embedded → nothing external to fetch, regardless of layout.
+    if open(archive, "CMP_READ").is_some() {
+        return Ok(Vec::new());
+    }
+
+    let (Some(seq_id), Some(seq_start), Some(seq_len)) = (
+        open(archive, "SEQ_ID"),
+        open(archive, "SEQ_START"),
+        open(archive, "SEQ_LEN"),
+    ) else {
+        return Ok(Vec::new());
+    };
+
+    let first_row = seq_len.first_row_id().unwrap_or(1);
+    let row_count = seq_len.row_count();
+    let seq_id = CachedColumn::new(seq_id, ColumnKind::Zip);
+    let seq_start = CachedColumn::new(seq_start, ColumnKind::Irzip { elem_bits: 32 });
+    let seq_len = CachedColumn::new(seq_len, ColumnKind::Irzip { elem_bits: 32 });
+
+    // Preserve first-seen order: REFERENCE chunks are laid out grouped by
+    // SEQ_ID, and reporting them in archive order keeps logs readable.
+    let mut order: Vec<String> = Vec::new();
+    let mut by_id: HashMap<String, ExternalRefNeed> = HashMap::new();
+
+    for row in first_row..first_row + row_count as i64 {
+        let id_bytes = seq_id.read_byte_row(row)?;
+        let id = String::from_utf8_lossy(&id_bytes).trim().to_string();
+        if id.is_empty() {
+            continue;
+        }
+        let start = seq_start.read_scalar_u32(row)? as u64;
+        let len = seq_len.read_scalar_u32(row)? as u64;
+
+        let need = by_id.entry(id.clone()).or_insert_with(|| {
+            order.push(id.clone());
+            ExternalRefNeed {
+                seq_id: id.clone(),
+                chunk_rows: 0,
+                max_end: 0,
+                all_n: true,
+            }
+        });
+        need.chunk_rows += 1;
+        // SEQ_START == 0 is the all-N sentinel: the chunk is `SEQ_LEN` Ns
+        // and addresses nothing in the external object.
+        if start > 0 {
+            need.all_n = false;
+            need.max_end = need.max_end.max(start - 1 + len);
+        }
+    }
+
+    Ok(order
+        .into_iter()
+        .filter_map(|id| by_id.remove(&id))
+        .collect())
+}
+
+/// A set of refseq objects already materialised on local disk, keyed by
+/// `REFERENCE.SEQ_ID`.
+///
+/// Immutable and shareable: build one per accession and clone the `Arc`
+/// into each decode worker. The per-worker mutable blob caches live in
+/// [`RefSeqReaders`], not here.
+pub struct RefSeqStore {
+    objects: HashMap<String, Arc<RefSeqObject>>,
+}
+
+/// One opened refseq object.
+pub struct RefSeqObject {
+    seq_id: String,
+    read: Arc<ColumnReader>,
+    altread: Option<Arc<ColumnReader>>,
+    max_seq_len: u32,
+    first_row: i64,
+    row_count: u64,
+    total_seq_len: u64,
+    circular: bool,
+}
+
+impl RefSeqStore {
+    /// Open every `(seq_id, local path)` pair. This is the single seam
+    /// that keeps network code out of `sracha-vdb`: callers hand over
+    /// paths, never URLs.
+    pub fn open<P: AsRef<Path>>(objects: &[(String, P)]) -> Result<Self> {
+        let mut map = HashMap::with_capacity(objects.len());
+        for (seq_id, path) in objects {
+            let obj = RefSeqObject::open(seq_id, path.as_ref())?;
+            map.insert(seq_id.clone(), Arc::new(obj));
+        }
+        Ok(Self { objects: map })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.objects.is_empty()
+    }
+
+    pub fn contains(&self, seq_id: &str) -> bool {
+        self.objects.contains_key(seq_id)
+    }
+
+    fn get(&self, seq_id: &str) -> Option<&Arc<RefSeqObject>> {
+        self.objects.get(seq_id)
+    }
+}
+
+impl RefSeqObject {
+    fn open(seq_id: &str, path: &Path) -> Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let mut archive = KarArchive::open(std::io::BufReader::new(file))?;
+        let col_base = inspect::column_base_path_public(&archive, None)?;
+
+        let read = ColumnReader::open(&mut archive, &format!("{col_base}/READ"), path)
+            .map_err(|e| Error::Format(format!("refseq {seq_id}: READ: {e}")))?;
+        let altread = ColumnReader::open(&mut archive, &format!("{col_base}/ALTREAD"), path).ok();
+
+        let first_row = read.first_row_id().unwrap_or(1);
+        let row_count = read.row_count();
+
+        // MAX_SEQ_LEN / TOTAL_SEQ_LEN / CIRCULAR are static metadata on a
+        // refseq object, not physical columns.
+        let meta = inspect::read_table_metadata(&mut archive, None).unwrap_or_default();
+        let max_seq_len = meta_u32(&meta, "col/MAX_SEQ_LEN/row")
+            .filter(|&v| v > 0)
+            .unwrap_or(crate::reference::DEFAULT_MAX_SEQ_LEN);
+        let total_seq_len =
+            meta_u64(&meta, "STATS/TOTAL_SEQ_LEN").unwrap_or(row_count * u64::from(max_seq_len));
+        let circular = meta_u32(&meta, "col/CIRCULAR/row")
+            .map(|v| v != 0)
+            .unwrap_or(false);
+
+        Ok(Self {
+            seq_id: seq_id.to_string(),
+            read: Arc::new(read),
+            altread: altread.map(Arc::new),
+            max_seq_len,
+            first_row,
+            row_count,
+            total_seq_len,
+            circular,
+        })
+    }
+}
+
+/// Read a little-endian scalar out of the static metadata tree. Values are
+/// stored at their natural width (`CIRCULAR` is one byte, `MAX_SEQ_LEN`
+/// four, `TOTAL_SEQ_LEN` eight), so accept anything up to the target size.
+fn meta_uint(nodes: &[crate::metadata::MetaNode], path: &str, max_bytes: usize) -> Option<u64> {
+    let v = &crate::metadata::find_meta_node(nodes, path)?.value;
+    if v.is_empty() || v.len() > max_bytes {
+        return None;
+    }
+    let mut buf = [0u8; 8];
+    buf[..v.len()].copy_from_slice(v);
+    Some(u64::from_le_bytes(buf))
+}
+
+fn meta_u32(nodes: &[crate::metadata::MetaNode], path: &str) -> Option<u32> {
+    meta_uint(nodes, path, 4).map(|v| v as u32)
+}
+
+fn meta_u64(nodes: &[crate::metadata::MetaNode], path: &str) -> Option<u64> {
+    meta_uint(nodes, path, 8)
+}
+
+/// Per-worker view over a shared [`RefSeqStore`].
+///
+/// Holds the single-slot decoded-blob caches that make row reads cheap;
+/// those use `RefCell`, so each rayon worker needs its own. Construction
+/// is a map walk — no file opens, no mmap, no decode.
+pub struct RefSeqReaders {
+    store: Arc<RefSeqStore>,
+    cols: HashMap<String, (CachedColumn, Option<CachedColumn>)>,
+}
+
+impl RefSeqReaders {
+    pub fn new(store: &Arc<RefSeqStore>) -> Self {
+        let mut cols = HashMap::with_capacity(store.objects.len());
+        for (seq_id, obj) in &store.objects {
+            cols.insert(
+                seq_id.clone(),
+                (
+                    CachedColumn::from_shared(obj.read.clone(), ColumnKind::TwoNa),
+                    obj.altread
+                        .as_ref()
+                        .map(|c| CachedColumn::from_shared(c.clone(), ColumnKind::Zip)),
+                ),
+            );
+        }
+        Self {
+            store: store.clone(),
+            cols,
+        }
+    }
+
+    /// `len` reference bases as 4na-bin bytes, starting at 0-based
+    /// position `pos` within `seq_id`.
+    pub fn bases_at(&self, seq_id: &str, pos: u64, len: usize) -> Result<Vec<u8>> {
+        let obj = self
+            .store
+            .get(seq_id)
+            .ok_or_else(|| Error::Format(format!("refseq {seq_id}: not materialised")))?;
+        let (read, altread) = self
+            .cols
+            .get(seq_id)
+            .ok_or_else(|| Error::Format(format!("refseq {seq_id}: no reader")))?;
+
+        let msl = u64::from(obj.max_seq_len);
+        let mut pos = if obj.circular && obj.total_seq_len > 0 {
+            pos % obj.total_seq_len
+        } else {
+            pos
+        };
+        let mut out = Vec::with_capacity(len);
+        while out.len() < len {
+            let row = obj.first_row + (pos / msl) as i64;
+            if row >= obj.first_row + obj.row_count as i64 {
+                if obj.circular {
+                    pos = 0;
+                    continue;
+                }
+                return Err(Error::Format(format!(
+                    "refseq {}: position {pos} past end ({} bases)",
+                    obj.seq_id, obj.total_seq_len
+                )));
+            }
+            let offset = (pos % msl) as usize;
+            let chunk = chunk_bases(read, altread.as_ref(), row)?;
+            if offset >= chunk.len() {
+                return Err(Error::Format(format!(
+                    "refseq {}: offset {offset} past chunk {row} ({} bases)",
+                    obj.seq_id,
+                    chunk.len()
+                )));
+            }
+            let take = (len - out.len()).min(chunk.len() - offset);
+            out.extend_from_slice(&chunk[offset..offset + take]);
+            pos += take as u64;
+        }
+        Ok(out)
+    }
+}
+
+/// Decode one refseq chunk row: 2na `READ` overlaid with the left-trimmed,
+/// right-aligned 4na `ALTREAD` mask. Where ALTREAD is non-zero it wins —
+/// that is how Ns and other ambiguity codes survive a 2na store.
+fn chunk_bases(read: &CachedColumn, altread: Option<&CachedColumn>, row: i64) -> Result<Vec<u8>> {
+    let mut bases = read.read_2na_row(row)?;
+    let Some(alt) = altread else {
+        return Ok(bases);
+    };
+    let mask = alt.read_byte_row(row)?;
+    if mask.is_empty() {
+        return Ok(bases);
+    }
+    // `trim<ALIGN_LEFT, 0>` drops leading zeros, so the stored mask is a
+    // suffix of the row: align it to the right before overlaying.
+    let shift = bases.len().saturating_sub(mask.len());
+    for (i, &m) in mask.iter().enumerate() {
+        if m != 0
+            && let Some(slot) = bases.get_mut(shift + i)
+        {
+            *slot = m & 0x0F;
+        }
+    }
+    Ok(bases)
+}
+
+/// Path a refseq object is cached at within `dir`.
+pub fn cache_path(dir: &Path, seq_id: &str) -> PathBuf {
+    dir.join(seq_id)
+}
+
+/// Is `seq_id` safe to use as a filename? `SEQ_ID` is archive content, so
+/// it must never be able to escape the cache directory.
+pub fn is_safe_seq_id(seq_id: &str) -> bool {
+    !seq_id.is_empty()
+        && seq_id.len() <= 64
+        && seq_id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The store is shared across rayon decode workers by `Arc`, so this
+    /// has to hold — the mutable per-worker state lives in `RefSeqReaders`.
+    #[test]
+    fn store_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<RefSeqStore>();
+    }
+
+    #[test]
+    fn seq_id_safety() {
+        assert!(is_safe_seq_id("CM000663.1"));
+        assert!(is_safe_seq_id("NC_012920.1"));
+        assert!(!is_safe_seq_id(""));
+        assert!(!is_safe_seq_id("../../etc/passwd"));
+        assert!(!is_safe_seq_id("a/b"));
+        assert!(!is_safe_seq_id(&"x".repeat(65)));
+    }
+
+    /// Ground truth from `vdb-dump ERR10213669 -T REFERENCE`: 24 external
+    /// references, the first being GRCh37 chr1 (`CM000663.1`) across
+    /// 49,851 chunk rows — 49,850 full 5000-base chunks plus a 621-base
+    /// tail, i.e. chr1's 249,250,621 bases. This is the regression guard
+    /// on decoding `SEQ_ID` (zip ascii behind a repeat-count page map) and
+    /// `SEQ_START` (signed izip, where 0 is the all-N sentinel).
+    #[test]
+    fn external_refs_for_err10213669() {
+        let p = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/ERR10213669.sra");
+        if !p.exists() {
+            return;
+        }
+        let file = std::fs::File::open(&p).unwrap();
+        let mut archive = KarArchive::open(std::io::BufReader::new(file)).unwrap();
+        let needs = external_refs_needed(&mut archive, &p).unwrap();
+
+        assert_eq!(needs.len(), 24, "GRCh37 primary assembly + chrM");
+        assert_eq!(needs[0].seq_id, "CM000663.1");
+        assert_eq!(needs[0].chunk_rows, 49_851);
+        assert!(!needs[0].all_n);
+        // The last chunks of chr1 are telomeric Ns (SEQ_START == 0), so the
+        // furthest *addressed* base stops short of the full length.
+        assert!(
+            (249_000_000..=249_250_621).contains(&needs[0].max_end),
+            "chr1 max_end out of range: {}",
+            needs[0].max_end
+        );
+        assert_eq!(needs[1].seq_id, "CM000664.1");
+    }
+
+    /// ALTREAD is stored left-trimmed, so it overlays the *tail* of the
+    /// row. A mask shorter than the row must not shift the bases it hits.
+    #[test]
+    fn altread_overlay_is_right_aligned() {
+        // 8 bases of A (0x1) with a 3-byte mask covering the last three.
+        let bases = vec![0x1u8; 8];
+        let mask = [0x0F, 0x00, 0x0F];
+        let shift = bases.len() - mask.len();
+        let mut got = bases.clone();
+        for (i, &m) in mask.iter().enumerate() {
+            if m != 0 {
+                got[shift + i] = m & 0x0F;
+            }
+        }
+        assert_eq!(got, vec![0x1, 0x1, 0x1, 0x1, 0x1, 0x0F, 0x1, 0x0F]);
+    }
+}

--- a/crates/sracha-vdb/src/refseq.rs
+++ b/crates/sracha-vdb/src/refseq.rs
@@ -389,45 +389,64 @@ impl RefSeqReaders {
                 )));
             }
             let offset = (pos % msl) as usize;
-            let chunk = chunk_bases(read, altread.as_ref(), row)?;
-            if offset >= chunk.len() {
+            let row_len = read.two_na_row_len(row)?;
+            if offset >= row_len {
                 return Err(Error::Format(format!(
-                    "refseq {}: offset {offset} past chunk {row} ({} bases)",
+                    "refseq {}: offset {offset} past chunk {row} ({row_len} bases)",
                     obj.seq_id,
-                    chunk.len()
                 )));
             }
-            let take = (len - out.len()).min(chunk.len() - offset);
-            out.extend_from_slice(&chunk[offset..offset + take]);
+            let take = (len - out.len()).min(row_len - offset);
+            chunk_bases_into(&mut out, read, altread.as_ref(), row, offset, take, row_len)?;
             pos += take as u64;
         }
         Ok(out)
     }
 }
 
-/// Decode one refseq chunk row: 2na `READ` overlaid with the left-trimmed,
-/// right-aligned 4na `ALTREAD` mask. Where ALTREAD is non-zero it wins —
-/// that is how Ns and other ambiguity codes survive a 2na store.
-fn chunk_bases(read: &CachedColumn, altread: Option<&CachedColumn>, row: i64) -> Result<Vec<u8>> {
-    let mut bases = read.read_2na_row(row)?;
+/// Append `take` bases from chunk `row`, starting `offset` into it: 2na
+/// `READ` overlaid with the left-trimmed, right-aligned 4na `ALTREAD` mask.
+/// Where ALTREAD is non-zero it wins — that is how Ns and other ambiguity
+/// codes survive a 2na store.
+///
+/// Windowed rather than whole-row: a refseq chunk is `MAX_SEQ_LEN` (5,000)
+/// bases and an alignment usually wants ~100 of them, so unpacking the
+/// whole chunk per alignment dominated the decode.
+fn chunk_bases_into(
+    out: &mut Vec<u8>,
+    read: &CachedColumn,
+    altread: Option<&CachedColumn>,
+    row: i64,
+    offset: usize,
+    take: usize,
+    row_len: usize,
+) -> Result<()> {
+    let base = out.len();
+    out.extend_from_slice(&read.read_2na_range(row, offset, take)?);
+
     let Some(alt) = altread else {
-        return Ok(bases);
+        return Ok(());
     };
     let mask = alt.read_byte_row(row)?;
     if mask.is_empty() {
-        return Ok(bases);
+        return Ok(());
     }
-    // `trim<ALIGN_LEFT, 0>` drops leading zeros, so the stored mask is a
-    // suffix of the row: align it to the right before overlaying.
-    let shift = bases.len().saturating_sub(mask.len());
+    // `trim<ALIGN_LEFT, 0>` drops leading zeros, so the stored mask covers
+    // the *last* `mask.len()` bases of the row. Map those onto our window.
+    let mask_start = row_len.saturating_sub(mask.len());
     for (i, &m) in mask.iter().enumerate() {
-        if m != 0
-            && let Some(slot) = bases.get_mut(shift + i)
-        {
+        if m == 0 {
+            continue;
+        }
+        let abs = mask_start + i;
+        if abs < offset || abs >= offset + take {
+            continue;
+        }
+        if let Some(slot) = out.get_mut(base + (abs - offset)) {
             *slot = m & 0x0F;
         }
     }
-    Ok(bases)
+    Ok(())
 }
 
 /// Path a refseq object is cached at within `dir`.

--- a/crates/sracha-vdb/src/refseq.rs
+++ b/crates/sracha-vdb/src/refseq.rs
@@ -180,6 +180,13 @@ impl RefSeqStore {
         self.objects.contains_key(seq_id)
     }
 
+    /// Is this reference circular? Alignments may span the origin of one
+    /// (the mitochondrion, plasmids), so a span reaching its end has to
+    /// wrap to its start rather than stop.
+    pub fn is_circular(&self, seq_id: &str) -> bool {
+        self.objects.get(seq_id).is_some_and(|o| o.circular)
+    }
+
     fn get(&self, seq_id: &str) -> Option<&Arc<RefSeqObject>> {
         self.objects.get(seq_id)
     }
@@ -340,6 +347,11 @@ impl RefSeqReaders {
             store: store.clone(),
             cols,
         }
+    }
+
+    /// Is this reference circular? See [`RefSeqStore::is_circular`].
+    pub fn is_circular(&self, seq_id: &str) -> bool {
+        self.store.is_circular(seq_id)
     }
 
     /// `len` reference bases as 4na-bin bytes, starting at 0-based

--- a/crates/sracha-vdb/src/refseq.rs
+++ b/crates/sracha-vdb/src/refseq.rs
@@ -328,10 +328,10 @@ impl RefSeqReaders {
                 cols.insert(
                     seq_id.clone(),
                     (
-                        CachedColumn::from_shared(read.clone(), ColumnKind::TwoNa),
+                        CachedColumn::from_shared_random(read.clone(), ColumnKind::TwoNa),
                         altread
                             .as_ref()
-                            .map(|c| CachedColumn::from_shared(c.clone(), ColumnKind::Zip)),
+                            .map(|c| CachedColumn::from_shared_random(c.clone(), ColumnKind::Zip)),
                     ),
                 );
             }

--- a/crates/sracha-vdb/src/restore.rs
+++ b/crates/sracha-vdb/src/restore.rs
@@ -78,16 +78,24 @@ pub fn align_restore_read(
     let mut mmi = 0usize; // mismatch read cursor
     let mut roi = 0usize; // ref_offset read cursor
     let mut rri: i64 = 0; // reference read cursor (signed — ref_offset may rewind)
+    // Last applied ref_offset, advanced once per output base. It only goes
+    // negative on a BAM `B` (back-up) operation, and while it is negative
+    // the pending has_ref_offset flags belong to that same back-up and must
+    // not each consume another offset — see the `bi >= 0` guard in
+    // ncbi-vdb/libs/axf/align-restore-read.c:101. Without this, archives
+    // carrying B operations over-advance `rri` and walk off the reference.
+    let mut bi: i64 = 0;
 
     for di in 0..read_len {
-        if has_ref_offset[di] != 0 {
+        if has_ref_offset[di] != 0 && bi >= 0 {
             let off = *ref_offset.get(roi).ok_or_else(|| {
                 Error::Format(format!(
                     "align_restore_read: ref_offset cursor {roi} past array of {}",
                     ref_offset.len()
                 ))
             })?;
-            rri += off as i64;
+            bi = off as i64;
+            rri += bi;
             roi += 1;
         }
 
@@ -111,6 +119,7 @@ pub fn align_restore_read(
         }
 
         rri += 1;
+        bi += 1;
     }
     Ok(out)
 }
@@ -228,6 +237,32 @@ pub fn seq_restore_read(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A BAM `B` (back-up) operation sets one negative REF_OFFSET but
+    /// flags every base it rewinds over in HAS_REF_OFFSET. Only the first
+    /// of those flags consumes an offset; the rest are part of the same
+    /// back-up (`bi >= 0` guard, align-restore-read.c:101). Consuming one
+    /// per flag reads past the end of REF_OFFSET and over-advances the
+    /// reference cursor.
+    #[test]
+    fn back_up_operation_consumes_one_ref_offset() {
+        // ref = A C G T, read walks 0,1,2 then backs up 2 and re-reads 1,2,3.
+        let ref_read = vec![0x1, 0x2, 0x4, 0x8];
+        let has_mismatch = vec![0, 0, 0, 0, 0, 0];
+        let has_ref_offset = vec![0, 0, 0, 1, 1, 0];
+        let ref_offset = vec![-2];
+
+        let out = align_restore_read(
+            &ref_read,
+            &has_mismatch,
+            &[],
+            &has_ref_offset,
+            &ref_offset,
+            6,
+        )
+        .expect("back-up must not consume a second offset");
+        assert_eq!(out, vec![0x1, 0x2, 0x4, 0x2, 0x4, 0x8]);
+    }
 
     #[test]
     fn complement_involution() {

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -363,6 +363,13 @@ pub struct FastqArgs {
     /// is skipped for archives that synthesize quality (SRA-Lite, --fasta).
     #[arg(long, help_heading = "Advanced")]
     pub verify: bool,
+
+    /// Directory for cached external reference sequences, used by aligned
+    /// (cSRA) runs whose reference bases live in NCBI refseq objects rather
+    /// than in the archive itself. Shared across accessions and runs.
+    /// Defaults to $SRACHA_REFSEQ_DIR, else ~/.cache/sracha/refseq.
+    #[arg(long, value_name = "DIR", help_heading = "Advanced")]
+    pub refseq_cache: Option<PathBuf>,
 }
 
 #[derive(Args)]
@@ -561,6 +568,13 @@ pub struct GetArgs {
     /// Format for `--dry-run` output.
     #[arg(long, value_enum, default_value = "tsv", help_heading = "Advanced")]
     pub dry_run_format: DryRunFormat,
+
+    /// Directory for cached external reference sequences, used by aligned
+    /// (cSRA) runs whose reference bases live in NCBI refseq objects rather
+    /// than in the archive itself. Shared across accessions and runs.
+    /// Defaults to $SRACHA_REFSEQ_DIR, else ~/.cache/sracha/refseq.
+    #[arg(long, value_name = "DIR", help_heading = "Advanced")]
+    pub refseq_cache: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy, ValueEnum, Default)]

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -345,7 +345,7 @@ async fn main() -> Result<()> {
                     continue;
                 }
 
-                let pipeline_config = sracha_core::pipeline::PipelineConfig {
+                let mut pipeline_config = sracha_core::pipeline::PipelineConfig {
                     output_dir: args.output_dir.clone(),
                     split_mode,
                     compression,
@@ -372,7 +372,33 @@ async fn main() -> Result<()> {
                     metadata_md5: None,
                     metadata_size: None,
                     metadata_service: None,
+                    refseq_paths: Vec::new(),
+                    refseq_cache_dir: args.refseq_cache.clone(),
                 };
+
+                // Aligned runs whose REFERENCE holds only the chunk layout
+                // need the assembly's bases fetched before decode; a no-op
+                // for every other archive shape.
+                match sracha_core::pipeline::refseq::prepare_external_refseqs(
+                    sra_path,
+                    None,
+                    &pipeline_config,
+                )
+                .await
+                {
+                    Ok(paths) => pipeline_config.refseq_paths = paths,
+                    Err(e) => {
+                        let acc = sra_path
+                            .file_stem()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or("unknown")
+                            .to_string();
+                        let client = sracha_core::http::default_client();
+                        suggest_ena_fallback(&client, &acc, &e.to_string()).await;
+                        fastq_skipped.push(acc);
+                        continue;
+                    }
+                }
 
                 let stats = match sracha_core::pipeline::run_fastq(sra_path, None, &pipeline_config)
                 {
@@ -646,6 +672,8 @@ async fn main() -> Result<()> {
                         metadata_md5: resolved.sra_file.md5.clone(),
                         metadata_size: Some(resolved.sra_file.size),
                         metadata_service: primary.map(|m| m.service.clone()),
+                        refseq_paths: Vec::new(),
+                        refseq_cache_dir: args.refseq_cache.clone(),
                     }
                 }
             };
@@ -694,7 +722,7 @@ async fn main() -> Result<()> {
                     break;
                 }
 
-                let pipeline_config = make_config(resolved);
+                let mut pipeline_config = make_config(resolved);
 
                 // ---- ENA fast path ------------------------------------------------
                 if let Some(ena) = &ena_results[i] {
@@ -775,6 +803,25 @@ async fn main() -> Result<()> {
                 }
                 // Skip trailing ENA indices after the one we just spawned.
                 let _ = i;
+
+                // Aligned runs that keep only the chunk layout in REFERENCE
+                // need the assembly's bases on disk before decode starts.
+                // Async, and once per accession — rayon workers never fetch.
+                match sracha_core::pipeline::refseq::prepare_external_refseqs(
+                    &downloaded.temp_path,
+                    None,
+                    &pipeline_config,
+                )
+                .await
+                {
+                    Ok(paths) => pipeline_config.refseq_paths = paths,
+                    Err(e) => {
+                        suggest_ena_fallback(&http_client, &resolved.accession, &e.to_string())
+                            .await;
+                        skipped_accessions.push(resolved.accession.clone());
+                        continue;
+                    }
+                }
 
                 // Decode (CPU-bound) while the next download runs in the background.
                 let source = resolved
@@ -1381,7 +1428,24 @@ fn print_local_file_info(path: &std::path::Path) {
         None
     };
     if sracha_core::vdb::csra::looks_like_decodable_csra(path, vdbcache_opt).unwrap_or(false) {
-        print_local_csra_info(path, &mut archive);
+        // Reopen the sidecar as its own archive: the probe above accepts
+        // split archives, so the cursor has to be sidecar-aware too or it
+        // fails on exactly the files we just said we could read.
+        let mut cache_archive = vdbcache_opt.and_then(|p| {
+            std::fs::File::open(p)
+                .map_err(|e| e.to_string())
+                .and_then(|f| {
+                    KarArchive::open(std::io::BufReader::new(f)).map_err(|e| e.to_string())
+                })
+                .map_err(|e| {
+                    eprintln!(
+                        "  {} vdbcache parse failed: {e}",
+                        style::error_label("error:")
+                    );
+                })
+                .ok()
+        });
+        print_local_csra_info(path, &mut archive, cache_archive.as_mut().zip(vdbcache_opt));
         return;
     }
 
@@ -1442,10 +1506,11 @@ fn print_local_file_info(path: &std::path::Path) {
 fn print_local_csra_info<R: std::io::Read + std::io::Seek>(
     path: &std::path::Path,
     archive: &mut sracha_core::vdb::kar::KarArchive<R>,
+    vdbcache: Option<(&mut sracha_core::vdb::kar::KarArchive<R>, &std::path::Path)>,
 ) {
     use sracha_core::vdb::csra::CsraCursor;
 
-    let csra = match CsraCursor::open(archive, path) {
+    let csra = match CsraCursor::open_any(archive, path, vdbcache) {
         Ok(c) => c,
         Err(e) => {
             eprintln!("  {} cSRA cursor failed: {e}", style::error_label("error:"));

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,6 +136,19 @@ sracha decodes compressed/aligned SRA archives (cSRA) in pure Rust,
 producing byte-identical FASTQ to fasterq-dump. No special flag is
 required — sracha detects the schema and switches decoders automatically.
 
+Runs aligned to a public assembly store only the chunk layout in their
+`REFERENCE` table; the bases live in separate NCBI refseq objects named by
+`SEQ_ID` (e.g. `CM000663.1` for GRCh37 chr1). sracha fetches those on
+demand and caches them so later runs against the same assembly reuse them:
+
+```bash
+sracha get ERR10213669                              # fetches GRCh37 once (~700 MiB)
+sracha get ERR10213669 --refseq-cache /scratch/refs # or pick the location
+```
+
+The cache defaults to `$SRACHA_REFSEQ_DIR`, else `~/.cache/sracha/refseq`.
+Put it on shared storage to amortise it across a group or a cluster.
+
 ## SRA-lite
 
 SRA-lite files are smaller (4-10x) because they use simplified quality


### PR DESCRIPTION
Closes #74 — but not the way the issue describes. **The issue's premise does not hold**, and the fix is unrelated to `.vdbcache`.

## What #74 got wrong

| claim | reality |
|---|---|
| ERR10213669's alignment tables live in a `.sra.vdbcache` sidecar | It has **no sidecar**. SDL returns one file (`type: "sra"`); `ListObjectsV2` on `sra/ERR10213669/` returns exactly one key. |
| Downloading the sidecar supplies `PRIMARY_ALIGNMENT` + `REFERENCE` | Both tables are **already in the main `.sra`** (27,367,664 and 619,146 rows). |
| The sidecar is the missing piece | A real `.vdbcache` (checked `SRR622461`, `ERR194147`) is schema `NCBI:align:tbl:mate_cache#1.1` — one `PRIMARY_ALIGNMENT` table whose only columns are `MATE_ALIGN_ID_CACHE`, `MATE_REF_NAME_CACHE`, `MATE_REF_POS_CACHE`, `RD_FILTER_CACHE`, `SAM_FLAGS_CACHE`, `SAM_QUALITY_CACHE`, `SPOT_GROUP_CACHE`, `TEMPLATE_LEN_CACHE`. **No bases, no REFERENCE table.** It accelerates `sam-dump` mate lookups and cannot contribute to FASTQ. |

So no vdbcache download was added. The existing discovery plumbing (`s3::vdbcache_url`, `find_vdbcache_file`, the sidecar download in `sracha fetch`) is untouched and still serves `fetch`/`info`.

The issue's "Caveat / possible follow-up" paragraph turned out to be the entire feature.

## What actually blocked it

1. **`decode_sra` had no cSRA dispatch at all.** Only `run_fastq` routed to `CsraCursor`, so `sracha get` on *any* aligned run fell through to `VdbCursor` and died in `reject_if_csra`.
2. **`looks_like_decodable_csra` required `SEQUENCE.CMP_READ`.** Fully-aligned runs store no unaligned residue, so they were never detected.
3. **`CsraCursor` opened `SEQUENCE.QUALITY`** with no `ORIGINAL_QUALITY` fallback — which the plain cursor has had all along.
4. **`REFERENCE` held only the chunk layout.** Bases live in NCBI refseq objects named by `SEQ_ID` (`CM000663.1` = GRCh37 chr1).

## The external-reference layer

`sracha-core` resolves the `SEQ_ID`s through SDL, downloads them into a shared cache, and hands `sracha-vdb` **local paths** — the vdb crate still performs no network I/O.

- Cache: `--refseq-cache` → `$SRACHA_REFSEQ_DIR` → `~/.cache/sracha/refseq`. Deliberately outside the output dir: one GRCh37 set (~686 MiB, 24 objects) serves every human cSRA. Downloads go to `.partial` and are renamed atomically; warm hits are accepted on size + `NCBI.sra` magic rather than re-hashing 700 MB per run.
- Per-chunk resolution mirrors ncbi-vdb's `ref_restore_read`: embedded `CMP_READ` → pad a short row with Ns → `SEQ_START == 0` means an all-N chunk → otherwise fetch externally. Modelled per row, not per table, because the schema allows both in one archive.
- Refseq `READ` is 2na overlaid with the left-trimmed, right-aligned `ALTREAD` mask. Without the overlay, telomeric N runs decode as `A`.
- `fetch_span` now refuses to walk across a `SEQ_ID` boundary instead of silently splicing in the next chromosome.
- `RefSeqStore` (shared `Arc`, opened once) / `RefSeqReaders` (per-rayon-worker blob caches) so 24 mmaps are opened once per accession, not once per chunk.

## Verification

`ERR10213669` vs `fasterq-dump` (sratoolkit 3.2.1), same input file:

```
sracha : 13,686,698 spots, 27,367,664 reads written
fasterq: 13,686,698 spots, 27,367,664 reads written
seq+qual md5, read 1: a5feafb37f08e108e7583c7eff0b8bfa  (both)
seq+qual md5, read 2: dd4f22413e066d774ee289f11800e54c  (both)
```

`VDB-3418` (monolithic embedded cSRA, existing fixture) is **full-file byte-identical**, deflines included — it was not before this PR, see below.

750 unit tests pass; `clippy --all-targets --all-features -D warnings` clean.

## Also fixed — all exposed by routing real cSRA through this path for the first time

- **`run_fastq_csra` held the entire FASTQ output in memory.** It collected every decoded chunk before writing any; harmless on the 12 MB test fixture, ~7.7 GB resident on ERR10213669. Now decodes and drains a bounded batch at a time.
- **cSRA deflines omitted the name field.** fasterq-dump synthesizes the spot id there (`DSD_FASTQ_SYN_NAME`), exactly as sracha's own plain path already did. This is why VDB-3418 was not byte-identical before.
- **`sracha info` on a split cSRA errored** — detection was sidecar-aware, the cursor open was not.

## Known gaps (not in this PR)

- `SEQUENCE.CMP_ALTREAD` is still unhandled, so partially-aligned archives that have one decode ambiguity codes as A/C/G/T. Present on `SRR622461`/`ERR194147`-class runs; worth its own issue.
- Circular references (chrM) have wrap handling but no fixture exercises it — ERR10213669's 24 references are all linear.

## Suggested issue hygiene

#74's title and both "What's needed" steps should be struck. Retitle to something like *"Natively decode fully-aligned cSRA with external reference"*.