### PR TITLE
fix(ci): adopt `as_chunks` for clippy 1.98's chunks_exact_to_as_chunks

### DIFF
--- a/crates/sracha-core/src/pipeline/blob_decode.rs
+++ b/crates/sracha-core/src/pipeline/blob_decode.rs
@@ -725,8 +725,10 @@ pub(crate) fn decode_blob_to_fastq(
         let rl_bytes = decode_irzip_column(&rldecoded)?;
 
         let mut lengths: Vec<u32> = rl_bytes
-            .chunks_exact(4)
-            .map(|chunk| u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&chunk| u32::from_le_bytes(chunk))
             .collect();
 
         // Trim to just the rows that pair with this READ blob: skip
@@ -985,13 +987,17 @@ pub(crate) fn decode_blob_to_fastq(
         // X/Y values are already decoded as u32 by irzip/izip (stored as
         // little-endian 4-byte groups in the output Vec<u8>).
         let x_vals: Vec<u32> = x_bytes
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&c| u32::from_le_bytes(c))
             .collect();
 
         let y_vals: Vec<u32> = y_bytes
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&c| u32::from_le_bytes(c))
             .collect();
 
         // Pick the template per spot using the skey spot_start mapping.

--- a/crates/sracha-vdb/src/blob.rs
+++ b/crates/sracha-vdb/src/blob.rs
@@ -3109,8 +3109,10 @@ mod tests {
         }
         let expanded = pm.expand_rows(&data, 4).unwrap();
         let vals: Vec<u32> = expanded
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&c| u32::from_le_bytes(c))
             .collect();
         assert_eq!(vals, vec![100, 100, 200, 200, 200, 300]);
     }
@@ -3132,8 +3134,10 @@ mod tests {
         assert_eq!(expanded.len(), 5 * 4); // 5 rows * 4 bytes each
 
         let vals: Vec<u32> = expanded
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&c| u32::from_le_bytes(c))
             .collect();
         assert_eq!(vals, vec![42, 42, 42, 99, 99]);
     }
@@ -3171,8 +3175,10 @@ mod tests {
         }
         let expanded = pm.expand_rows(&data, 4).unwrap();
         let vals: Vec<u32> = expanded
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&c| u32::from_le_bytes(c))
             .collect();
         assert_eq!(vals, vec![42, 99, 42]);
     }
@@ -3208,8 +3214,10 @@ mod tests {
 
         let expanded = pm.expand_rows(&data, 4).unwrap();
         let vals: Vec<u32> = expanded
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&c| u32::from_le_bytes(c))
             .collect();
         // row0=[10] row1=[10] row2=[20,21,22] row3=[30] row4=[30]
         assert_eq!(vals, vec![10, 10, 20, 21, 22, 30, 30]);
@@ -3279,8 +3287,10 @@ mod tests {
         // 2 + 1 + 3 = 6 logical rows, each 2 u32s.
         assert_eq!(expanded.len(), 6 * 8);
         let vals: Vec<u32> = expanded
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&c| u32::from_le_bytes(c))
             .collect();
         assert_eq!(vals, vec![10, 11, 10, 11, 20, 21, 30, 31, 30, 31, 30, 31]);
 
@@ -3633,8 +3643,10 @@ mod tests {
 
         let result = irzip_decode(&data, 32, 4, 100, delta_both, 0x01, None).unwrap();
         let vals: Vec<u32> = result
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&c| u32::from_le_bytes(c))
             .collect();
         assert_eq!(vals, vec![100, 110, 105, 115]);
     }
@@ -3665,8 +3677,10 @@ mod tests {
 
         let result = irzip_decode(&data, 32, 4, 100, delta_pos, 0x01, series2).unwrap();
         let vals: Vec<u32> = result
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&c| u32::from_le_bytes(c))
             .collect();
         assert_eq!(vals, vec![100, 200, 105, 203]);
     }
@@ -3700,8 +3714,10 @@ mod tests {
 
         let result = irzip_decode(&data, 32, 4, 1000, delta_both, 0x01, series2).unwrap();
         let vals: Vec<u32> = result
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&c| u32::from_le_bytes(c))
             .collect();
         assert_eq!(vals, vec![1000, 2000, 1015, 1990]);
     }
