### PR TITLE
release: 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.7.0 (2026-09-05)
 
 ### Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "sracha"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "sracha-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "sracha-vdb"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "byteorder",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/sracha", "crates/sracha-core", "crates/sracha-vdb"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.95"
 repository = "https://github.com/rnabioco/sracha-rs"


### PR DESCRIPTION
Bumps the workspace to 0.7.0 and dates the `Unreleased` changelog section.

Minor rather than patch, matching how 0.4.0 and 0.6.0 were cut — both carried a `### Features` section, as this one does (Windows support).

Verified the release workflow's `awk` extractor pulls the right section for `ver=0.7.0`, so the GitHub release body will render the Features + Fixes blocks and stop at the 0.6.0 header.

Tagging `v0.7.0` once this lands, which will build the first `sracha-0.7.0-x86_64-pc-windows-msvc.zip` for #146.

https://claude.ai/code/session_014pVk7APvtoC7aCoZ5KLVBe