### PR TITLE
perf(vdb): don't expand a whole RLE blob's extents to read one row

### DIFF
--- a/crates/sracha-core/src/pipeline/mod.rs
+++ b/crates/sracha-core/src/pipeline/mod.rs
@@ -1498,7 +1498,14 @@ fn run_fastq_csra(
     // Opening CsraCursor inside rayon workers means we don't need to
     // share the top-level one; drop it here to release its file handle
     // and avoid the small double-open cost on single-threaded paths.
-    let total_spots = csra.row_count();
+    let mut total_spots = csra.row_count();
+    // Diagnostic: cap the decode so a measurement run takes a minute
+    // instead of an hour. Unset in normal use.
+    if let Ok(v) = std::env::var("SRACHA_MAX_SPOTS")
+        && let Ok(n) = v.parse::<u64>()
+    {
+        total_spots = total_spots.min(n);
+    }
     let first_row = csra.first_row();
     drop(csra);
     drop(archive);
@@ -1698,6 +1705,10 @@ fn run_fastq_csra(
             std::fs::rename(tmp_path, final_path).map_err(Error::Io)?;
             final_paths.push(final_path.clone());
         }
+    }
+
+    if std::env::var_os("SRACHA_COLSTATS").is_some() {
+        crate::vdb::cache::dump_column_stats();
     }
 
     Ok(FastqStats {

--- a/crates/sracha-vdb/Cargo.toml
+++ b/crates/sracha-vdb/Cargo.toml
@@ -23,3 +23,9 @@ tracing.workspace = true
 proptest.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
 tempfile.workspace = true
+
+[features]
+# Per-column blob-cache counters, printed by `dump_column_stats`. Off by
+# default: the counters sit in the hot path, so this is for investigation
+# runs, not production.
+colstats = []

--- a/crates/sracha-vdb/src/alignment.rs
+++ b/crates/sracha-vdb/src/alignment.rs
@@ -7,7 +7,7 @@
 use std::io::{Read, Seek};
 use std::path::Path;
 
-use crate::cache::{CachedColumn, ColumnKind};
+use crate::cache::{CachedColumn, ColLabel, ColumnKind};
 use crate::error::{Error, Result};
 use crate::inspect;
 use crate::kar::KarArchive;
@@ -112,12 +112,16 @@ impl AlignmentCursor {
             global_ref_start: CachedColumn::new(
                 global_ref_start,
                 ColumnKind::Irzip { elem_bits: 64 },
-            ),
+            )
+            .labelled(ColLabel::PaGlobalRefStart),
             ref_len: CachedColumn::new(ref_len, ColumnKind::Irzip { elem_bits: 32 }),
-            has_mismatch: CachedColumn::new(has_mismatch, ColumnKind::Zip),
-            has_ref_offset: CachedColumn::new(has_ref_offset, ColumnKind::Zip),
-            mismatch: CachedColumn::new(mismatch, ColumnKind::Zip),
-            ref_offset: CachedColumn::new(ref_offset, ColumnKind::Irzip { elem_bits: 32 }),
+            has_mismatch: CachedColumn::new(has_mismatch, ColumnKind::Zip)
+                .labelled(ColLabel::PaHasMismatch),
+            has_ref_offset: CachedColumn::new(has_ref_offset, ColumnKind::Zip)
+                .labelled(ColLabel::PaHasRefOffset),
+            mismatch: CachedColumn::new(mismatch, ColumnKind::Zip).labelled(ColLabel::PaMismatch),
+            ref_offset: CachedColumn::new(ref_offset, ColumnKind::Irzip { elem_bits: 32 })
+                .labelled(ColLabel::PaRefOffset),
             row_count,
             first_row,
         })

--- a/crates/sracha-vdb/src/blob.rs
+++ b/crates/sracha-vdb/src/blob.rs
@@ -360,6 +360,26 @@ impl PageMap {
         self.row_extents_range(0, self.total_rows() as usize)
     }
 
