### PR TITLE
chore: ignore __pycache__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ validation/
 
 # development artifacts
 .sracha-done-*
+
+# byte-compiled .github/scripts
+__pycache__/


### PR DESCRIPTION
Running or importing `.github/scripts/sync-bioconda-version.py` leaves a `__pycache__/` beside it, which shows up as untracked.

Also serving as the end-to-end check that the new `main` ruleset and auto-merge behave — this PR is being merged with `--auto`, which should now *queue* until `CI Status` reports rather than merging on the spot.

https://claude.ai/code/session_014pVk7APvtoC7aCoZ5KLVBe