### PR TITLE
feat: support Windows (#146)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       # One platform failing should not cancel the other's report.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -78,18 +78,35 @@ jobs:
         with:
           # Shared with `check` and `integration`, which compile the same
           # crates with the same flags. rust-cache still partitions by
-          # os/arch, so ubuntu and macOS keep separate entries.
+          # os/arch, so each OS keeps a separate entry.
           shared-key: tests
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@nextest
+      - name: Install NASM (Windows)
+        if: runner.os == 'Windows'
+        # reqwest's `rustls` feature pins the aws-lc-rs crypto provider, and
+        # aws-lc-sys assembles its x86_64 routines with NASM, which is not on
+        # the runner image. CMake is. Chocolatey ships with the runner, so
+        # this needs no third-party action.
+        run: |
+          choco install nasm -y --no-progress
+          echo "C:\Program Files\NASM" >> $env:GITHUB_PATH
       - name: Run tests
         run: cargo nextest run --all-features --profile ci
 
   integration:
-    name: Integration Test
+    name: Integration Test (${{ matrix.os }})
     needs: check
-    runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      # Windows is here, and not only in `test`, on purpose: the #[ignore]d
+      # tests are the only ones that download a real archive, mmap it, and
+      # then delete or rename it. Windows refuses to unlink a file with a live
+      # mapping, so that interaction cannot be proved by the unit tests.
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -98,6 +115,11 @@ jobs:
           shared-key: tests
           save-if: false
       - uses: taiki-e/install-action@nextest
+      - name: Install NASM (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install nasm -y --no-progress
+          echo "C:\Program Files\NASM" >> $env:GITHUB_PATH
       - name: Cache SRA fixture
         uses: actions/cache@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,15 @@ jobs:
             suffix: -v3
           - target: aarch64-apple-darwin
             os: macos-latest
+          # Windows ships one baseline binary rather than the v2/v3 pair: the
+          # Windows audience for this tool is small enough that a second
+          # artifact is more of a "which do I pick?" tax than a speedup.
+          # crt-static keeps the promise the README makes for every other
+          # target — one file, no runtime to install (MSVC otherwise links the
+          # CRT dynamically and the exe needs VCRUNTIME140.dll).
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            extra_rustflags: -C target-feature=+crt-static
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -67,6 +76,15 @@ jobs:
         if: matrix.target == 'aarch64-unknown-linux-musl'
         run: cargo install cross --git https://github.com/cross-rs/cross --locked
 
+      - name: Install NASM (Windows)
+        if: runner.os == 'Windows'
+        # reqwest's `rustls` feature pins the aws-lc-rs crypto provider, and
+        # aws-lc-sys assembles its x86_64 routines with NASM, which the runner
+        # image does not carry (it does have the CMake that build also wants).
+        run: |
+          choco install nasm -y --no-progress
+          echo "C:\Program Files\NASM" >> $env:GITHUB_PATH
+
       - name: Build (cross)
         if: matrix.target == 'aarch64-unknown-linux-musl'
         run: cross build --release --target ${{ matrix.target }}
@@ -74,23 +92,33 @@ jobs:
       - name: Build (native)
         if: matrix.target != 'aarch64-unknown-linux-musl'
         env:
-          # Empty for ARM (no cpu set); raises the ISA floor for x86 variants.
-          RUSTFLAGS: ${{ matrix.cpu && format('-C target-cpu={0}', matrix.cpu) || '' }}
+          # Empty for ARM (no cpu set); raises the ISA floor for x86 variants;
+          # appends whatever a target asks for on top (Windows: static CRT).
+          RUSTFLAGS: ${{ format('{0} {1}', matrix.cpu && format('-C target-cpu={0}', matrix.cpu) || '', matrix.extra_rustflags || '') }}
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package
         shell: bash
         run: |
           version="${GITHUB_REF_NAME#v}"
+          name="sracha-${version}-${{ matrix.target }}${{ matrix.suffix }}"
           cd target/${{ matrix.target }}/release
-          tar czf ../../../sracha-${version}-${{ matrix.target }}${{ matrix.suffix }}.tar.gz sracha
+          if [ -f sracha.exe ]; then
+            # Explorer opens a .zip natively; a .tar.gz would send Windows
+            # users looking for a third-party extractor.
+            7z a "../../../${name}.zip" sracha.exe
+          else
+            tar czf "../../../${name}.tar.gz" sracha
+          fi
           cd ../../..
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: sracha-${{ github.ref_name }}-${{ matrix.target }}${{ matrix.suffix }}
-          path: sracha-*-${{ matrix.target }}${{ matrix.suffix }}.tar.gz
+          path: |
+            sracha-*-${{ matrix.target }}${{ matrix.suffix }}.tar.gz
+            sracha-*-${{ matrix.target }}${{ matrix.suffix }}.zip
 
   release:
     name: Create Release
@@ -118,4 +146,6 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           body_path: release_notes.md
-          files: artifacts/**/*.tar.gz
+          files: |
+            artifacts/**/*.tar.gz
+            artifacts/**/*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+**Windows is now a supported platform** ([#146]). Releases carry an
+`x86_64-pc-windows-msvc` `.zip` alongside the existing Linux and macOS
+tarballs, holding a single statically linked `sracha.exe` — the CRT is linked
+in, so there is no Visual C++ redistributable to install. CI runs the unit
+suite on Windows, and the integration suite too, since only that one
+downloads, mmaps, and then deletes a real archive — the interaction Windows is
+strictest about.
+
+Note that Bioconda builds for Linux and macOS only and has no Windows
+channel, so `bioconda::sracha` and the BioContainers images remain
+Linux/macOS-only. Windows users take the release `.zip`, `cargo install`, or
+WSL2.
+
+### Fixes
+
+- The parallel chunked downloader wrote through `pwrite`, which is Unix-only.
+  Positional reads and writes now go through a portable shim
+  (`util::write_all_at` / `util::read_exact_at`) that uses `pwrite` on Unix
+  and `seek_write`/`seek_read` on Windows.
+- The external-reference cache directory had no Windows branch, so aligned
+  (cSRA) runs failed outright unless `--refseq-cache` or `$SRACHA_REFSEQ_DIR`
+  was set. It now falls back to `%LOCALAPPDATA%`, then `%USERPROFILE%`.
+- `~/` in `--accession-file` paths expands via `%USERPROFILE%` when `HOME` is
+  unset.
+- The pre-download disk-space check was a silent no-op off Unix; it now uses
+  `GetDiskFreeSpaceExW` on Windows.
+- ANSI escape processing is enabled on the Windows console at startup, so
+  styled output renders instead of printing raw `\x1b[` sequences.
+
+[#146]: https://github.com/rnabioco/sracha-rs/issues/146
+
 ## 0.6.0 (2026-08-26)
 
 ### Upgrade note

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2212,6 +2212,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -122,11 +122,22 @@ or install from source:
 cargo install --git https://github.com/rnabioco/sracha-rs sracha
 ```
 
-On x86_64 the release page carries two variants per platform: pick **`-v2`**
+The release page covers Linux (x86_64, aarch64), macOS (Intel, Apple
+silicon), and Windows (x86_64) — a `.tar.gz` per Unix target and a `.zip` for
+Windows.
+
+On Linux and macOS x86_64 there are two variants per platform: pick **`-v2`**
 (the safe default — runs on any CPU since ~2009), or **`-v3`** for extra SIMD
 throughput on Haswell-or-newer (2013+) hardware. A `-v3` binary aborts with an
 illegal-instruction fault at startup on older CPUs, so prefer `-v2` unless you
-know the host has AVX2. ARM builds (`aarch64`) ship a single binary.
+know the host has AVX2. ARM (`aarch64`) and Windows builds ship a single
+binary.
+
+**Windows users:** take the `.zip` from the release page, or build with
+`cargo install` above. Bioconda cannot help here — it builds for Linux and
+macOS only, and never for Windows, so `bioconda::sracha` and the
+BioContainers images below are unavailable on Windows. (Running sracha under
+WSL2 also works, and gets you the Bioconda package.)
 
 To build from source tuned for the current machine, set
 `RUSTFLAGS="-C target-cpu=native"` before `cargo install`/`cargo build --release`.

--- a/crates/sracha-core/src/download/mod.rs
+++ b/crates/sracha-core/src/download/mod.rs
@@ -431,7 +431,7 @@ impl Drop for ChunkTicks<'_> {
 /// Streams hyper's response pieces through a bounded mpsc into a
 /// single `spawn_blocking` writer that uses `pwrite` on a shared
 /// `std::fs::File` (opened once in `download_file`). Pieces are
-/// coalesced into a 1 MiB buffer before each `write_all_at`, which
+/// coalesced into a 1 MiB buffer before each positional write, which
 /// keeps syscall count near the chunk count instead of the piece
 /// count (hyper emits ~16 KiB pieces, so at 70 MiB/s that's ~4500
 /// syscalls/s without batching). The channel is bounded at 4 pieces
@@ -468,7 +468,6 @@ async fn try_download_chunk(
     let writer_file = file.clone();
     let writer_start = chunk.start;
     let writer = tokio::task::spawn_blocking(move || -> std::io::Result<u64> {
-        use std::os::unix::fs::FileExt;
         const WRITE_THRESHOLD: usize = 1 << 20; // 1 MiB
         let mut offset = writer_start;
         let mut total = 0u64;
@@ -477,13 +476,13 @@ async fn try_download_chunk(
             total += piece.len() as u64;
             buf.extend_from_slice(&piece);
             if buf.len() >= WRITE_THRESHOLD {
-                writer_file.write_all_at(&buf, offset)?;
+                crate::util::write_all_at(&writer_file, &buf, offset)?;
                 offset += buf.len() as u64;
                 buf.clear();
             }
         }
         if !buf.is_empty() {
-            writer_file.write_all_at(&buf, offset)?;
+            crate::util::write_all_at(&writer_file, &buf, offset)?;
         }
         Ok(total)
     });

--- a/crates/sracha-core/src/pipeline/refseq.rs
+++ b/crates/sracha-core/src/pipeline/refseq.rs
@@ -50,6 +50,12 @@ pub fn refseq_cache_dir(override_dir: Option<&Path>) -> Result<PathBuf> {
         } else {
             PathBuf::from(home).join(".cache")
         }
+    } else if let Some(local) = std::env::var_os("LOCALAPPDATA") {
+        // Windows: %LOCALAPPDATA% is the per-user, non-roaming cache root.
+        PathBuf::from(local)
+    } else if let Some(profile) = std::env::var_os("USERPROFILE") {
+        // Older/stripped Windows environments where LOCALAPPDATA is unset.
+        PathBuf::from(profile).join("AppData").join("Local")
     } else {
         return Err(Error::Pipeline(
             "cannot locate a cache directory for external references — set \

--- a/crates/sracha-core/src/util.rs
+++ b/crates/sracha-core/src/util.rs
@@ -64,6 +64,81 @@ pub fn jitter_ms(max: u64) -> u64 {
     nanos % max
 }
 
+/// Write `buf` in full at absolute byte `offset`, without relying on the
+/// file's cursor.
+///
+/// The parallel chunked downloader has many threads writing disjoint ranges of
+/// one shared handle at once, so every write must name its own offset. Unix
+/// gets that from `pwrite`; Windows from `WriteFile` with an explicit
+/// `OVERLAPPED` offset. Both are genuinely positional, so concurrent calls
+/// against a shared handle stay correct.
+///
+/// Windows' `seek_write` does move the handle's cursor as a side effect. That
+/// is harmless for the caller that matters: the download handle is opened
+/// write-only and touched exclusively through this function, so nothing reads
+/// the cursor back.
+#[cfg(unix)]
+pub fn write_all_at(file: &std::fs::File, buf: &[u8], offset: u64) -> std::io::Result<()> {
+    std::os::unix::fs::FileExt::write_all_at(file, buf, offset)
+}
+
+#[cfg(windows)]
+pub fn write_all_at(file: &std::fs::File, mut buf: &[u8], mut offset: u64) -> std::io::Result<()> {
+    // Windows has no `write_all_at`, and a short write is not an error there,
+    // so drive the loop the way std's Unix implementation does.
+    use std::os::windows::fs::FileExt;
+    while !buf.is_empty() {
+        match file.seek_write(buf, offset) {
+            Ok(0) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "failed to write whole buffer",
+                ));
+            }
+            Ok(n) => {
+                buf = &buf[n..];
+                offset += n as u64;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+/// Fill `buf` from absolute byte `offset`, without relying on the file's
+/// cursor. The read counterpart of [`write_all_at`].
+#[cfg(unix)]
+pub fn read_exact_at(file: &std::fs::File, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+    std::os::unix::fs::FileExt::read_exact_at(file, buf, offset)
+}
+
+#[cfg(windows)]
+pub fn read_exact_at(
+    file: &std::fs::File,
+    mut buf: &mut [u8],
+    mut offset: u64,
+) -> std::io::Result<()> {
+    use std::os::windows::fs::FileExt;
+    while !buf.is_empty() {
+        match file.seek_read(buf, offset) {
+            Ok(0) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "failed to fill whole buffer",
+                ));
+            }
+            Ok(n) => {
+                buf = &mut buf[n..];
+                offset += n as u64;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -127,5 +202,46 @@ mod tests {
         assert_eq!(format_bases(1_500), "1.5 Kbp");
         assert_eq!(format_bases(2_500_000), "2.50 Mbp");
         assert_eq!(format_bases(3_000_000_000), "3.00 Gbp");
+    }
+
+    // positional I/O shim
+
+    #[test]
+    fn positional_io_round_trip() {
+        use std::io::Write;
+
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(&[0u8; 64]).unwrap();
+        tmp.flush().unwrap();
+
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(tmp.path())
+            .unwrap();
+
+        // Write two disjoint ranges out of order, as the chunked downloader does.
+        write_all_at(&file, b"world", 32).unwrap();
+        write_all_at(&file, b"hello", 8).unwrap();
+
+        let mut buf = [0u8; 5];
+        read_exact_at(&file, &mut buf, 8).unwrap();
+        assert_eq!(&buf, b"hello");
+        read_exact_at(&file, &mut buf, 32).unwrap();
+        assert_eq!(&buf, b"world");
+
+        // Untouched bytes stay zero: nothing was written at the cursor.
+        let mut head = [0xffu8; 8];
+        read_exact_at(&file, &mut head, 0).unwrap();
+        assert_eq!(head, [0u8; 8]);
+    }
+
+    #[test]
+    fn read_exact_at_past_eof_errors() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let file = std::fs::File::open(tmp.path()).unwrap();
+        let mut buf = [0u8; 4];
+        let err = read_exact_at(&file, &mut buf, 0).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
     }
 }

--- a/crates/sracha-core/tests/remote_vdb.rs
+++ b/crates/sracha-core/tests/remote_vdb.rs
@@ -15,7 +15,6 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
-use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Once;
@@ -140,7 +139,7 @@ fn handle_one(mut stream: TcpStream, file: &File, len: u64) -> bool {
     let (start, end) = range.unwrap_or((0, len - 1));
     let end = end.min(len - 1);
     let mut buf = vec![0u8; (end - start + 1) as usize];
-    file.read_exact_at(&mut buf, start).unwrap();
+    sracha_core::util::read_exact_at(file, &mut buf, start).unwrap();
     let head = format!(
         "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\n\
          Content-Range: bytes {start}-{end}/{len}\r\nConnection: close\r\n\r\n",

--- a/crates/sracha/Cargo.toml
+++ b/crates/sracha/Cargo.toml
@@ -32,3 +32,6 @@ tempfile.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Console"] }

--- a/crates/sracha/src/cli.rs
+++ b/crates/sracha/src/cli.rs
@@ -373,7 +373,8 @@ pub struct FastqArgs {
     /// Directory for cached external reference sequences, used by aligned
     /// (cSRA) runs whose reference bases live in NCBI refseq objects rather
     /// than in the archive itself. Shared across accessions and runs.
-    /// Defaults to $SRACHA_REFSEQ_DIR, else ~/.cache/sracha/refseq.
+    /// Defaults to $SRACHA_REFSEQ_DIR, else the platform cache dir
+    /// (~/.cache/sracha/refseq, or %LOCALAPPDATA%\sracha\refseq on Windows).
     #[arg(long, value_name = "DIR", help_heading = "Advanced")]
     pub refseq_cache: Option<PathBuf>,
 }
@@ -584,7 +585,8 @@ pub struct GetArgs {
     /// Directory for cached external reference sequences, used by aligned
     /// (cSRA) runs whose reference bases live in NCBI refseq objects rather
     /// than in the archive itself. Shared across accessions and runs.
-    /// Defaults to $SRACHA_REFSEQ_DIR, else ~/.cache/sracha/refseq.
+    /// Defaults to $SRACHA_REFSEQ_DIR, else the platform cache dir
+    /// (~/.cache/sracha/refseq, or %LOCALAPPDATA%\sracha\refseq on Windows).
     #[arg(long, value_name = "DIR", help_heading = "Advanced")]
     pub refseq_cache: Option<PathBuf>,
 }

--- a/crates/sracha/src/main.rs
+++ b/crates/sracha/src/main.rs
@@ -57,6 +57,8 @@ async fn main() -> Result<()> {
         libc::signal(libc::SIGPIPE, libc::SIG_DFL);
     }
 
+    enable_windows_ansi();
+
     let cli = Cli::parse();
 
     // Set up tracing
@@ -1221,10 +1223,15 @@ async fn main() -> Result<()> {
 /// Lines in the accession list file are trimmed; blank lines and lines
 /// starting with `#` are skipped.
 fn expand_tilde(s: &str) -> String {
-    if let Some(rest) = s.strip_prefix("~/")
-        && let Ok(home) = std::env::var("HOME")
-    {
-        return format!("{home}/{rest}");
+    if let Some(rest) = s.strip_prefix("~/") {
+        // `HOME` is unset on Windows; `USERPROFILE` is the equivalent. A
+        // forward slash joins fine there too, so the format is shared.
+        if let Some(home) = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .and_then(|h| h.into_string().ok())
+        {
+            return format!("{home}/{rest}");
+        }
     }
     s.to_string()
 }
@@ -2200,6 +2207,37 @@ fn check_disk_space(required_bytes: u64, output_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Turn on VT escape processing for the console attached to stderr.
+///
+/// `style::*` writes ANSI escapes unconditionally. Modern Windows consoles
+/// understand them, but only once a process opts in — without this, a
+/// `conhost` session prints the raw `\x1b[1m` sequences instead of rendering
+/// them. Best-effort by design: when stderr is redirected to a file or a pipe
+/// there is no console mode to set, and the call simply fails and is ignored.
+#[cfg(windows)]
+fn enable_windows_ansi() {
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::System::Console::{
+        ENABLE_VIRTUAL_TERMINAL_PROCESSING, GetConsoleMode, GetStdHandle, STD_ERROR_HANDLE,
+        SetConsoleMode,
+    };
+
+    unsafe {
+        let handle = GetStdHandle(STD_ERROR_HANDLE);
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+            return;
+        }
+        let mut mode = 0u32;
+        if GetConsoleMode(handle, &mut mode) == 0 {
+            return;
+        }
+        SetConsoleMode(handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+    }
+}
+
+#[cfg(not(windows))]
+fn enable_windows_ansi() {}
+
 /// Query available disk space via `statvfs`.
 #[cfg(unix)]
 fn available_space(path: &Path) -> Option<u64> {
@@ -2216,7 +2254,35 @@ fn available_space(path: &Path) -> Option<u64> {
     Some(stat.f_bavail as u64 * stat.f_frsize as u64)
 }
 
-#[cfg(not(unix))]
+/// Query available disk space via `GetDiskFreeSpaceExW`.
+///
+/// The Win32 call wants a directory path, and returns the quota-aware free
+/// space for the calling user rather than the raw volume free space — which
+/// is what the preflight actually wants to compare an output size against.
+#[cfg(windows)]
+fn available_space(path: &Path) -> Option<u64> {
+    use std::os::windows::ffi::OsStrExt;
+
+    // Wide, NUL-terminated. Reject interior NULs the same way CString does.
+    let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    if wide.contains(&0) {
+        return None;
+    }
+    wide.push(0);
+
+    let mut free_to_caller: u64 = 0;
+    let ok = unsafe {
+        windows_sys::Win32::Storage::FileSystem::GetDiskFreeSpaceExW(
+            wide.as_ptr(),
+            &mut free_to_caller,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    (ok != 0).then_some(free_to_caller)
+}
+
+#[cfg(not(any(unix, windows)))]
 fn available_space(_path: &Path) -> Option<u64> {
     None
 }
@@ -2627,14 +2693,17 @@ mod tests {
 
     #[test]
     fn available_space_returns_some_for_real_path() {
-        let space = available_space(Path::new("/tmp"));
+        let space = available_space(&std::env::temp_dir());
         assert!(space.is_some());
         assert!(space.unwrap() > 0);
     }
 
     #[test]
     fn available_space_returns_none_for_nonexistent() {
-        let space = available_space(Path::new("/nonexistent/path/that/does/not/exist"));
+        // An absolute path on a volume that exists, but a directory that does
+        // not — so both statvfs and GetDiskFreeSpaceExW fail on the lookup.
+        let missing = std::env::temp_dir().join("sracha-nonexistent-abcdef123456");
+        let space = available_space(&missing);
         assert!(space.is_none());
     }
 }

--- a/crates/sracha/src/style.rs
+++ b/crates/sracha/src/style.rs
@@ -1,4 +1,9 @@
 //! Centralized styling for CLI output.
+//!
+//! These color unconditionally. They are called from both `println!` (the
+//! `info` report tables) and `eprintln!` (progress and diagnostics), so there
+//! is no single stream to test here. `enable_windows_ansi` in `main.rs` makes
+//! sure the escapes render rather than print raw on a Windows console.
 
 use owo_colors::OwoColorize;
 use std::fmt::Display;

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,14 @@ the [CLI Reference](cli.md) for all options.
 ### From binary releases
 
 Download pre-built binaries from the
-[releases page](https://github.com/rnabioco/sracha-rs/releases).
+[releases page](https://github.com/rnabioco/sracha-rs/releases), which covers
+Linux (x86_64, aarch64), macOS (Intel, Apple silicon), and Windows (x86_64).
+Unix targets ship a `.tar.gz`; Windows ships a `.zip` holding a single
+statically linked `sracha.exe` with no runtime to install.
+
+On Linux and macOS x86_64, pick the `-v2` build unless you know the host has
+AVX2, in which case `-v3` decodes faster. ARM and Windows builds ship a single
+binary.
 
 ### From source
 
@@ -83,6 +90,10 @@ cargo install --git https://github.com/rnabioco/sracha-rs sracha
 ```bash
 pixi add bioconda::sracha
 ```
+
+Bioconda builds for Linux (x86_64, aarch64) and macOS (Intel, Apple silicon)
+only — it has no Windows channel, so this and the container images below are
+not available on Windows. Use the release `.zip`, `cargo install`, or WSL2.
 
 ### With containers
 


### PR DESCRIPTION
Closes the Windows half of #146. (The GSA request in that issue is a separate
feature and is not addressed here.)

## Bioconda will not pick this up, and cannot

Worth stating up front, since it is the obvious follow-up question on the
issue: Bioconda builds for Linux (x86_64, aarch64) and macOS (x86_64, arm64)
only — Windows is explicitly unsupported, and there is no `win-64` channel.
The recipe also builds from our **source tarball** with `{{ compiler('rust') }}`,
so it never touches the release binaries. Adding a Windows artifact therefore
changes nothing upstream: the autobump bot keeps bumping the version exactly
as it does now, `bioconda-sync.yml` keeps working unchanged, and
BioContainers stays Linux-only.

Windows users get the release `.zip` or `cargo install --git`. Docs now say so.

## Code

`sracha-vdb` needed nothing — it was already portable. So were rustls (no
OpenSSL in the lockfile), `memmap2`, Ctrl-C (tokio uses `SetConsoleCtrlHandler`),
and the SIGPIPE reset, which was already `cfg(unix)`-gated.

**The one hard blocker** was `std::os::unix::fs::FileExt::write_all_at` in the
chunked downloader, ungated. Positional I/O now goes through
`util::write_all_at` / `util::read_exact_at`: `pwrite`/`pread` on Unix, a
short-write loop over `seek_write`/`seek_read` on Windows (that API has no
`write_all_at`, and a short write is not an error there). Both are genuinely
positional — Windows passes an explicit `OVERLAPPED` offset — so the
concurrent per-chunk writers sharing one handle stay correct.

Four things compiled but misbehaved:

- refseq cache dir had no Windows branch and hard-errored → `%LOCALAPPDATA%`, then `%USERPROFILE%`
- `expand_tilde` read only `HOME` → falls back to `USERPROFILE`
- disk-space preflight was stubbed to `None` → `GetDiskFreeSpaceExW`
- `style::*` escapes print raw on a Windows console → VT processing enabled at startup

## CI and release

`windows-latest` joins both `test` and `integration`. Windows is on the
integration job and not only on `test` deliberately: the `#[ignore]`d tests
are the only ones that download a real archive, mmap it, and then delete or
rename it — and Windows refuses to unlink a file with a live mapping. The unit
tests cannot prove that interaction.

**Both workflows now install NASM on Windows.** `reqwest`'s `rustls` feature
pins the aws-lc-rs crypto provider, and `aws-lc-sys` assembles its x86_64
routines with NASM, which the runner image does not carry (it does have the
CMake that build also wants). Without this step the Windows build fails
outright — this was the one thing reading the source did not surface.

Releases add a single `x86_64-pc-windows-msvc` entry, built with
`+crt-static` (MSVC otherwise links the CRT dynamically and the exe needs
VCRUNTIME140.dll, contradicting the "single static binary" promise in the
README), packaged as `.zip` rather than `.tar.gz`. One baseline binary rather
than the v2/v3 pair.

`pixi.toml` is deliberately unchanged — adding `win-64` forces a full lock
re-solve and `mold`/`sra-tools`/`bwa`/`samtools` have no `win-64` builds.

## One plan item scaled back

The intent was also to gate `style::*` on stderr being a TTY. That turns out
to be wrong here: 25 of the ~60 styled call sites are `println!` (the `info`
report tables go to **stdout**), so a stderr gate would put escapes into
`sracha info > file`, and doing it per-stream is a 60-call-site refactor well
beyond this change. Coloring stays unconditional; only the Windows VT setup
landed. Gating color on redirect/`NO_COLOR` is a genuine improvement and
deserves its own PR.

## Verification

Locally: 763 tests pass, clippy and fmt clean, both workflow YAMLs parse.

The full tree cannot be cross-compiled from macOS (the C deps want MSVC
headers), so all four `#[cfg(windows)]` functions were extracted verbatim
into a scratch crate and type-checked **and** clippy'd against the real
`x86_64-pc-windows-msvc` target — clean.

Two things only this PR's CI run can settle:

1. the mmap-vs-`remove_file` ordering on the real platform (integration job);
2. `available_space_returns_none_for_nonexistent` assumes `GetDiskFreeSpaceExW`
   fails on a missing directory — plausible per the API docs, unverified.

Note that the `check` job (clippy `-D warnings`) is ubuntu-only, so
Windows-only code is compiled by the Windows `test` job but never linted in
CI. Worth a follow-up if that matters.

Before tagging a release, the plan called for a manual smoke test on Windows —
`sracha get` end to end, `--keep-sra` (exercises the `fs::rename`), `sracha info`,
and piping to `head` — plus a prerelease tag to confirm the `.zip` attaches and
the six existing artifacts still build.

https://claude.ai/code/session_014pVk7APvtoC7aCoZ5KLVBe