+    /// One row's extent, without materialising the rest of the blob.
+    ///
+    /// Costs one step per length run crossed, not one per row (see
+    /// `LengthRunCursor::skip_rows`), so it is O(1) on the RLE blobs that
+    /// make eager expansion ruinous — a constant-valued column stores the
+    /// whole table as a single run.
+    pub fn extent_at(&self, row: usize) -> Result<RowExtent> {
+        let mut found = None;
+        self.for_each_row_extent(row, 1, |_, e| {
+            found = Some(e);
+            Ok(())
+        })?;
+        found.ok_or_else(|| {
+            Error::Format(format!(
+                "page_map: row {row} outside blob of {} rows",
+                self.total_rows()
+            ))
+        })
+    }
+
     /// [`row_extents`](Self::row_extents) for the window `[skip, skip + take)`.
     pub fn row_extents_range(&self, skip: usize, take: usize) -> Result<Vec<RowExtent>> {
         let mut out = Vec::with_capacity(take.min(self.total_rows() as usize));

--- a/crates/sracha-vdb/src/cache.rs
+++ b/crates/sracha-vdb/src/cache.rs
@@ -10,10 +10,128 @@
 
 use std::cell::RefCell;
 use std::sync::Arc;
+#[cfg(feature = "colstats")]
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::blob::{self, DecodedBlob, PageMap, RowExtent};
 use crate::error::{Error, Result};
 use crate::kdb::ColumnReader;
+
+/// Above this many rows in a single blob, don't expand every row's extent
+/// on decode — look rows up one at a time instead.
+///
+/// A constant-valued column is stored as one run covering the whole table:
+/// `SEQUENCE.READ_LEN` on a fixed-length run is a single blob spanning every
+/// spot. Expanding that to read one row allocated ~740 MB per decode worker
+/// and accounted for 99.6% of all extent expansion on SRR622461. Blobs below
+/// the threshold keep the eager path, which is cheaper once several rows of
+/// a blob get read — measured, not assumed.
+const EAGER_EXTENT_MAX_ROWS: u64 = 1 << 20;
+
+/// Diagnostic label so per-column blob-cache behaviour can be attributed.
+/// Profilers lose the caller of `row_extents_range` to inlining, so the
+/// counters below are the only way to tell which column is thrashing.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ColLabel {
+    Other,
+    SeqCmpRead,
+    SeqCmpAltread,
+    SeqQuality,
+    SeqAlignId,
+    SeqReadLen,
+    SeqReadType,
+    PaGlobalRefStart,
+    PaHasMismatch,
+    PaHasRefOffset,
+    PaMismatch,
+    PaRefOffset,
+    RefCmpRead,
+    RefSeqRead,
+    RefSeqAltread,
+}
+
+impl ColLabel {
+    #[allow(dead_code)]
+    pub(crate) const COUNT: usize = 15;
+
+    #[cfg(feature = "colstats")]
+    fn idx(self) -> usize {
+        self as usize
+    }
+
+    #[cfg(feature = "colstats")]
+    fn name(i: usize) -> &'static str {
+        [
+            "other",
+            "SEQ.CMP_READ",
+            "SEQ.CMP_ALTREAD",
+            "SEQ.QUALITY",
+            "SEQ.PRIMARY_ALIGNMENT_ID",
+            "SEQ.READ_LEN",
+            "SEQ.READ_TYPE",
+            "PA.GLOBAL_REF_START",
+            "PA.HAS_MISMATCH",
+            "PA.HAS_REF_OFFSET",
+            "PA.MISMATCH",
+            "PA.REF_OFFSET",
+            "REFERENCE.CMP_READ",
+            "refseq.READ",
+            "refseq.ALTREAD",
+        ][i]
+    }
+}
+
+// One counter per label. `AtomicU64` has interior mutability, so this is
+// spelled out rather than built from a `const` initialiser.
+#[cfg(feature = "colstats")]
+#[allow(clippy::declare_interior_mutable_const)]
+const ZERO: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "colstats")]
+static HITS: [AtomicU64; ColLabel::COUNT] = [ZERO; ColLabel::COUNT];
+#[cfg(feature = "colstats")]
+static MISSES: [AtomicU64; ColLabel::COUNT] = [ZERO; ColLabel::COUNT];
+#[cfg(feature = "colstats")]
+static EXTENTS: [AtomicU64; ColLabel::COUNT] = [ZERO; ColLabel::COUNT];
+
+#[cfg(feature = "colstats")]
+#[inline]
+fn bump(counters: &[AtomicU64; ColLabel::COUNT], label: ColLabel, n: u64) {
+    counters[label.idx()].fetch_add(n, Ordering::Relaxed);
+}
+
+/// Print per-column blob-cache stats to stderr. Diagnostic only.
+#[cfg(not(feature = "colstats"))]
+pub fn dump_column_stats() {
+    eprintln!("column stats unavailable: rebuild with --features sracha-vdb/colstats");
+}
+
+/// Print per-column blob-cache stats to stderr. Diagnostic only.
+#[cfg(feature = "colstats")]
+pub fn dump_column_stats() {
+    eprintln!(
+        "{:<26} {:>14} {:>14} {:>7} {:>16}",
+        "column", "hits", "misses", "miss%", "extents expanded"
+    );
+    let mut total_extents = 0u64;
+    for i in 0..ColLabel::COUNT {
+        let h = HITS[i].load(Ordering::Relaxed);
+        let m = MISSES[i].load(Ordering::Relaxed);
+        let e = EXTENTS[i].load(Ordering::Relaxed);
+        total_extents += e;
+        if h + m == 0 {
+            continue;
+        }
+        eprintln!(
+            "{:<26} {:>14} {:>14} {:>6.1}% {:>16}",
+            ColLabel::name(i),
+            h,
+            m,
+            100.0 * m as f64 / (h + m) as f64,
+            e
+        );
+    }
+    eprintln!("{:<26} {:>54}", "TOTAL extents expanded", total_extents);
+}
 
 /// How a column's blob payload is decoded once `blob::decode_blob` has
 /// stripped the envelope / headers / page map. Caller selects the kind