@@ -3808,8 +3824,10 @@ mod tests {
                 mapping: RowMapping::RepeatCounts(runs.clone()),
             };
             let got: Vec<u32> = pm.expand_rows(&data, 4).unwrap()
-                .chunks_exact(4)
-                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|&c| u32::from_le_bytes(c))
                 .collect();
             let expected: Vec<u32> = values
                 .iter()

--- a/crates/sracha-vdb/src/cache.rs
+++ b/crates/sracha-vdb/src/cache.rs
@@ -358,8 +358,10 @@ impl CachedColumn {
                 )));
             }
             Ok(blob.bytes[start..end]
-                .chunks_exact(4)
-                .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|&c| i32::from_le_bytes(c))
                 .collect())
         })
     }
@@ -379,8 +381,10 @@ impl CachedColumn {
                 )));
             }
             Ok(blob.bytes[start..end]
-                .chunks_exact(4)
-                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|&c| u32::from_le_bytes(c))
                 .collect())
         })
     }
@@ -400,8 +404,10 @@ impl CachedColumn {
                 )));
             }
             Ok(blob.bytes[start..end]
-                .chunks_exact(8)
-                .map(|c| i64::from_le_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]))
+                .as_chunks::<8>()
+                .0
+                .iter()
+                .map(|&c| i64::from_le_bytes(c))
                 .collect())
         })
     }

--- a/crates/sracha-vdb/src/dump.rs
+++ b/crates/sracha-vdb/src/dump.rs
@@ -883,8 +883,10 @@ fn cell_to_json(kind: CellKind, bytes: &[u8]) -> Value {
         | CellKind::AsciiBytes => Value::String(String::from_utf8_lossy(bytes).into_owned()),
         CellKind::U32Array => {
             let vals: Vec<Value> = bytes
-                .chunks_exact(4)
-                .map(|c| json!(u32::from_le_bytes(c.try_into().unwrap())))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|&c| json!(u32::from_le_bytes(c)))
                 .collect();
             Value::Array(vals)
         }
