### PR TITLE
ci: flip the Anaconda badge cache-buster when pins move

### DIFF
--- a/.github/scripts/sync-bioconda-version.py
+++ b/.github/scripts/sync-bioconda-version.py
@@ -15,6 +15,13 @@ Two independent sources, because they can legitimately disagree:
   * the `conda` directive pin comes from anaconda.org, which is the package
     that `conda`/`pixi` would actually resolve.
 
+The Anaconda badges are rewritten too, for a different reason: they render the
+current version by themselves, but GitHub serves README images through its
+camo proxy, which caches them long past a release. The `?v=` on those URLs is
+a cache-buster with no meaning to anaconda.org, so flipping it is what makes
+the badge re-fetch. It is flipped only when a pin actually moved, so a
+no-change week still produces no diff and no PR.
+
 Usage:
     sync-bioconda-version.py            # rewrite the files in place
     sync-bioconda-version.py --check    # exit 1 if anything is out of date
@@ -44,6 +51,24 @@ ANACONDA_PKG = "https://api.anaconda.org/package/bioconda/sracha"
 CONTAINER_TAG_RE = re.compile(r"(?<=sracha:)(\d[\d.]*)--([A-Za-z0-9_]+)")
 # `conda 'bioconda::sracha=0.3.11'`
 CONDA_PIN_RE = re.compile(r"(?<=bioconda::sracha=)(\d[\d.]*)")
+# `anaconda.org/bioconda/sracha/badges/version.svg?v=1`, with the query string
+# optional — a badge that has never been flipped does not carry one yet.
+BADGE_RE = re.compile(r"(anaconda\.org/bioconda/sracha/badges/\w+\.svg)(?:\?v=(\d+))?")
+
+
+def flip_badge_cache_busters(text: str) -> str:
+    """Toggle every Anaconda badge URL's `?v=` between 1 and 2.
+
+    The value itself is meaningless; only the change matters, because that is
+    what makes GitHub's camo proxy treat it as a new image and fetch it again.
+    Alternating between two values keeps the URL from growing forever.
+    """
+
+    def flip(match: re.Match) -> str:
+        url, current = match.group(1), match.group(2)
+        return f"{url}?v={2 if current == '1' else 1}"
+
+    return BADGE_RE.sub(flip, text)
 
 
 def fetch_json(url: str) -> dict:
@@ -105,7 +130,9 @@ def main() -> int:
             continue
         stale.append(relative)
         if not args.check:
-            path.write_text(updated)
+            # Only after a pin moved: --check stays a question about pins, and
+            # flipping unconditionally would open an empty PR every week.
+            path.write_text(flip_badge_cache_busters(updated))
 
     if not stale:
         print("pins are up to date")

--- a/.github/workflows/bioconda-sync.yml
+++ b/.github/workflows/bioconda-sync.yml
@@ -57,7 +57,12 @@ jobs:
             "" \
             "quay.io publishes no \`latest\` tag for BioContainers images, so these" \
             "pins name a concrete \`<version>--<build>\` and have to be refreshed" \
-            "after each release." > pr-body.md
+            "after each release." \
+            "" \
+            "The \`?v=\` on the Anaconda badge URLs is flipped in the same pass." \
+            "Those badges render the current version themselves, but GitHub" \
+            "serves README images through its camo proxy, which caches them long" \
+            "past a release — changing the URL is what forces a re-fetch." > pr-body.md
 
           gh pr create \
             --head "$BRANCH" \


### PR DESCRIPTION
The Anaconda badges render the current version themselves, so nothing here has
to name a version for them. But GitHub serves README images through its camo
proxy, which caches them long past a release, so the badge keeps showing
whatever version camo first fetched — which is why they have been fixed by
hand before (222282e).

The `?v=` on those URLs means nothing to anaconda.org. It exists purely so the
URL can change, and changing it is what makes camo re-fetch.
`sync-bioconda-version.py` now flips it between 1 and 2 in the same pass that
rewrites the version pins, so the weekly sync PR carries the badge refresh
along with it and there is nothing left to do by hand.

Details:

- Flipped **only when a pin actually moved**, so a no-change week still
  produces no diff and no PR.
- `--check` is untouched — it stays a question about pins alone.
- A badge carrying no `?v=` yet (`docs/index.md`) picks one up on its first
  flip.
- The bot's PR body now explains the badge change too.

## Verification

Ran the real script against the real files, both ways:

**Pins current** (today's state) — `pins are up to date`, no diff on either
file, badges untouched.

**Pins one release behind** (rolled `README.md`/`docs/index.md` back to 0.5.0,
then ran the sync) — pins restored to `0.6.0--h54198d6_0`, and:

```
README.md:     badges/version.svg?v=1   -> ?v=2
README.md:     badges/downloads.svg?v=1 -> ?v=2
docs/index.md: badges/version.svg       -> ?v=1
```

Also checked the flip alternates rather than drifting (`1 -> 2 -> 1 -> 2`),
handles the missing-param case, and changes nothing on the line but the `?v=`
value.

https://claude.ai/code/session_014pVk7APvtoC7aCoZ5KLVBe
