### PR TITLE
fix(cli): don't require disk for output `--stdout` never writes (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features
 
+- `--no-disk-check` on `get` and `fetch` opts out of the free-disk-space
+  preflight entirely, for output filesystems that autoscale or report a
+  quota `statvfs` can't see through (#137).
 - Decode aligned cSRA whose reference bases live outside the archive (#74).
   Runs aligned to a public assembly keep only the chunk layout in
   `REFERENCE`; the bases are fetched from NCBI refseq objects named by
@@ -23,6 +26,12 @@ zero, so nothing downstream would have flagged it.
 
 ### Fixes
 
+- `sracha get --stdout` no longer demands disk for output it never writes
+  (#137). The preflight sized a streaming run as if every accession's FASTQ
+  landed on disk and every temp archive stayed there, so peak was
+  `sum(archive + fastq)` across the whole batch. Streaming writes no FASTQ at
+  all and deletes each archive as its decode ends, so the requirement is now
+  the largest `--prefetch-depth + 1` archives — flat in batch size.
 - Restore ambiguity codes in the unaligned half of a cSRA read
   (`SEQUENCE.CMP_ALTREAD`) — see the upgrade note.
 - `sracha get` now routes reference-compressed cSRA through the cSRA decoder.

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -225,6 +225,12 @@ pub struct FetchArgs {
     #[arg(long)]
     pub no_progress: bool,
 
+    /// Skip the free-disk-space preflight check entirely. Useful when the
+    /// output filesystem autoscales, or when `statvfs` reports a quota that
+    /// doesn't reflect what the job can actually use.
+    #[arg(long, help_heading = "Advanced")]
+    pub no_disk_check: bool,
+
     /// Skip MD5 verification after download (verification is on by default)
     #[arg(long, help_heading = "Advanced")]
     pub no_validate: bool,
@@ -504,6 +510,12 @@ pub struct GetArgs {
     /// Disable download resume (re-download from scratch)
     #[arg(long, help_heading = "Advanced")]
     pub no_resume: bool,
+
+    /// Skip the free-disk-space preflight check entirely. Useful when the
+    /// output filesystem autoscales, or when `statvfs` reports a quota that
+    /// doesn't reflect what the job can actually use.
+    #[arg(long, help_heading = "Advanced")]
+    pub no_disk_check: bool,
 
     /// Skip the EUtils RunInfo API call (read structure will be derived
     /// from VDB file metadata instead).

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -115,7 +115,7 @@ async fn main() -> Result<()> {
             // the filesystem, by which point these files are on disk, so the
             // two checks compose rather than double-count.
             let ena_bytes: u64 = ena_results.iter().flatten().map(|e| e.total_size).sum();
-            if ena_bytes > 0 {
+            if ena_bytes > 0 && !args.no_disk_check {
                 check_disk_space(ena_bytes, &args.output_dir)?;
             }
 
@@ -215,7 +215,12 @@ async fn main() -> Result<()> {
             // size is the whole requirement.
             let sizes = expected_bytes_each(&resolved_all, &[], SraDisposition::KeepArchive);
             check_download_confirmation(&resolved_all, &sizes, args.yes, has_projects)?;
-            check_disk_space(sizes.iter().sum(), &args.output_dir)?;
+            if !args.no_disk_check {
+                check_disk_space(
+                    peak_disk_bytes(&sizes, SraDisposition::KeepArchive),
+                    &args.output_dir,
+                )?;
+            }
 
             for resolved in &resolved_all {
                 let acc = &resolved.accession;
@@ -551,15 +556,25 @@ async fn main() -> Result<()> {
 
             // `get` decodes each NCBI archive to FASTQ written beside it, so
             // peak disk is archive + output. ENA-served runs skip both.
-            let sizes = expected_bytes_each(
-                &resolved_all,
-                &ena_results,
+            // `--stdout` skips the output too: nothing is written, and each
+            // temp archive is deleted as its decode ends, so only the runs in
+            // flight count. (ENA and --stdout are mutually exclusive — see
+            // `ena_compatible` above — so the two branches never mix.)
+            let disposition = if args.stdout {
+                SraDisposition::StreamToStdout {
+                    // The accession being decoded, plus the prefetch queue.
+                    in_flight: args.prefetch_depth.max(1).saturating_add(1),
+                }
+            } else {
                 SraDisposition::DecodeToFastq {
                     compressed: !matches!(compression, sracha_core::fastq::CompressionMode::None),
-                },
-            );
+                }
+            };
+            let sizes = expected_bytes_each(&resolved_all, &ena_results, disposition);
             check_download_confirmation(&resolved_all, &sizes, args.yes, has_projects)?;
-            check_disk_space(sizes.iter().sum(), &args.output_dir)?;
+            if !args.no_disk_check {
+                check_disk_space(peak_disk_bytes(&sizes, disposition), &args.output_dir)?;
+            }
 
             let format_label = if args.fasta { "FASTA" } else { "FASTQ" };
             tracing::info!(
@@ -2046,6 +2061,30 @@ enum SraDisposition {
     /// it — the temp `.sracha-tmp-<acc>.sra` is not removed until decode
     /// finishes, so both exist at once.
     DecodeToFastq { compressed: bool },
+    /// `get --stdout`: the FASTQ is streamed, never written, and each temp
+    /// archive is deleted the moment its decode finishes. Only the runs in
+    /// flight — the one decoding plus the prefetch queue — occupy disk, so
+    /// peak is bounded by `in_flight` archives no matter how long the batch.
+    StreamToStdout { in_flight: usize },
+}
+
+/// Peak bytes on disk for the whole batch, as distinct from total bytes
+/// transferred.
+///
+/// For dispositions that leave every run's output on disk these are the same
+/// number, so the per-run sizes just add up. Under `--stdout` they are not:
+/// the archives are transient, so only the largest `in_flight` of them are
+/// ever resident at once (see #137 — summing them made a streaming run
+/// demand disk proportional to the batch size it never uses).
+fn peak_disk_bytes(sizes: &[u64], disposition: SraDisposition) -> u64 {
+    match disposition {
+        SraDisposition::StreamToStdout { in_flight } => {
+            let mut sorted = sizes.to_vec();
+            sorted.sort_unstable_by(|a, b| b.cmp(a));
+            sorted.into_iter().take(in_flight.max(1)).sum()
+        }
+        SraDisposition::KeepArchive | SraDisposition::DecodeToFastq { .. } => sizes.iter().sum(),
+    }
 }
 
 /// Assumed gzip/zstd ratio for FASTQ output.
@@ -2108,7 +2147,11 @@ fn expected_bytes_each(
             // ENA files land directly as the deliverable — no archive, no decode.
             Some(ena) => ena.total_size,
             None => match disposition {
-                SraDisposition::KeepArchive => r.sra_file.size,
+                // Streaming writes no FASTQ at all, so the archive is the
+                // entire footprint — same as `fetch`, minus the permanence.
+                SraDisposition::KeepArchive | SraDisposition::StreamToStdout { .. } => {
+                    r.sra_file.size
+                }
                 SraDisposition::DecodeToFastq { compressed } => r
                     .sra_file
                     .size
@@ -2146,7 +2189,8 @@ fn check_disk_space(required_bytes: u64, output_dir: &Path) -> Result<()> {
 
     if total_size > available {
         anyhow::bail!(
-            "not enough disk space: download requires {} but only {} available in {}",
+            "not enough disk space: download requires {} but only {} available in {} \
+             (pass --no-disk-check to skip this preflight)",
             format_size(total_size),
             format_size(available),
             output_dir.display(),
@@ -2511,6 +2555,70 @@ mod tests {
             SraDisposition::DecodeToFastq { compressed: true },
         );
         assert_eq!(total(sizes), 4096);
+    }
+
+    // -----------------------------------------------------------------------
+    // peak_disk_bytes / --stdout sizing (#137)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn expected_bytes_stdout_excludes_fastq_output() {
+        // Streaming writes no FASTQ to disk, so the estimate that
+        // DecodeToFastq adds must not appear.
+        let resolved = vec![make_resolved_with_runinfo("SRR1", 1000, 1, &[100, 100])];
+        let sizes = expected_bytes_each(
+            &resolved,
+            &[],
+            SraDisposition::StreamToStdout { in_flight: 2 },
+        );
+        assert_eq!(total(sizes), 1000);
+    }
+
+    #[test]
+    fn peak_disk_sums_every_run_when_output_is_kept() {
+        let sizes = [1000, 500, 2000];
+        assert_eq!(peak_disk_bytes(&sizes, SraDisposition::KeepArchive), 3500);
+        assert_eq!(
+            peak_disk_bytes(&sizes, SraDisposition::DecodeToFastq { compressed: true }),
+            3500
+        );
+    }
+
+    #[test]
+    fn peak_disk_stdout_counts_only_the_runs_in_flight() {
+        // The largest two archives, not all four: the rest are deleted as
+        // their decodes finish.
+        let sizes = [1000, 500, 2000, 300];
+        assert_eq!(
+            peak_disk_bytes(&sizes, SraDisposition::StreamToStdout { in_flight: 2 }),
+            3000
+        );
+    }
+
+    #[test]
+    fn peak_disk_stdout_is_flat_in_batch_size() {
+        // The point of #137: a 500-run streaming batch must not demand 500x
+        // the disk of a 2-run one.
+        let small = [1000u64; 2];
+        let large = [1000u64; 500];
+        let d = SraDisposition::StreamToStdout { in_flight: 2 };
+        assert_eq!(peak_disk_bytes(&small, d), peak_disk_bytes(&large, d));
+    }
+
+    #[test]
+    fn peak_disk_stdout_handles_degenerate_in_flight() {
+        // in_flight is clamped to at least one archive, so a zero can never
+        // turn the check into a no-op that admits an impossible transfer.
+        let sizes = [1000, 4000];
+        assert_eq!(
+            peak_disk_bytes(&sizes, SraDisposition::StreamToStdout { in_flight: 0 }),
+            4000
+        );
+        // More slots than runs is fine too — it just sums what exists.
+        assert_eq!(
+            peak_disk_bytes(&sizes, SraDisposition::StreamToStdout { in_flight: 99 }),
+            5000
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -106,6 +106,7 @@ sracha get [OPTIONS] [ACCESSION]...
 | `--prefer-sdl` | | Skip direct S3 and resolve via the SDL API |
 | `--prefer-ena` | | Try ENA FASTQ mirrors first; fall back to the NCBI SRA path if ENA has no FASTQ for the accession or its output config is incompatible with the requested split/compression |
 | `--no-runinfo` | | Skip EUtils RunInfo API call (derive read structure from VDB metadata) |
+| `--no-disk-check` | | Skip the free-disk-space preflight. Useful when the output filesystem autoscales, or when `statvfs` reports a quota that does not reflect what the job can actually use |
 | `--prefetch-depth <N>` | `2` | Number of accessions to download ahead of the decoder. Larger values hide slow networks behind decode at the cost of one extra temp SRA file per step. Multi-accession `get` only |
 | `--keep-sra` | | Keep the downloaded SRA file in the output directory instead of deleting it after decode |
 | `--no-progress` | | Disable progress bar |
@@ -142,6 +143,7 @@ sracha fetch [OPTIONS] [ACCESSION]...
 | `-y, --yes` | | Confirm project downloads and large downloads (>100 GiB) |
 | `--prefer-sdl` | | Skip direct S3 and resolve via the SDL API |
 | `--prefer-ena` | | Fetch pre-computed FASTQ.gz from ENA's mirror instead of the SRA binary. Falls back to the NCBI path when ENA has no FASTQ for an accession |
+| `--no-disk-check` | | Skip the free-disk-space preflight. Useful when the output filesystem autoscales, or when `statvfs` reports a quota that does not reflect what the job can actually use |
 | `--no-progress` | | Disable progress bar |
 
 ---


### PR DESCRIPTION
Closes #137.

## The problem

`sracha get`'s disk preflight sized every run as `archive + fastq` and required the **sum across the whole batch** — regardless of `--stdout`. Under `--stdout` neither term holds:

- **No FASTQ is ever written.** The pipeline builds a single stdout writer and skips creating the output directory entirely (`pipeline/mod.rs:522`, `:536`).
- **Archives don't accumulate.** Each temp `.sra` is deleted the moment its decode finishes (`pipeline/mod.rs:2253`), and on cancellation too (`:2205`). At most `prefetch_depth + 1` exist at once.

So a streaming run's real peak is the largest `prefetch_depth + 1` archives, while the check demanded `Σ(archive + fastq)`. For a 100-run batch that's over two orders of magnitude more disk than the run touches — which is exactly the over-provisioning described in the issue, where jobs request scratch purely to appease a check on output that never lands.

Verified end to end: a clean `get --stdout` run leaves the output directory **completely empty**.

```
$ sracha get SRR28588231 --stdout --split interleaved -O ./sout > /dev/null
SRR28588231: 66220 spots, 132440 reads written, 22.31 MiB downloaded from [s3-direct]
$ ls -A sout
$          # nothing — the temp archive is already gone
```

## The fix

**1. Model `--stdout` correctly rather than deleting the check.** New `SraDisposition::StreamToStdout { in_flight }`, plus a `peak_disk_bytes()` that separates *peak bytes on disk* from *total bytes transferred*:

- `expected_bytes_each` returns the bare archive size for `StreamToStdout` — no FASTQ estimate.
- `peak_disk_bytes` sums the largest `in_flight` archives for `StreamToStdout` and the full set for every other disposition.
- `in_flight = prefetch_depth.max(1) + 1` — the accession decoding plus the prefetch queue.

The confirmation table and the >100 GiB prompt still receive the per-run `sizes`, so they keep reporting the honest transfer volume; only the disk number changes. ENA and `--stdout` are mutually exclusive (`ena_compatible` requires `!args.stdout`), so the two sizing paths never mix.

The check stays meaningful — it still refuses a run whose archive genuinely won't fit — but it's now flat in batch size instead of linear.

**2. `--no-disk-check` on `get` and `fetch`**, the explicit opt-out also requested in the issue, for output filesystems that autoscale or report a quota `statvfs` can't see through. The bail message now names it, so the escape hatch is discoverable at the point of failure.

## Trying the patch

```
cargo install --git https://github.com/rnabioco/sracha-rs --branch fix/137-stdout-disk-check sracha
```

That drops `sracha` into `~/.cargo/bin`. @nrminor — the streaming path needs no flag to benefit; `--no-disk-check` is there if the corrected estimate still doesn't match how your scratch is provisioned.

## Tests

Five unit tests alongside the existing `expected_bytes_*` / `disk_space_*` blocks: the stdout disposition excludes the FASTQ estimate; `peak_disk_bytes` still sums for `KeepArchive`/`DecodeToFastq`; the stdout peak counts only the largest `in_flight` archives; **the stdout peak is identical for a 2-run and a 500-run batch**; and a degenerate `in_flight: 0` clamps to one archive rather than becoming a no-op that admits an impossible transfer.

Full suite green (761 passed), `cargo clippy --all-targets --all-features -D warnings` and `cargo fmt --check` clean under the pixi toolchain.

## Follow-up, deliberately not bundled

The non-`--stdout` path overcounts the same way: without `--keep-sra` the archive is transient there too, so peak is `Σfastq + in-flight archives`, not `Σ(archive + fastq)`. `peak_disk_bytes` is the right place to fix it, but it loosens the default-path check and deserves its own issue.