@@ -931,11 +933,11 @@ fn write_u32_array<W: Write>(
     if lead != 0 {
         w.write_all(&[lead])?;
     }
-    for (i, chunk) in bytes.chunks_exact(4).enumerate() {
+    for (i, &chunk) in bytes.as_chunks::<4>().0.iter().enumerate() {
         if i > 0 {
             w.write_all(sep)?;
         }
-        let v = u32::from_le_bytes(chunk.try_into().unwrap());
+        let v = u32::from_le_bytes(chunk);
         write!(w, "{v}")?;
     }
     if trail != 0 {

--- a/crates/sracha-vdb/src/encoding.rs
+++ b/crates/sracha-vdb/src/encoding.rs
@@ -103,12 +103,19 @@ pub fn unpack_2na(packed: &[u8], num_bases: usize) -> Vec<u8> {
     // Pre-size the output. Previously `Vec::with_capacity` + per-iter
     // `extend_from_slice` forced LLVM to emit a capacity check and len
     // writeback inside the hot loop (~33% of its time per `perf
-    // annotate`). With a sized Vec and `chunks_exact_mut(4)` the loop
-    // becomes load-byte → LUT-load → 4-byte store, with no bookkeeping.
+    // annotate`). With a sized Vec and `as_chunks_mut::<4>()` the loop
+    // becomes load-byte → LUT-load → 4-byte store, with no bookkeeping:
+    // the chunk is a `[u8; 4]`, so the store is a plain array assignment
+    // rather than a `copy_from_slice` with a length check to elide.
     let mut bases = vec![0u8; num_bases];
 
-    for (chunk, &byte) in bases.chunks_exact_mut(4).zip(packed[..full_bytes].iter()) {
-        chunk.copy_from_slice(&LUT_2NA[byte as usize]);
+    for (chunk, &byte) in bases
+        .as_chunks_mut::<4>()
+        .0
+        .iter_mut()
+        .zip(packed[..full_bytes].iter())
+    {
+        *chunk = LUT_2NA[byte as usize];
     }
 
     if trailing > 0 && full_bytes < packed.len() {
@@ -139,7 +146,12 @@ pub fn unpack_4na(packed: &[u8], num_bases: usize) -> Vec<u8> {
     // writeback — mirrors unpack_2na's pattern.
     let mut bases = vec![0u8; output_len];
 
-    for (chunk, &byte) in bases.chunks_exact_mut(2).zip(packed[..full_bytes].iter()) {
+    for (chunk, &byte) in bases
+        .as_chunks_mut::<2>()
+        .0
+        .iter_mut()
+        .zip(packed[..full_bytes].iter())
+    {
         chunk[0] = DNA_4NA[((byte >> 4) & 0x0F) as usize];
         chunk[1] = DNA_4NA[(byte & 0x0F) as usize];
     }
@@ -242,7 +254,9 @@ pub fn merge_altread_bin(bases: &mut [u8], altread_bytes: &[u8], num_bases: usiz
 /// Returns one phred byte per base. Input length must be a multiple of 4.
 pub fn qual4_log_odds_to_phred(qual4: &[u8]) -> Vec<u8> {
     qual4
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .map(|c| log_odds_to_phred(c[0] as i8))
         .collect()
 }


### PR DESCRIPTION
## Why CI is red

Not a regression from any PR — **`main` has been failing since 2026-08-21** (d11a0b8). The signature is the same on every branch: `Check` fails, `MSRV (1.95)` passes, everything downstream skips.

`ci.yml` uses `dtolnay/rust-toolchain@stable`, which floats. Rust 1.98 promoted `clippy::chunks_exact_to_as_chunks` to warn-by-default, and `-D warnings` makes it fatal. The pixi-pinned toolchain is older, so local `pixi run clippy` stays green — the breakage is only visible on a 1.98 host.

## The fix

All **20 sites** rewritten to `as_chunks::<N>()` / `as_chunks_mut::<N>()`. Note the count: CI reported 8, because it stopped at `sracha-vdb`'s lib errors. Clearing those exposed 3 more in `sracha-core` (`pipeline/blob_decode.rs`) and 9 in `sracha-vdb` test code that the build never reached.

| crate | file | sites |
|---|---|---|
| sracha-vdb | `blob.rs` (tests) | 9 |
| sracha-vdb | `cache.rs` | 3 |
| sracha-vdb | `encoding.rs` | 3 |
| sracha-vdb | `dump.rs` | 2 |
| sracha-core | `pipeline/blob_decode.rs` | 3 |

Semantics are unchanged — `as_chunks` drops a partial trailing chunk exactly as `chunks_exact` does. The difference is that the chunk arrives as a `[u8; N]` instead of a slice, which pays off three ways rather than just silencing the lint:

- **`from_le_bytes` takes the array directly.** Every elementwise `u32::from_le_bytes([c[0], c[1], c[2], c[3]])` rebuild collapses to `u32::from_le_bytes(c)`.
- **Two `dump.rs` sites lose a `try_into().unwrap()`** — a panic path that was unreachable but still had to be written and read as though it weren't.
- **`unpack_2na`'s hot loop gets faster, not just shorter.** The existing comment there explains that `Vec::with_capacity` + `extend_from_slice` cost ~33% of the loop to capacity checks and length writeback per `perf annotate`. With a `[u8; 4]` chunk the LUT store becomes a plain array assignment instead of `copy_from_slice`, dropping the last length check the comment was working to elide. Comment updated to match.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` clean on **rustc 1.98.0**, the toolchain CI actually resolves — this is the check that was failing.
- `cargo fmt --all --check` clean.
- Full suite green: **756 passed**, 42 skipped.
- `as_chunks` / `as_chunks_mut` have been stable since **1.88**, comfortably under the 1.95 MSRV; the `MSRV (1.95)` job confirms.

## Follow-up worth considering

A floating `@stable` means CI breaks on someone else's schedule — every clippy release can turn a new warn-by-default lint into a red main, unrelated to any change in the repo. Pinning `dtolnay/rust-toolchain` to an explicit version (bumped deliberately) would make these arrive as an intentional PR rather than as a surprise failure on unrelated work. Not done here to keep this diff to the fix.

---

#138 is stacked on this branch and goes green once this lands.