@@ -61,10 +179,16 @@ impl DecodedColumnBlob {
     /// With no page map every row is one element wide at its own index.
     pub fn extent(&self, logical_offset: usize) -> Result<RowExtent> {
         if self.extents.is_empty() {
-            return Ok(RowExtent {
-                offset: logical_offset as u32,
-                len: 1,
-            });
+            // Either the blob was too wide to expand (see
+            // `EAGER_EXTENT_MAX_ROWS`) or it has no page map at all, in
+            // which case every row is one element wide at its own index.
+            return match &self.page_map {
+                Some(pm) => pm.extent_at(logical_offset),
+                None => Ok(RowExtent {
+                    offset: logical_offset as u32,
+                    len: 1,
+                }),
+            };
         }
         self.extents.get(logical_offset).copied().ok_or_else(|| {
             Error::Format(format!(
@@ -82,6 +206,7 @@ impl DecodedColumnBlob {
 pub(crate) struct CachedColumn {
     col: Arc<ColumnReader>,
     kind: ColumnKind,
+    label: ColLabel,
     cache: RefCell<Option<DecodedColumnBlob>>,
 }
 
@@ -98,8 +223,15 @@ impl CachedColumn {
         Self {
             col,
             kind,
+            label: ColLabel::Other,
             cache: RefCell::new(None),
         }
+    }
+
+    /// Tag this column for the diagnostic counters.
+    pub fn labelled(mut self, label: ColLabel) -> Self {
+        self.label = label;
+        self
     }
 
     /// Ensure the blob containing `row_id` is decoded (reusing the cached
@@ -123,9 +255,13 @@ impl CachedColumn {
             if let Some(cached) = borrow.as_ref()
                 && cached.start_id == start_id
             {
+                #[cfg(feature = "colstats")]
+                bump(&HITS, self.label, 1);
                 return f(cached, logical_offset);
             }
         }
+        #[cfg(feature = "colstats")]
+        bump(&MISSES, self.label, 1);
 
         let raw = self.col.read_raw_blob_slice(row_id)?;
         let decoded = blob::decode_blob(
@@ -141,11 +277,12 @@ impl CachedColumn {
         };
         let page_map = decoded.page_map;
         let row_length = decoded.row_length;
-        let extents = page_map
-            .as_ref()
-            .map(|pm| pm.row_extents())
-            .transpose()?
-            .unwrap_or_default();
+        let extents = match page_map.as_ref() {
+            Some(pm) if pm.total_rows() <= EAGER_EXTENT_MAX_ROWS => pm.row_extents()?,
+            _ => Vec::new(),
+        };
+        #[cfg(feature = "colstats")]
+        bump(&EXTENTS, self.label, extents.len() as u64);
 
         *self.cache.borrow_mut() = Some(DecodedColumnBlob {
             start_id,

--- a/crates/sracha-vdb/src/csra.rs
+++ b/crates/sracha-vdb/src/csra.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::alignment::AlignmentCursor;
-use crate::cache::{CachedColumn, ColumnKind};
+use crate::cache::{CachedColumn, ColLabel, ColumnKind};
 use crate::error::{Error, Result};
 use crate::inspect;
 use crate::kar::KarArchive;
@@ -353,15 +353,20 @@ impl CsraCursor {
         let row_count = primary_alignment_id.row_count();
 
         Ok(Self {
-            cmp_read: cmp_read.map(|c| CachedColumn::new(c, ColumnKind::TwoNa)),
-            cmp_altread: cmp_altread.map(|c| CachedColumn::new(c, ColumnKind::Zip)),
+            cmp_read: cmp_read
+                .map(|c| CachedColumn::new(c, ColumnKind::TwoNa).labelled(ColLabel::SeqCmpRead)),
+            cmp_altread: cmp_altread
+                .map(|c| CachedColumn::new(c, ColumnKind::Zip).labelled(ColLabel::SeqCmpAltread)),
             primary_alignment_id: CachedColumn::new(
                 primary_alignment_id,
                 ColumnKind::Irzip { elem_bits: 64 },
-            ),
-            read_len: CachedColumn::new(read_len, ColumnKind::Irzip { elem_bits: 32 }),
-            read_type: CachedColumn::new(read_type, ColumnKind::Zip),
-            quality: CachedColumn::new(quality, ColumnKind::Zip),
+            )
+            .labelled(ColLabel::SeqAlignId),
+            read_len: CachedColumn::new(read_len, ColumnKind::Irzip { elem_bits: 32 })
+                .labelled(ColLabel::SeqReadLen),
+            read_type: CachedColumn::new(read_type, ColumnKind::Zip)
+                .labelled(ColLabel::SeqReadType),
+            quality: CachedColumn::new(quality, ColumnKind::Zip).labelled(ColLabel::SeqQuality),
             alignment,
             reference,
             row_count,

--- a/crates/sracha-vdb/src/lib.rs
+++ b/crates/sracha-vdb/src/lib.rs
@@ -7,7 +7,7 @@
 pub mod alignment;
 pub mod blob;
 pub mod blob_codecs;
-pub(crate) mod cache;
+pub mod cache;
 pub mod csra;
 pub mod cursor;
 pub mod dump;

--- a/crates/sracha-vdb/src/reference.rs
+++ b/crates/sracha-vdb/src/reference.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 
 use std::sync::Arc;
 
-use crate::cache::{CachedColumn, ColumnKind};
+use crate::cache::{CachedColumn, ColLabel, ColumnKind};
 use crate::error::{Error, Result};
 use crate::inspect;
 use crate::kar::KarArchive;
@@ -113,7 +113,8 @@ impl ReferenceCursor {
         let first_row = seq_len.first_row_id().unwrap_or(1);
         let row_count = seq_len.row_count();
 
-        let cmp_read = cmp_read.map(|c| CachedColumn::new(c, ColumnKind::TwoNa));
+        let cmp_read = cmp_read
+            .map(|c| CachedColumn::new(c, ColumnKind::TwoNa).labelled(ColLabel::RefCmpRead));
         let external = refseqs.map(RefSeqReaders::new);
         let layout = match layout {
             Some(l) => l.clone(),

--- a/crates/sracha-vdb/src/refseq.rs
+++ b/crates/sracha-vdb/src/refseq.rs
@@ -24,7 +24,7 @@ use std::io::{Read, Seek};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::cache::{CachedColumn, ColumnKind};
+use crate::cache::{CachedColumn, ColLabel, ColumnKind};
 use crate::error::{Error, Result};
 use crate::inspect;
 use crate::kar::KarArchive;
@@ -335,10 +335,12 @@ impl RefSeqReaders {
                 cols.insert(
                     seq_id.clone(),
                     (
-                        CachedColumn::from_shared(read.clone(), ColumnKind::TwoNa),
-                        altread
-                            .as_ref()
-                            .map(|c| CachedColumn::from_shared(c.clone(), ColumnKind::Zip)),
+                        CachedColumn::from_shared(read.clone(), ColumnKind::TwoNa)
+                            .labelled(ColLabel::RefSeqRead),
+                        altread.as_ref().map(|c| {
+                            CachedColumn::from_shared(c.clone(), ColumnKind::Zip)
+                                .labelled(ColLabel::RefSeqAltread)
+                        }),
                     ),
                 );
             }


### PR DESCRIPTION
Stacked on #133 — review that first. This is the follow-up it asks for: profiling SRR622461, the 15× case that #133 explicitly left open.

## The bug

`SEQUENCE.READ_LEN` on a fixed-length run is constant, so VDB stores it as a single length run covering the whole table. On SRR622461 that is **one blob spanning all 92,459,459 rows**. `CachedColumn` expanded it into a per-row extent vector on every blob decode — ~740 MB allocated, 92.4M entries written — **to read one row's value**.

Profiling alone couldn't find this: `PageMap::row_extents_range` was 87% of cycles, but the unwinder loses its caller to inlining, so there was no way to tell which column. I guessed twice in #133 and was wrong both times. So this PR adds per-column counters behind a `colstats` feature, and they answered it immediately:

```
column                     misses    extents expanded
SEQ.READ_LEN                  391      36,147,204,363
everything else            ~32,000        ~143,000,000
```

99.6% of all expansion from 0.4% of the misses. 391 misses is exactly one per decode chunk. It also explains the resident set — 16 workers each holding one of those vectors.

## The fix

Blobs above `EAGER_EXTENT_MAX_ROWS` (1M rows) resolve rows one at a time via `PageMap::extent_at`, which walks length *runs* rather than rows — O(1) on exactly the RLE shape that made eager expansion ruinous. Smaller blobs keep the eager path.

That threshold is deliberate, not cautious hedging: #133 tried making *every* column lazy and it was **60% slower**, because a blob that gets several rows read amortises one expansion well. The win is specific to blobs so wide that they are decoded to serve a single row.

## Measured

| | before | after | fasterq-dump |
|---|---|---|---|
| ERR10213669 wall | 150 s | **87 s** | 84 s |
| ERR10213669 peak RSS | 2.5 GB | **860 MB** | — |
| SRR622461, 400k-spot sample | 18.4 s | **7.4 s** | — |
| SRR622461 extents expanded (400k spots) | 36.3B | **144M** | — |

ERR10213669 output remains byte-identical to `fasterq-dump` on both mates. 756 tests pass; clippy clean.

Full SRR622461 timing and parity are running and will be added as a comment.

## Also here

- `colstats` feature — per-column blob-cache hit/miss/extent counters, off by default so the atomics cost nothing in normal builds. This is the capability whose absence made #133's optimization attempts guesswork.
- `SRACHA_MAX_SPOTS` — caps a decode so an investigation run takes a minute instead of an hour. Diagnostic only.