### PR TITLE
ci: add a CI Status gate for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,20 +3,17 @@ name: CI
 on:
   push:
     branches: [main]
-    # Kept in sync with the pull_request list below by hand: GitHub Actions'
-    # workflow parser rejects YAML anchors, so the two cannot share one node.
     paths-ignore:
       - "**/*.md"
       - "docs/**"
       - "zensical.toml"
       - ".github/workflows/docs.yml"
+  # Deliberately unfiltered, unlike the push trigger above. `CI Status` is a
+  # required check on main, and a required check that never runs leaves a PR
+  # blocked on a report that will never arrive — which would strand every
+  # docs-only PR, the weekly bioconda-sync bot's included.
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "zensical.toml"
-      - ".github/workflows/docs.yml"
 
 concurrency:
   # Supersede a PR's in-flight run when it is pushed again. Pushes to main are
@@ -208,3 +205,31 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check MSRV
         run: cargo check --all-targets
+
+  ci-status:
+    # The one required check on main. Naming a single aggregate here rather
+    # than each matrix leg means adding or renaming a platform never silently
+    # drops a requirement (a required check that no longer exists blocks
+    # everything) or leaves a new one ungated.
+    #
+    # `integration` and `coverage` are watched but not gated: the integration
+    # suite downloads real archives from NCBI, so making it blocking would let
+    # an NCBI outage stop all merges. They still run, and still report.
+    name: CI Status
+    if: always()
+    needs: [check, test, msrv, integration, coverage]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check gating jobs
+        env:
+          RESULTS: ${{ needs.check.result }} ${{ needs.test.result }} ${{ needs.msrv.result }}
+        run: |
+          echo "check/test/msrv: $RESULTS"
+          echo "integration: ${{ needs.integration.result }} (not gating)"
+          echo "coverage:    ${{ needs.coverage.result }} (not gating)"
+          for r in $RESULTS; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "::error::a gating job did not pass ($r)"; exit 1 ;;
+            esac
+          done


### PR DESCRIPTION
Groundwork for turning on branch protection so `gh pr merge --auto` actually
waits for green instead of merging immediately.

Two things had to be true first.

**One stable check name.** Requiring each matrix leg (`Test (ubuntu-latest)`,
…) is brittle in both directions: renaming a platform makes a required check
vanish, which blocks every PR until protection is edited, and adding one
leaves it silently ungated. `CI Status` aggregates instead, so the required
list never has to change.

`integration` and `coverage` are in `needs` — so they're waited on and
reported — but are **not** gating. The integration suite downloads real
archives from NCBI; making it blocking would let an NCBI outage stop all
merges, which is the opposite of not babysitting.

**The `paths-ignore` deadlock.** This is the part worth a close look. A
required status check that never runs does not pass — the PR sits on
"Expected — waiting for status to be reported" forever. `ci.yml` skipped
`**/*.md` and `docs/**` on `pull_request`, so with protection on, **every
docs-only PR would have been permanently unmergeable** — including the weekly
`bioconda-sync` bot PR, which by construction only ever touches `README.md`
and `docs/index.md`.

So the `pull_request` trigger is now unfiltered. The `push` trigger keeps its
filter, so doc commits landing on main still skip the Rust suite.

The tradeoff: a docs-only PR now runs the full suite. On a public repo those
minutes are free, and it is the price of a gate that cannot deadlock. If it
proves annoying, the refinement is a cheap `changes` job that the heavy jobs
key off with `if:` — happy to add that instead, it's just more machinery than
this needed today.

## After this merges

1. `allow_auto_merge` on the repo (currently `false` — the other reason
   `--auto` didn't wait).
2. A ruleset on `main` requiring `CI Status`, with admin bypass so direct
   pushes to main still work.

https://claude.ai/code/session_014pVk7APvtoC7aCoZ5KLVBe
